### PR TITLE
fix: Correct inverted comparison message in cli_comparison.sh

### DIFF
--- a/benchmark/cli_comparison.sh
+++ b/benchmark/cli_comparison.sh
@@ -154,8 +154,8 @@ benchmark_file() {
     echo "Analysis:"
     echo "  zsv single -> parallel speedup: $(echo "scale=2; $zsv_1t / $zsv_parallel" | bc)x"
     echo "  scsv single -> auto speedup: $(echo "scale=2; $scsv_1t / $scsv_auto" | bc)x"
-    echo "  zsv (1t) vs scsv (1t): zsv is $(echo "scale=2; $scsv_1t / $zsv_1t" | bc)x faster"
-    echo "  zsv (parallel) vs scsv (auto): $(echo "scale=2; $zsv_parallel / $scsv_auto" | bc)x (>1 means scsv faster)"
+    echo "  scsv (1t) vs zsv (1t): $(echo "scale=2; $zsv_1t / $scsv_1t" | bc)x (>1 means scsv faster)"
+    echo "  scsv (auto) vs zsv (parallel): $(echo "scale=2; $zsv_parallel / $scsv_auto" | bc)x (>1 means scsv faster)"
 
     # Store results for final summary
     echo "$size_mb,$zsv_1t,$zsv_parallel,$scsv_1t,$scsv_auto" >> "$TEMP_DIR/results.csv"


### PR DESCRIPTION
## Summary
- Fix misleading comparison message in `benchmark/cli_comparison.sh` line 157
- The original code calculated `scsv_time / zsv_time` but labeled it as "zsv is Nx faster", producing confusing output like "zsv is 0.33x faster" when scsv was actually 3x faster
- Changed to consistent "scsv vs zsv" ordering with `zsv_time / scsv_time` calculation and "(>1 means scsv faster)" clarification

## Test plan
- [x] Build succeeds
- [x] All 1089 tests pass
- [ ] Manually verify output makes sense when running benchmark (requires zsv installed)

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)