### PR TITLE
fix: Update CI badge to only show main branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # simdcsv
 
 <!-- badges: start -->
-[![CI](https://github.com/jimhester/simdcsv/workflows/CI/badge.svg)](https://github.com/jimhester/simdcsv/actions)
+[![CI](https://github.com/jimhester/simdcsv/workflows/CI/badge.svg?branch=main)](https://github.com/jimhester/simdcsv/actions?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/jimhester/simdcsv/branch/main/graph/badge.svg)](https://codecov.io/gh/jimhester/simdcsv)
 <!-- badges: end -->
 


### PR DESCRIPTION
## Summary
- Update CI badge URL to include `?branch=main` query parameter so it only reflects main branch status
- Update the badge link to filter GitHub Actions view by main branch

Fixes #140

## Test plan
- [x] Verify badge URL syntax is correct
- [ ] After merge, verify badge reflects main branch CI status

🤖 Generated with [Claude Code](https://claude.com/claude-code)