### PR TITLE
fix: Add defensive bounds check in parse_integer_simd sign handling

### DIFF
--- a/include/simd_number_parsing.h
+++ b/include/simd_number_parsing.h
@@ -1131,7 +1131,7 @@ really_inline ExtractResult<IntType> parse_integer_simd(const char* str, size_t 
 
     // Check max_integer_digits limit (matching scalar parse_integer behavior)
     const char* digit_start = ptr;
-    if (*ptr == '-' || *ptr == '+') ++digit_start;
+    if (ptr < end && (*ptr == '-' || *ptr == '+')) ++digit_start;
     size_t digit_count = end - digit_start;
     if (digit_count > config.max_integer_digits) {
         return {std::nullopt, "Integer too large"};


### PR DESCRIPTION
## Summary

- Add explicit `ptr < end` bounds check before dereferencing `ptr` when checking for sign characters in `parse_integer_simd()`

## Background

While the current code is functionally correct due to earlier validation:
- Early return if `len == 0` (line 1114)
- Early return if `ptr == end` after whitespace trimming (line 1123)

This change makes the safety explicit and follows defensive programming patterns used elsewhere in the codebase (e.g., whitespace trimming at line 1121).

## Test plan

- [x] Existing tests cover empty input and whitespace-only cases
- [ ] All existing tests pass in CI

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)