### PR TITLE
fix: Mask delimiter detection in SIMD second pass to prevent corruption

### DIFF
--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -557,7 +557,7 @@ class two_pass {
       uint64_t quotes = cmp_mask_against_input(in, static_cast<uint8_t>(quote_char)) & mask;
 
       uint64_t quote_mask = find_quote_mask2(quotes, prev_iter_inside_quote);
-      uint64_t sep = cmp_mask_against_input(in, static_cast<uint8_t>(delimiter));
+      uint64_t sep = cmp_mask_against_input(in, static_cast<uint8_t>(delimiter)) & mask;
       // Support LF, CRLF, and CR-only line endings
       uint64_t end_mask = compute_line_ending_mask_simple(in, mask);
       uint64_t field_sep = (end_mask | sep) & ~quote_mask;


### PR DESCRIPTION
## Summary

- Fix multi-threaded CSV parsing corruption where garbage bytes beyond valid data were incorrectly detected as field separators
- Add `& mask` to delimiter detection in `second_pass_simd()` to match the masking already applied to quote and line ending detection
- Add two regression tests that verify comma-filled padding doesn't cause excessive garbage separator detection

## Root Cause

In `second_pass_simd()` at `include/two_pass.h:560`, the delimiter detection was not masked with `valid_mask`:

```cpp
// Before (bug):
uint64_t sep = cmp_mask_against_input(in, static_cast<uint8_t>(delimiter));

// After (fix):  
uint64_t sep = cmp_mask_against_input(in, static_cast<uint8_t>(delimiter)) & mask;
```

When processing partial 64-byte SIMD blocks at the end of chunks, garbage bytes in the padding area could contain delimiter characters (like commas). Without masking, these garbage bytes were detected as field separators, corrupting the output. This was especially visible on macOS/ARM where memory allocation patterns differ.

## Test plan

- [x] Verified fix locally with multi-threaded parsing tests
- [x] All 1646 existing tests pass
- [x] Added `MultiThreadedDelimiterMasking` test that fills padding with commas and verifies no garbage detection
- [x] Added `MultiThreadedChunkBoundaryPartialBlock` test for chunk boundary handling with 2-8 threads
- [ ] CI passes on all platforms (Linux, macOS ARM64)

Fixes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)