### PR TITLE
fix: Use valid data pointer in empty string_view to prevent SIGABRT

### DIFF
--- a/include/arrow_output.h
+++ b/include/arrow_output.h
@@ -106,8 +106,10 @@ private:
      * @param end Ending byte offset of the field (exclusive)
      * @param dialect CSV dialect settings
      * @return A string_view of the field contents, with quotes stripped if present.
-     *         Returns empty string_view if start >= end.
+     *         Returns empty string_view with valid data pointer (buf+start) if start >= end.
      * @pre end >= start (asserted in debug builds to catch corrupted index data)
+     * @note The returned string_view always has a valid (non-null) data pointer,
+     *       even when empty. This avoids undefined behavior when converting to std::string.
      */
     std::string_view extract_field(const uint8_t* buf, size_t start, size_t end, const Dialect& dialect);
     ColumnType infer_cell_type(std::string_view cell);

--- a/src/value_extraction.cpp
+++ b/src/value_extraction.cpp
@@ -33,7 +33,8 @@ std::string_view ValueExtractor::get_string_view(size_t row, size_t col) const {
 
 std::string_view ValueExtractor::get_string_view_internal(size_t row, size_t col) const {
     size_t field_idx = compute_field_index(row, col);
-    if (field_idx >= linear_indexes_.size()) return std::string_view();  // Bounds check
+    // Return empty view with valid pointer to avoid undefined behavior when converting to std::string
+    if (field_idx >= linear_indexes_.size()) return std::string_view(reinterpret_cast<const char*>(buf_), 0);
     size_t start = (field_idx == 0) ? 0 : linear_indexes_[field_idx - 1] + 1;
     size_t end = linear_indexes_[field_idx];
     if (end > len_) end = len_;  // Bounds check


### PR DESCRIPTION
## Summary

- Fixed SIGABRT crash in `ArrowOutputTest.EmptyFields` test on macOS caused by constructing `std::string` from `std::string_view` with null data pointer
- `extract_field` now returns empty `string_view` with valid pointer (`buf+start`) instead of default-constructed `string_view()` with `data()==nullptr`
- Fixed similar issue in `ValueExtractor::get_string_view_internal`

## Root Cause

When `extract_field` returned `std::string_view()` for empty fields (where `start >= end`), the view had `data() == nullptr` and `size() == 0`. When this view was later converted to `std::string` via `std::string(cell)` in `build_string_column`, the constructor `basic_string(const CharT* s, size_type count)` was called with a null pointer. While C++ allows this when count is 0, some implementations (notably macOS) may still dereference the pointer, causing undefined behavior and SIGABRT.

## Test plan

- [ ] CI passes - `ArrowOutputTest.EmptyFields` should no longer crash
- [ ] Existing tests continue to pass
- [ ] Related tests `FieldRangeStartEqualsEnd` and `ConsecutiveDelimiters` still work

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)