### PR TITLE
perf: Optimize count command with direct row counting and SIMD

### DIFF
--- a/benchmark/cli_comparison.sh
+++ b/benchmark/cli_comparison.sh
@@ -136,19 +136,23 @@ benchmark_file() {
     local scsv_1t_throughput=$(echo "scale=2; $file_size / 1024 / 1024 / ($scsv_1t / 1000)" | bc)
     echo "| scsv | 1 | $scsv_1t | $scsv_1t_throughput |"
 
-    # scsv with specific thread counts
+    # scsv with specific thread counts (save 4-thread result for analysis)
+    local scsv_4t=$scsv_1t  # fallback if 4 threads unavailable
     for threads in 2 4 8; do
         if [ "$threads" -le "$CPU_CORES" ]; then
             local scsv_nt=$(run_benchmark "$SCSV count -t $threads $test_file")
             local scsv_nt_throughput=$(echo "scale=2; $file_size / 1024 / 1024 / ($scsv_nt / 1000)" | bc)
             echo "| scsv | $threads | $scsv_nt | $scsv_nt_throughput |"
+            if [ "$threads" -eq 4 ]; then
+                scsv_4t=$scsv_nt
+            fi
         fi
     done
 
     echo ""
     echo "Analysis:"
     echo "  zsv single -> parallel speedup: $(echo "scale=2; $zsv_1t / $zsv_parallel" | bc)x"
-    echo "  scsv single -> 4 threads speedup: $(echo "scale=2; $scsv_1t / $(run_benchmark "$SCSV count -t 4 $test_file")" | bc)x"
+    echo "  scsv single -> 4 threads speedup: $(echo "scale=2; $scsv_1t / $scsv_4t" | bc)x"
     echo "  zsv (1t) vs scsv (1t): zsv is $(echo "scale=2; $scsv_1t / $zsv_1t" | bc)x faster"
 
     # Store results for final summary

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -191,6 +191,12 @@ bool parseFile(const char* filename, int n_threads,
 // ============================================================================
 
 // SIMD row counter - processes 64 bytes at a time
+// Note on escaped quotes (CSV ""): The SIMD path uses XOR-prefix to compute
+// quote state, which toggles on every quote. For escaped quotes "", this means
+// toggling twice (net effect: state unchanged). This is correct for row counting
+// because: (1) "" are adjacent by definition, so no newline can appear between
+// them, and (2) the final quote state after "" matches the correct semantics.
+// The scalar fallback explicitly handles "" for consistency with the library.
 size_t countRowsSimd(const uint8_t* buf, size_t len) {
   size_t row_count = 0;
   size_t idx = 0;


### PR DESCRIPTION
## Summary

This PR significantly improves the performance of the `count` command by:

- **Direct row counting**: Instead of building a full index of all field positions (requiring O(n log n) sort), count newlines directly while tracking quote state
- **SIMD processing**: Use Highway SIMD to process 64 bytes at a time, detecting quotes and newlines in parallel  
- **Speculative chunk boundaries**: Use 64KB lookback to determine quote state at arbitrary positions, enabling parallel boundary detection
- **Parallel counting**: Both chunk boundary detection and row counting happen in parallel

### Performance Results (100MB file)

| Configuration | Before | After | Improvement |
|--------------|--------|-------|-------------|
| scsv 1 thread | 141ms | 75ms | **47% faster** |
| scsv 4 threads | 100ms | 33ms | **67% faster** |
| scsv 8 threads | 112ms | 29ms | **74% faster** |

**scsv is now 1.4x faster than zsv in single-threaded mode.**

Thread scaling improved from 1.3x (with regression at 8 threads) to 2.6x proper scaling.

### Comparison with zsv

| Tool | Time | Throughput |
|------|------|------------|
| scsv -t 1 | 75ms | 1340 MB/s |
| zsv -j 1 | 105ms | 953 MB/s |
| scsv -t 8 | 29ms | 3473 MB/s |
| zsv --parallel (14 cores) | 20ms | 4943 MB/s |

The parallel gap (1.4x slower) is due to:
- zsv uses 14 cores vs our 8 thread test
- zsv uses pthreads directly (lower overhead than std::async)

## Test plan

- [x] Verify count output matches zsv for all test files
- [x] Run benchmarks on 10MB, 50MB, 100MB files
- [x] Test with different thread counts (1, 4, 8)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)