### PR TITLE
test: Add smoke test for scsv binary in minimal release build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,12 @@ jobs:
           exit 1
         fi
 
+    - name: Smoke test scsv binary
+      run: |
+        echo "Running smoke test: scsv --help"
+        ./build/scsv --help
+        echo "✓ scsv binary runs successfully"
+
     - name: Verify test executables are NOT built
       run: |
         echo "Verifying test executables are not present..."


### PR DESCRIPTION
## Summary

- Add smoke test step to minimal-release-build CI job that runs `./build/scsv --help`
- Verifies the binary is functional and doesn't crash upon execution, not just that it exists

## Test plan

- [x] Tested locally that `./build/scsv --help` runs successfully after a minimal build
- [ ] CI workflow runs and the smoke test step passes

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)