### PR TITLE
fix: Remove unused simd_input parameter from find_quote_mask functions

### DIFF
--- a/include/branchless_state_machine.h
+++ b/include/branchless_state_machine.h
@@ -395,7 +395,7 @@ really_inline size_t process_block_simd_branchless(
 
     // Compute quote mask: positions that are inside quotes
     // Uses XOR prefix sum to track quote parity
-    uint64_t inside_quote = find_quote_mask2(in, quotes, prev_quote_state);
+    uint64_t inside_quote = find_quote_mask2(quotes, prev_quote_state);
 
     // Field separators are delimiters/newlines that are NOT inside quotes
     uint64_t field_seps = (delimiters | newlines) & ~inside_quote & valid_mask;

--- a/include/simd_highway.h
+++ b/include/simd_highway.h
@@ -84,8 +84,7 @@ HWY_ATTR really_inline uint64_t cmp_mask_against_input(const simd_input& in, uin
 // Find quote mask using carryless multiplication (PCLMULQDQ on x86, PMULL on ARM).
 // This computes a parallel prefix XOR over quote bit positions in constant time,
 // replacing a O(64) scalar loop with a single SIMD instruction (~28x speedup).
-// Pass by const reference to avoid ABI issues with 64-byte alignment on ARM.
-HWY_ATTR really_inline uint64_t find_quote_mask(const simd_input& in, uint64_t quote_bits,
+HWY_ATTR really_inline uint64_t find_quote_mask(uint64_t quote_bits,
                                                 uint64_t prev_iter_inside_quote) {
   // Use Highway's portable CLMul which maps to:
   // - x86: PCLMULQDQ instruction
@@ -114,7 +113,7 @@ HWY_ATTR really_inline uint64_t find_quote_mask(const simd_input& in, uint64_t q
 
 // Find quote mask with state tracking using carryless multiplication
 // This version updates prev_iter_inside_quote for the next iteration
-HWY_ATTR really_inline uint64_t find_quote_mask2(const simd_input& in, uint64_t quote_bits,
+HWY_ATTR really_inline uint64_t find_quote_mask2(uint64_t quote_bits,
                                                  uint64_t& prev_iter_inside_quote) {
   // Use Highway's portable CLMul which maps to:
   // - x86: PCLMULQDQ instruction

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -308,7 +308,7 @@ class two_pass {
           continue;
         }
         if (needs_even) {
-          uint64_t quote_mask2 = find_quote_mask(in, quotes, ~0ULL) & mask;
+          uint64_t quote_mask2 = find_quote_mask(quotes, ~0ULL) & mask;
           uint64_t even_nl = quote_mask2 & nl;
           if (even_nl > 0) {
             out.first_even_nl = start + idx + trailing_zeroes(even_nl);
@@ -316,7 +316,7 @@ class two_pass {
           needs_even = false;
         }
         if (needs_odd) {
-          uint64_t quote_mask = find_quote_mask(in, quotes, 0ULL) & mask;
+          uint64_t quote_mask = find_quote_mask(quotes, 0ULL) & mask;
           uint64_t odd_nl = quote_mask & nl & mask;
           if (odd_nl > 0) {
             out.first_odd_nl = start + idx + trailing_zeroes(odd_nl);
@@ -472,7 +472,7 @@ class two_pass {
 
       uint64_t quotes = cmp_mask_against_input(in, static_cast<uint8_t>(quote_char)) & mask;
 
-      uint64_t quote_mask = find_quote_mask2(in, quotes, prev_iter_inside_quote);
+      uint64_t quote_mask = find_quote_mask2(quotes, prev_iter_inside_quote);
       uint64_t sep = cmp_mask_against_input(in, static_cast<uint8_t>(delimiter));
       uint64_t end_mask = cmp_mask_against_input(in, '\n');
       uint64_t field_sep = (end_mask | sep) & ~quote_mask;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -281,7 +281,7 @@ size_t countRowsSimd(const uint8_t* buf, size_t len) {
     uint64_t newlines = simdcsv::cmp_mask_against_input(in, '\n');
 
     // Build quote mask (1 = inside quote, 0 = outside)
-    uint64_t quote_mask = simdcsv::find_quote_mask2(in, quotes, prev_iter_inside_quote);
+    uint64_t quote_mask = simdcsv::find_quote_mask2(quotes, prev_iter_inside_quote);
 
     // Newlines outside quotes
     uint64_t valid_newlines = newlines & ~quote_mask;

--- a/test/quote_mask_test.cpp
+++ b/test/quote_mask_test.cpp
@@ -22,8 +22,6 @@ uint64_t reference_quote_mask(uint64_t quote_bits, uint64_t prev_inside_quote) {
 }
 
 class QuoteMaskTest : public ::testing::Test {
- protected:
-  simd_input dummy_input{};  // Required by API but not used in computation
 };
 
 // Test: No quotes at all
@@ -31,10 +29,10 @@ TEST_F(QuoteMaskTest, NoQuotes) {
   uint64_t quote_bits = 0;
 
   // Starting outside quotes
-  EXPECT_EQ(find_quote_mask(dummy_input, quote_bits, 0), 0ULL);
+  EXPECT_EQ(find_quote_mask(quote_bits, 0), 0ULL);
 
   // Starting inside quotes (all bits should be set)
-  EXPECT_EQ(find_quote_mask(dummy_input, quote_bits, ~0ULL), ~0ULL);
+  EXPECT_EQ(find_quote_mask(quote_bits, ~0ULL), ~0ULL);
 }
 
 // Test: Single quote at position 0
@@ -42,11 +40,11 @@ TEST_F(QuoteMaskTest, SingleQuoteAtStart) {
   uint64_t quote_bits = 1ULL;  // Quote at position 0
 
   // Starting outside: bits 0-63 should all be 1 (inside quote after pos 0)
-  uint64_t result = find_quote_mask(dummy_input, quote_bits, 0);
+  uint64_t result = find_quote_mask(quote_bits, 0);
   EXPECT_EQ(result, ~0ULL);  // All bits set after the quote
 
   // Starting inside: quote closes, all bits should be 0
-  result = find_quote_mask(dummy_input, quote_bits, ~0ULL);
+  result = find_quote_mask(quote_bits, ~0ULL);
   EXPECT_EQ(result, 0ULL);
 }
 
@@ -55,11 +53,11 @@ TEST_F(QuoteMaskTest, SingleQuoteAtEnd) {
   uint64_t quote_bits = 1ULL << 63;  // Quote at position 63
 
   // Starting outside: only bit 63 should be set
-  uint64_t result = find_quote_mask(dummy_input, quote_bits, 0);
+  uint64_t result = find_quote_mask(quote_bits, 0);
   EXPECT_EQ(result, 1ULL << 63);
 
   // Starting inside: all bits except 63 should be set
-  result = find_quote_mask(dummy_input, quote_bits, ~0ULL);
+  result = find_quote_mask(quote_bits, ~0ULL);
   EXPECT_EQ(result, ~(1ULL << 63));
 }
 
@@ -68,7 +66,7 @@ TEST_F(QuoteMaskTest, QuotePair) {
   // Quote at positions 10 and 20
   uint64_t quote_bits = (1ULL << 10) | (1ULL << 20);
 
-  uint64_t result = find_quote_mask(dummy_input, quote_bits, 0);
+  uint64_t result = find_quote_mask(quote_bits, 0);
 
   // Bits 10-19 should be inside quotes (1), others outside (0)
   for (int i = 0; i < 64; i++) {
@@ -87,7 +85,7 @@ TEST_F(QuoteMaskTest, StateTransitionAcrossBoundaries) {
   uint64_t chunk1_quotes = 1ULL << 32;
   uint64_t prev_state = 0;
 
-  uint64_t mask1 = find_quote_mask2(dummy_input, chunk1_quotes, prev_state);
+  uint64_t mask1 = find_quote_mask2(chunk1_quotes, prev_state);
 
   // After chunk 1, we should be inside a quote
   EXPECT_EQ(prev_state, ~0ULL) << "Should be inside quote after chunk 1";
@@ -102,7 +100,7 @@ TEST_F(QuoteMaskTest, StateTransitionAcrossBoundaries) {
   // Chunk 2: quote closes at position 16
   uint64_t chunk2_quotes = 1ULL << 16;
 
-  uint64_t mask2 = find_quote_mask2(dummy_input, chunk2_quotes, prev_state);
+  uint64_t mask2 = find_quote_mask2(chunk2_quotes, prev_state);
 
   // After chunk 2, we should be outside a quote
   EXPECT_EQ(prev_state, 0ULL) << "Should be outside quote after chunk 2";
@@ -120,7 +118,7 @@ TEST_F(QuoteMaskTest, AlternatingQuotes) {
   // Every other bit is a quote
   uint64_t quote_bits = 0x5555555555555555ULL;  // 0101...
 
-  uint64_t result = find_quote_mask(dummy_input, quote_bits, 0);
+  uint64_t result = find_quote_mask(quote_bits, 0);
 
   // Expected pattern: positions 0,2,4,... are quotes
   // After pos 0: inside (bits 0 set)
@@ -141,7 +139,7 @@ TEST_F(QuoteMaskTest, AlternatingQuotes) {
 TEST_F(QuoteMaskTest, AllQuotes) {
   uint64_t quote_bits = ~0ULL;  // All positions are quotes
 
-  uint64_t result = find_quote_mask(dummy_input, quote_bits, 0);
+  uint64_t result = find_quote_mask(quote_bits, 0);
 
   // Each bit toggles: inside at 0, outside at 1, inside at 2, ...
   // Pattern: 1,0,1,0,... = 0x5555...
@@ -167,7 +165,7 @@ TEST_F(QuoteMaskTest, MatchesReferenceImplementation) {
   for (uint64_t pattern : patterns) {
     for (uint64_t prev : {0ULL, ~0ULL}) {
       uint64_t expected = reference_quote_mask(pattern, prev);
-      uint64_t actual = find_quote_mask(dummy_input, pattern, prev);
+      uint64_t actual = find_quote_mask(pattern, prev);
       EXPECT_EQ(actual, expected)
           << "Mismatch for pattern=0x" << std::hex << pattern
           << " prev=0x" << prev;
@@ -181,12 +179,12 @@ TEST_F(QuoteMaskTest, FindQuoteMask2StateTracking) {
 
   // Process pattern that ends inside a quote
   uint64_t pattern1 = 1ULL << 32;  // Single quote in middle
-  find_quote_mask2(dummy_input, pattern1, prev_state);
+  find_quote_mask2(pattern1, prev_state);
   EXPECT_EQ(prev_state, ~0ULL) << "Should be inside quote (MSB was set)";
 
   // Process pattern that ends outside a quote
   uint64_t pattern2 = 1ULL;  // Quote at start closes it
-  find_quote_mask2(dummy_input, pattern2, prev_state);
+  find_quote_mask2(pattern2, prev_state);
   EXPECT_EQ(prev_state, 0ULL) << "Should be outside quote";
 }
 
@@ -206,7 +204,7 @@ TEST_F(QuoteMaskTest, RandomPatternsFuzz) {
     uint64_t prev = (next_random() & 1) ? ~0ULL : 0ULL;
 
     uint64_t expected = reference_quote_mask(pattern, prev);
-    uint64_t actual = find_quote_mask(dummy_input, pattern, prev);
+    uint64_t actual = find_quote_mask(pattern, prev);
 
     EXPECT_EQ(actual, expected)
         << "Fuzz test failed at iteration " << i


### PR DESCRIPTION
## Summary

- Removes the unused `const simd_input& in` parameter from `find_quote_mask` and `find_quote_mask2` functions
- Updates all call sites to remove the parameter

## Background

PR #60 updated the `find_quote_mask` and `find_quote_mask2` functions in `include/simd_highway.h` to use Highway's `CLMulLower` for PCLMULQDQ-based quote mask computation. After this change, the `const simd_input& in` parameter was no longer used in the new CLMul-based implementation, but was retained in the function signatures.

## Changes

- **include/simd_highway.h**: Remove `const simd_input& in` parameter from both `find_quote_mask` and `find_quote_mask2` function signatures
- **include/two_pass.h**: Update 3 call sites to `find_quote_mask` and `find_quote_mask2`
- **include/branchless_state_machine.h**: Update 1 call site to `find_quote_mask2`
- **src/cli.cpp**: Update 1 call site to `find_quote_mask2`
- **test/quote_mask_test.cpp**: Remove unused `dummy_input` member from test fixture and update all test calls

## Test plan

- [x] All 1089 existing tests pass
- [x] Verified the quote_mask_test.cpp tests still validate the CLMul implementation correctness

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)