### PR TITLE
Fix Codecov excludes for test and benchmark directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,10 @@ jobs:
     - name: Generate coverage info
       run: |
         cd build
-        lcov --config-file ../.lcovrc --capture --directory . --output-file coverage.info --ignore-errors mismatch,unused
+        # Capture coverage
+        lcov --capture --directory . --output-file coverage.info --ignore-errors mismatch,unused
+        # Remove test, benchmark, and external dependencies from coverage
+        lcov --remove coverage.info '*/test/*' '*/benchmark/*' '*/build/_deps/*' '/usr/*' --output-file coverage.info --ignore-errors unused
         lcov --list coverage.info
 
     - name: Upload coverage to Codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,8 +25,11 @@ comment:
   behavior: default
   require_changes: false
 
-# Additional paths to ignore (lcov excludes are in .lcovrc)
+# Paths to ignore from coverage reports
 ignore:
+  - "test/**/*"
+  - "benchmark/**/*"
+  - "build/_deps/**/*"
   - "**/*.md"
 
 flags:


### PR DESCRIPTION
## Summary

The `.lcovrc` excludes from PR #17 weren't being applied correctly. Test and benchmark directories are still appearing in Codecov reports.

## Changes

1. **CI workflow**: Use explicit `lcov --remove` to filter out files after capturing coverage
   - More reliable than config-file based excludes
   - Removes: `*/test/*`, `*/benchmark/*`, `*/build/_deps/*`, `/usr/*`

2. **codecov.yml**: Add ignore patterns as a backup layer
   - `test/**/*`
   - `benchmark/**/*`
   - `build/_deps/**/*`

## Why the previous approach didn't work

The `.lcovrc` `exclude` patterns work during capture, but the paths may not match correctly depending on how lcov interprets them. The `lcov --remove` step explicitly filters the coverage.info file after capture, which is more reliable.

## Test plan

- [ ] Verify CI passes
- [ ] Check Codecov report no longer includes test/benchmark files

🤖 Generated with [Claude Code](https://claude.com/claude-code)