### PR TITLE
test: Improve test coverage for simdcsv_c.cpp (C API)

### DIFF
--- a/test/c_api_test.cpp
+++ b/test/c_api_test.cpp
@@ -47,6 +47,29 @@ TEST_F(CAPITest, ErrorStrings) {
     EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_NULL_POINTER), "Null pointer");
 }
 
+TEST_F(CAPITest, AllErrorStrings) {
+    // Test all error strings for complete coverage
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_INVALID_QUOTE_ESCAPE), "Invalid quote escape");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_QUOTE_IN_UNQUOTED), "Quote in unquoted field");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_INCONSISTENT_FIELDS), "Inconsistent field count");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_FIELD_TOO_LARGE), "Field too large");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_MIXED_LINE_ENDINGS), "Mixed line endings");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_INVALID_LINE_ENDING), "Invalid line ending");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_INVALID_UTF8), "Invalid UTF-8");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_NULL_BYTE), "Null byte in data");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_EMPTY_HEADER), "Empty header");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_DUPLICATE_COLUMNS), "Duplicate columns");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_AMBIGUOUS_SEPARATOR), "Ambiguous separator");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_FILE_TOO_LARGE), "File too large");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_IO), "I/O error");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_INTERNAL), "Internal error");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_INVALID_ARGUMENT), "Invalid argument");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_OUT_OF_MEMORY), "Out of memory");
+    EXPECT_STREQ(simdcsv_error_string(SIMDCSV_ERROR_INVALID_HANDLE), "Invalid handle");
+    // Unknown error code
+    EXPECT_STREQ(simdcsv_error_string(static_cast<simdcsv_error_t>(999)), "Unknown error");
+}
+
 // Buffer Tests
 TEST_F(CAPITest, BufferCreateFromData) {
     const uint8_t data[] = "a,b,c\n1,2,3\n";
@@ -77,6 +100,18 @@ TEST_F(CAPITest, BufferNullHandling) {
     simdcsv_buffer_destroy(nullptr);
 }
 
+TEST_F(CAPITest, BufferCreateInvalidInput) {
+    // Null data pointer
+    EXPECT_EQ(simdcsv_buffer_create(nullptr, 100), nullptr);
+    // Zero length
+    const uint8_t data[] = "test";
+    EXPECT_EQ(simdcsv_buffer_create(data, 0), nullptr);
+}
+
+TEST_F(CAPITest, BufferLoadFileNull) {
+    EXPECT_EQ(simdcsv_buffer_load_file(nullptr), nullptr);
+}
+
 // Dialect Tests
 TEST_F(CAPITest, DialectCSV) {
     simdcsv_dialect_t* d = simdcsv_dialect_csv();
@@ -102,8 +137,81 @@ TEST_F(CAPITest, DialectCustom) {
     simdcsv_dialect_destroy(d);
 }
 
+TEST_F(CAPITest, DialectSemicolon) {
+    simdcsv_dialect_t* d = simdcsv_dialect_semicolon();
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(simdcsv_dialect_delimiter(d), ';');
+    EXPECT_EQ(simdcsv_dialect_quote_char(d), '"');
+    EXPECT_EQ(simdcsv_dialect_escape_char(d), '"');
+    EXPECT_TRUE(simdcsv_dialect_double_quote(d));
+    simdcsv_dialect_destroy(d);
+}
+
+TEST_F(CAPITest, DialectPipe) {
+    simdcsv_dialect_t* d = simdcsv_dialect_pipe();
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(simdcsv_dialect_delimiter(d), '|');
+    EXPECT_EQ(simdcsv_dialect_quote_char(d), '"');
+    EXPECT_EQ(simdcsv_dialect_escape_char(d), '"');
+    EXPECT_TRUE(simdcsv_dialect_double_quote(d));
+    simdcsv_dialect_destroy(d);
+}
+
+TEST_F(CAPITest, DialectEscapeAndDoubleQuote) {
+    // Test custom dialect with escape char and double_quote = false
+    simdcsv_dialect_t* d = simdcsv_dialect_create(',', '"', '\\', false);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(simdcsv_dialect_escape_char(d), '\\');
+    EXPECT_FALSE(simdcsv_dialect_double_quote(d));
+    simdcsv_dialect_destroy(d);
+}
+
+TEST_F(CAPITest, DialectToString) {
+    simdcsv_dialect_t* d = simdcsv_dialect_csv();
+    ASSERT_NE(d, nullptr);
+
+    // Test with null buffer - should return required size
+    size_t required = simdcsv_dialect_to_string(d, nullptr, 0);
+    EXPECT_GT(required, 0u);
+
+    // Test with sufficient buffer
+    char buffer[256];
+    size_t len = simdcsv_dialect_to_string(d, buffer, sizeof(buffer));
+    EXPECT_GT(len, 0u);
+    EXPECT_GT(strlen(buffer), 0u);
+
+    // Test with small buffer (should truncate)
+    char small_buffer[5];
+    len = simdcsv_dialect_to_string(d, small_buffer, sizeof(small_buffer));
+    EXPECT_GT(len, sizeof(small_buffer)); // Original length should be larger
+    EXPECT_EQ(strlen(small_buffer), sizeof(small_buffer) - 1);
+
+    simdcsv_dialect_destroy(d);
+}
+
+TEST_F(CAPITest, DialectToStringNull) {
+    EXPECT_EQ(simdcsv_dialect_to_string(nullptr, nullptr, 0), 0u);
+}
+
+TEST_F(CAPITest, DialectValidateInvalid) {
+    // Test dialect with null delimiter
+    simdcsv_dialect_t* d = simdcsv_dialect_create('\0', '"', '"', true);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(simdcsv_dialect_validate(d), SIMDCSV_ERROR_INVALID_ARGUMENT);
+    simdcsv_dialect_destroy(d);
+
+    // Test dialect where delimiter equals quote char
+    d = simdcsv_dialect_create(',', ',', '"', true);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(simdcsv_dialect_validate(d), SIMDCSV_ERROR_INVALID_ARGUMENT);
+    simdcsv_dialect_destroy(d);
+}
+
 TEST_F(CAPITest, DialectNullHandling) {
     EXPECT_EQ(simdcsv_dialect_delimiter(nullptr), '\0');
+    EXPECT_EQ(simdcsv_dialect_quote_char(nullptr), '\0');
+    EXPECT_EQ(simdcsv_dialect_escape_char(nullptr), '\0');
+    EXPECT_FALSE(simdcsv_dialect_double_quote(nullptr));
     EXPECT_EQ(simdcsv_dialect_validate(nullptr), SIMDCSV_ERROR_NULL_POINTER);
     simdcsv_dialect_destroy(nullptr);
 }
@@ -118,9 +226,53 @@ TEST_F(CAPITest, ErrorCollectorCreate) {
     simdcsv_error_collector_destroy(c);
 }
 
+TEST_F(CAPITest, ErrorCollectorSetMode) {
+    simdcsv_error_collector_t* c = simdcsv_error_collector_create(SIMDCSV_MODE_STRICT, 100);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(simdcsv_error_collector_mode(c), SIMDCSV_MODE_STRICT);
+
+    simdcsv_error_collector_set_mode(c, SIMDCSV_MODE_BEST_EFFORT);
+    EXPECT_EQ(simdcsv_error_collector_mode(c), SIMDCSV_MODE_BEST_EFFORT);
+
+    // Test set_mode with null (should be no-op)
+    simdcsv_error_collector_set_mode(nullptr, SIMDCSV_MODE_PERMISSIVE);
+
+    simdcsv_error_collector_destroy(c);
+}
+
+TEST_F(CAPITest, ErrorCollectorClear) {
+    simdcsv_error_collector_t* c = simdcsv_error_collector_create(SIMDCSV_MODE_PERMISSIVE, 100);
+    ASSERT_NE(c, nullptr);
+
+    // Clear should work even on empty collector
+    simdcsv_error_collector_clear(c);
+    EXPECT_EQ(simdcsv_error_collector_count(c), 0u);
+
+    // Clear with null (should be no-op)
+    simdcsv_error_collector_clear(nullptr);
+
+    simdcsv_error_collector_destroy(c);
+}
+
+TEST_F(CAPITest, ErrorCollectorGetErrors) {
+    simdcsv_error_collector_t* c = simdcsv_error_collector_create(SIMDCSV_MODE_PERMISSIVE, 100);
+    ASSERT_NE(c, nullptr);
+
+    simdcsv_parse_error_t error;
+    // Test get with invalid index (no errors yet)
+    EXPECT_EQ(simdcsv_error_collector_get(c, 0, &error), SIMDCSV_ERROR_INVALID_ARGUMENT);
+
+    // Test get with null error pointer
+    EXPECT_EQ(simdcsv_error_collector_get(c, 0, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+
+    simdcsv_error_collector_destroy(c);
+}
+
 TEST_F(CAPITest, ErrorCollectorNullHandling) {
     EXPECT_EQ(simdcsv_error_collector_mode(nullptr), SIMDCSV_MODE_STRICT);
     EXPECT_FALSE(simdcsv_error_collector_has_errors(nullptr));
+    EXPECT_FALSE(simdcsv_error_collector_has_fatal(nullptr));
+    EXPECT_EQ(simdcsv_error_collector_count(nullptr), 0u);
     simdcsv_parse_error_t error;
     EXPECT_EQ(simdcsv_error_collector_get(nullptr, 0, &error), SIMDCSV_ERROR_NULL_POINTER);
     simdcsv_error_collector_destroy(nullptr);
@@ -140,8 +292,51 @@ TEST_F(CAPITest, IndexCreateInvalid) {
     EXPECT_EQ(simdcsv_index_create(1000, 0), nullptr);
 }
 
+TEST_F(CAPITest, IndexColumnsAndTotalCount) {
+    const uint8_t data[] = "a,b,c\n1,2,3\n4,5,6\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(len, 1);
+    ASSERT_NE(buffer, nullptr);
+    ASSERT_NE(parser, nullptr);
+    ASSERT_NE(index, nullptr);
+
+    simdcsv_error_t err = simdcsv_parse(parser, buffer, index, nullptr);
+    EXPECT_EQ(err, SIMDCSV_OK);
+
+    // Test columns accessor
+    size_t columns = simdcsv_index_columns(index);
+    EXPECT_GE(columns, 0u);  // Columns may or may not be set by parse
+
+    // Test total_count accessor
+    uint64_t total = simdcsv_index_total_count(index);
+    EXPECT_GT(total, 0u);
+
+    // Verify total_count matches count for single-threaded parse
+    EXPECT_EQ(total, simdcsv_index_count(index, 0));
+
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, IndexCountOutOfBounds) {
+    simdcsv_index_t* idx = simdcsv_index_create(1000, 2);
+    ASSERT_NE(idx, nullptr);
+
+    // Thread ID out of bounds
+    EXPECT_EQ(simdcsv_index_count(idx, 100), 0u);
+
+    simdcsv_index_destroy(idx);
+}
+
 TEST_F(CAPITest, IndexNullHandling) {
     EXPECT_EQ(simdcsv_index_num_threads(nullptr), 0u);
+    EXPECT_EQ(simdcsv_index_columns(nullptr), 0u);
+    EXPECT_EQ(simdcsv_index_count(nullptr, 0), 0u);
+    EXPECT_EQ(simdcsv_index_total_count(nullptr), 0u);
     EXPECT_EQ(simdcsv_index_positions(nullptr), nullptr);
     simdcsv_index_destroy(nullptr);
 }
@@ -207,6 +402,101 @@ TEST_F(CAPITest, ParseNullPointers) {
     simdcsv_buffer_destroy(buffer);
 }
 
+TEST_F(CAPITest, ParseWithErrorsNullPointers) {
+    const uint8_t data[] = "a,b,c\n";
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, sizeof(data) - 1);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(100, 1);
+    simdcsv_error_collector_t* errors = simdcsv_error_collector_create(SIMDCSV_MODE_PERMISSIVE, 100);
+
+    EXPECT_EQ(simdcsv_parse_with_errors(nullptr, buffer, index, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+    EXPECT_EQ(simdcsv_parse_with_errors(parser, nullptr, index, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+    EXPECT_EQ(simdcsv_parse_with_errors(parser, buffer, nullptr, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+
+    simdcsv_error_collector_destroy(errors);
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseWithErrorsNullErrorCollector) {
+    // Test that null error collector is handled gracefully (falls back to non-error parse)
+    const uint8_t data[] = "a,b,c\n1,2,3\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(len, 1);
+
+    simdcsv_error_t err = simdcsv_parse_with_errors(parser, buffer, index, nullptr, nullptr);
+    EXPECT_EQ(err, SIMDCSV_OK);
+
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseTwoPassWithErrors) {
+    const uint8_t data[] = "a,b,c\n1,2,3\n4,5,6\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(len, 1);
+    simdcsv_error_collector_t* errors = simdcsv_error_collector_create(SIMDCSV_MODE_PERMISSIVE, 100);
+    simdcsv_dialect_t* dialect = simdcsv_dialect_csv();
+
+    simdcsv_error_t err = simdcsv_parse_two_pass_with_errors(parser, buffer, index, errors, dialect);
+    EXPECT_EQ(err, SIMDCSV_OK);
+    EXPECT_GT(simdcsv_index_count(index, 0), 0u);
+    EXPECT_FALSE(simdcsv_error_collector_has_fatal(errors));
+
+    simdcsv_dialect_destroy(dialect);
+    simdcsv_error_collector_destroy(errors);
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseTwoPassWithErrorsNullPointers) {
+    const uint8_t data[] = "a,b,c\n";
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, sizeof(data) - 1);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(100, 1);
+    simdcsv_error_collector_t* errors = simdcsv_error_collector_create(SIMDCSV_MODE_PERMISSIVE, 100);
+
+    EXPECT_EQ(simdcsv_parse_two_pass_with_errors(nullptr, buffer, index, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+    EXPECT_EQ(simdcsv_parse_two_pass_with_errors(parser, nullptr, index, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+    EXPECT_EQ(simdcsv_parse_two_pass_with_errors(parser, buffer, nullptr, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+
+    simdcsv_error_collector_destroy(errors);
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseTwoPassWithErrorsNullErrorCollector) {
+    // Test that null error collector falls back to non-error two-pass parse
+    const uint8_t data[] = "a,b,c\n1,2,3\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(len, 1);
+
+    simdcsv_error_t err = simdcsv_parse_two_pass_with_errors(parser, buffer, index, nullptr, nullptr);
+    EXPECT_EQ(err, SIMDCSV_OK);
+
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParserDestroyNull) {
+    // Should not crash with null
+    simdcsv_parser_destroy(nullptr);
+}
+
 // Dialect Detection Tests
 TEST_F(CAPITest, DetectDialectCSV) {
     const uint8_t data[] = "name,value,count\nalpha,1,100\nbeta,2,200\n";
@@ -229,10 +519,47 @@ TEST_F(CAPITest, DetectDialectNull) {
     EXPECT_EQ(simdcsv_detect_dialect(nullptr), nullptr);
 }
 
+TEST_F(CAPITest, DetectionResultAllAccessors) {
+    const uint8_t data[] = "name,value,count\nalpha,1,100\nbeta,2,200\ngamma,3,300\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_detection_result_t* result = simdcsv_detect_dialect(buffer);
+    ASSERT_NE(result, nullptr);
+
+    EXPECT_TRUE(simdcsv_detection_result_success(result));
+    EXPECT_GT(simdcsv_detection_result_confidence(result), 0.0);
+
+    // Test columns accessor
+    size_t columns = simdcsv_detection_result_columns(result);
+    EXPECT_EQ(columns, 3u);
+
+    // Test rows_analyzed accessor
+    size_t rows = simdcsv_detection_result_rows_analyzed(result);
+    EXPECT_GE(rows, 1u);
+
+    // Test has_header accessor
+    bool has_header = simdcsv_detection_result_has_header(result);
+    // The header detection may vary, so just verify it returns a value
+    (void)has_header;
+
+    // Test warning accessor (may be null for clean data)
+    const char* warning = simdcsv_detection_result_warning(result);
+    // warning is expected to be null or a valid string
+    (void)warning;
+
+    simdcsv_detection_result_destroy(result);
+    simdcsv_buffer_destroy(buffer);
+}
+
 TEST_F(CAPITest, DetectionResultNullHandling) {
     EXPECT_FALSE(simdcsv_detection_result_success(nullptr));
     EXPECT_EQ(simdcsv_detection_result_confidence(nullptr), 0.0);
     EXPECT_EQ(simdcsv_detection_result_dialect(nullptr), nullptr);
+    EXPECT_EQ(simdcsv_detection_result_columns(nullptr), 0u);
+    EXPECT_EQ(simdcsv_detection_result_rows_analyzed(nullptr), 0u);
+    EXPECT_FALSE(simdcsv_detection_result_has_header(nullptr));
+    EXPECT_EQ(simdcsv_detection_result_warning(nullptr), nullptr);
     simdcsv_detection_result_destroy(nullptr);
 }
 
@@ -256,6 +583,84 @@ TEST_F(CAPITest, ParseAuto) {
     }
 
     simdcsv_error_collector_destroy(errors);
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseAutoNullPointers) {
+    const uint8_t data[] = "name,value\n";
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, sizeof(data) - 1);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(100, 1);
+    simdcsv_error_collector_t* errors = simdcsv_error_collector_create(SIMDCSV_MODE_PERMISSIVE, 100);
+
+    EXPECT_EQ(simdcsv_parse_auto(nullptr, buffer, index, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+    EXPECT_EQ(simdcsv_parse_auto(parser, nullptr, index, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+    EXPECT_EQ(simdcsv_parse_auto(parser, buffer, nullptr, errors, nullptr), SIMDCSV_ERROR_NULL_POINTER);
+
+    simdcsv_error_collector_destroy(errors);
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseAutoNullDetectedPointer) {
+    // Test that parse_auto works when detected out-parameter is null
+    const uint8_t data[] = "name,value\nalpha,1\nbeta,2\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(len, 1);
+    simdcsv_error_collector_t* errors = simdcsv_error_collector_create(SIMDCSV_MODE_PERMISSIVE, 0);
+
+    simdcsv_error_t err = simdcsv_parse_auto(parser, buffer, index, errors, nullptr);
+    EXPECT_EQ(err, SIMDCSV_OK);
+
+    simdcsv_error_collector_destroy(errors);
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseAutoNullErrorCollector) {
+    // Test that parse_auto works when error collector is null
+    const uint8_t data[] = "name,value\nalpha,1\nbeta,2\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(len, 1);
+
+    simdcsv_detection_result_t* detected = nullptr;
+    simdcsv_error_t err = simdcsv_parse_auto(parser, buffer, index, nullptr, &detected);
+    EXPECT_EQ(err, SIMDCSV_OK);
+
+    if (detected) {
+        simdcsv_detection_result_destroy(detected);
+    }
+
+    simdcsv_index_destroy(index);
+    simdcsv_parser_destroy(parser);
+    simdcsv_buffer_destroy(buffer);
+}
+
+TEST_F(CAPITest, ParseWithDialect) {
+    // Test parse with explicit dialect
+    const uint8_t data[] = "a\tb\tc\n1\t2\t3\n";
+    size_t len = sizeof(data) - 1;
+
+    simdcsv_buffer_t* buffer = simdcsv_buffer_create(data, len);
+    simdcsv_parser_t* parser = simdcsv_parser_create();
+    simdcsv_index_t* index = simdcsv_index_create(len, 1);
+    simdcsv_dialect_t* dialect = simdcsv_dialect_tsv();
+
+    simdcsv_error_t err = simdcsv_parse(parser, buffer, index, dialect);
+    EXPECT_EQ(err, SIMDCSV_OK);
+    EXPECT_GT(simdcsv_index_count(index, 0), 0u);
+
+    simdcsv_dialect_destroy(dialect);
     simdcsv_index_destroy(index);
     simdcsv_parser_destroy(parser);
     simdcsv_buffer_destroy(buffer);


### PR DESCRIPTION
## Summary
- Increases C API test coverage from 27 to 51 tests
- Adds comprehensive tests for all previously untested public API functions
- Covers edge cases, null pointer handling, and error paths

## Changes
- **Error strings**: Added tests for all 20 error codes including unknown error case
- **Buffer functions**: Added tests for null data, zero length, and null filename
- **Dialect functions**: Added tests for semicolon, pipe, escape_char, double_quote, to_string, and validation edge cases
- **Error collector**: Added tests for set_mode, clear, get with invalid index/null pointer
- **Index functions**: Added tests for columns, total_count, and out-of-bounds thread ID
- **Parser functions**: Added tests for parse_two_pass_with_errors and null error collector fallback paths
- **Detection result**: Added tests for columns, rows_analyzed, has_header, and warning accessors
- **Parse auto**: Added tests for null pointer cases and optional parameters

## Test plan
- [x] All 51 C API tests pass locally
- [x] All 670 project tests pass (verified with `ctest --output-on-failure`)
- [x] Tests exercise all identified coverage gaps from issue #98

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)