### PR TITLE
cleanup: Remove empty placeholder methods from two_pass.h

### DIFF
--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -249,8 +249,6 @@ class index {
       delete[] n_indexes;
     }
   }
-
-  void fill_double_array(index* idx, uint64_t column, double* out) {}
 };
 
 /**
@@ -2020,11 +2018,4 @@ class two_pass {
   }
 };
 
-class parser {
- public:
-  parser() noexcept {};
-  void parse(const uint8_t* buf, size_t len) {}
-
- private:
-};
 }  // namespace libvroom


### PR DESCRIPTION
## Summary
- Remove empty `index::fill_double_array()` method that was never implemented
- Remove empty `parser` class that was superseded by the full `Parser` implementation

These placeholder methods were identified in issue #277 as incomplete planning work that should be cleaned up. If similar functionality is needed in the future, it should be properly designed and implemented in separate issues.

## Test plan
- [x] All 1661 existing tests pass
- [x] Build succeeds with no new errors
- [x] Verified no usages of removed code exist in codebase

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)