### PR TITLE
Disable Highway contrib and install to speed up builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ FetchContent_Declare(
 )
 set(HWY_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
 set(HWY_ENABLE_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(HWY_ENABLE_CONTRIB OFF CACHE BOOL "" FORCE)
+set(HWY_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(highway)
 
 # Google Benchmark for performance testing


### PR DESCRIPTION
## Summary

- Disable `HWY_ENABLE_CONTRIB` to skip building Highway's sorting algorithms, image utilities, and other contrib components that simdcsv does not use
- Disable `HWY_ENABLE_INSTALL` to skip generating installation targets for Highway

This reduces build time, particularly for release builds, by not compiling the vqsort SIMD sorting implementation and other unused Highway contrib modules.

## Test plan

- [x] Verified CMake configuration succeeds with new options
- [x] Verified full build completes successfully
- [x] Verified all 194 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)