### PR TITLE
fix: Improve directory exclusion patterns for Codecov reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,20 @@ jobs:
     - name: Generate coverage info
       run: |
         cd build
-        # Capture coverage
-        lcov --capture --directory . --output-file coverage.info --ignore-errors mismatch,unused
+        # Capture coverage using the config file from repo root
+        lcov --config-file ../.lcovrc --capture --directory . --output-file coverage.info --ignore-errors mismatch,unused
         # Remove test, benchmark, and external dependencies from coverage
-        lcov --remove coverage.info '*/test/*' '*/benchmark/*' '*/build/_deps/*' '/usr/*' --output-file coverage.info --ignore-errors unused
+        lcov --config-file ../.lcovrc --remove coverage.info '*/test/*' '*/benchmark/*' '*/build/_deps/*' '/usr/*' --output-file coverage.info --ignore-errors unused
+        # Show what files remain in the coverage report
+        echo "=== Files in final coverage report ==="
         lcov --list coverage.info
+        echo "=== Verifying no test/benchmark files remain ==="
+        if grep -E "^SF:.*/test/|^SF:.*/benchmark/" coverage.info; then
+          echo "ERROR: test or benchmark files found in coverage report!"
+          exit 1
+        else
+          echo "OK: No test or benchmark files in coverage report"
+        fi
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.lcovrc
+++ b/.lcovrc
@@ -1,6 +1,18 @@
 # lcov configuration file
 # Used by both local coverage runs and CI
+# These patterns filter out test code, benchmarks, and external dependencies
 
+# Exclude test files
 exclude = */test/*
+
+# Exclude benchmark files
 exclude = */benchmark/*
+
+# Exclude external dependencies (fetched via CMake)
 exclude = */build/_deps/*
+
+# Exclude system headers
+exclude = /usr/*
+
+# Exclude documentation
+exclude = */docs/*

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,11 +26,26 @@ comment:
   require_changes: false
 
 # Paths to ignore from coverage reports
+# These patterns exclude entire directories from coverage analysis
 ignore:
-  - "test/**/*"
-  - "benchmark/**/*"
-  - "build/_deps/**/*"
+  - "test/**"
+  - "benchmark/**"
+  - "build/**"
+  - "docs/**"
   - "**/*.md"
+
+# Define coverage components for better organization
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+      - type: patch
+  individual_components:
+    - component_id: library
+      name: Library Code
+      paths:
+        - src/**
+        - include/**
 
 flags:
   unittests:


### PR DESCRIPTION
## Summary

- Update codecov.yml ignore patterns to use simpler glob syntax for better Codecov compatibility
- Add component_management section to explicitly define library code paths (src/, include/)
- Reference .lcovrc config file in CI workflow for consistency
- Add verification step to CI to ensure no test/benchmark files leak into coverage reports
- Expand .lcovrc exclusions to include system headers and docs

## Test plan

- [ ] CI passes and coverage job completes successfully
- [ ] Verification step confirms no test/benchmark files in coverage.info
- [ ] Codecov report shows only src/ and include/ directories

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)