### PR TITLE
ci: Integrate fuzzing into CI with weekly scheduled runs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -95,6 +95,31 @@ When adding new test files:
 - **Parallel builds**: CMake uses multiple cores by default
 - **Test parallelization**: CTest can run tests in parallel
 
+### fuzz.yml - Fuzz Testing
+
+Continuous fuzz testing using libFuzzer with sanitizers.
+
+**Triggers:**
+- **Scheduled**: Weekly on Sundays at 2:00 UTC
+- **Manual**: On-demand via workflow_dispatch
+
+**Fuzz Targets:**
+- `fuzz_csv_parser` - Core two-pass CSV parser
+- `fuzz_dialect_detection` - Dialect detection
+- `fuzz_parse_auto` - Integrated parse_auto()
+
+**Configuration:**
+- Default duration: 10 minutes per target (scheduled runs)
+- Manual runs: Configurable 1-30 minutes
+- Sanitizers: AddressSanitizer, UndefinedBehaviorSanitizer
+
+**On Crash Detection:**
+1. Workflow fails with error message
+2. Crash artifacts uploaded (30-day retention)
+3. Details in workflow logs
+
+See `fuzz/README.md` for local fuzzing instructions.
+
 ## Future Enhancements
 
 Potential workflow additions:
@@ -102,8 +127,7 @@ Potential workflow additions:
 1. **Coverage reporting**: Add code coverage with lcov/gcov
 2. **Benchmarking**: Performance regression testing
 3. **Static analysis**: clang-tidy, cppcheck
-4. **Sanitizers**: AddressSanitizer, UndefinedBehaviorSanitizer
-5. **Format checking**: clang-format validation
-6. **Windows builds**: MSVC support
-7. **ARM64 builds**: Native ARM testing
-8. **Release automation**: Automatic tagging and releases
+4. **Format checking**: clang-format validation
+5. **Windows builds**: MSVC support
+6. **ARM64 builds**: Native ARM testing
+7. **Release automation**: Automatic tagging and releases

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,6 +1,10 @@
 name: Fuzz Testing
 
 on:
+  # Weekly scheduled fuzzing (Sundays at 2:00 UTC)
+  schedule:
+    - cron: '0 2 * * 0'
+  # Manual dispatch for on-demand fuzzing
   workflow_dispatch:
     inputs:
       duration:
@@ -12,41 +16,80 @@ on:
         type: choice
         options: [all, fuzz_csv_parser, fuzz_dialect_detection, fuzz_parse_auto]
 
+env:
+  # Default duration for scheduled runs (10 minutes per target)
+  DEFAULT_DURATION: 600
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install deps
+
+    - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install -y cmake clang llvm
-    - name: Build
+
+    - name: Build fuzzers
       run: |
         cmake -B build -DENABLE_FUZZING=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
         cmake --build build --target fuzz_csv_parser fuzz_dialect_detection fuzz_parse_auto
-    - name: Setup RAM disk
+
+    - name: Setup RAM disk for fuzzing
       run: |
-        sudo mkdir -p /mnt/ramdisk && sudo mount -t tmpfs -o size=512M tmpfs /mnt/ramdisk
+        sudo mkdir -p /mnt/ramdisk
+        sudo mount -t tmpfs -o size=512M tmpfs /mnt/ramdisk
         cp -r build/fuzz_corpus /mnt/ramdisk/corpus
         mkdir -p /mnt/ramdisk/artifacts
-    - name: Fuzz
+
+    - name: Run fuzzers
       run: |
-        DUR=${{ github.event.inputs.duration }}; [ "$DUR" -gt 1800 ] && DUR=1800
+        # Use input duration for manual dispatch, default for scheduled runs
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          DUR="${{ github.event.inputs.duration }}"
+          TARGET="${{ github.event.inputs.target }}"
+        else
+          DUR="${DEFAULT_DURATION}"
+          TARGET="all"
+        fi
+
+        # Cap duration at 30 minutes
+        [ "$DUR" -gt 1800 ] && DUR=1800
+
+        echo "Fuzzing duration: ${DUR}s per target"
+        echo "Target: ${TARGET}"
+
         for t in fuzz_csv_parser fuzz_dialect_detection fuzz_parse_auto; do
-          if [ "${{ github.event.inputs.target }}" = "all" ] || [ "${{ github.event.inputs.target }}" = "$t" ]; then
-            timeout ${DUR}s ./build/$t /mnt/ramdisk/corpus -artifact_prefix=/mnt/ramdisk/artifacts/ -max_len=65536 -timeout=5 || true
+          if [ "$TARGET" = "all" ] || [ "$TARGET" = "$t" ]; then
+            echo "::group::Running $t"
+            timeout ${DUR}s ./build/$t /mnt/ramdisk/corpus \
+              -artifact_prefix=/mnt/ramdisk/artifacts/ \
+              -max_len=65536 \
+              -timeout=5 \
+              -print_final_stats=1 || true
+            echo "::endgroup::"
           fi
         done
-    - name: Check crashes
+
+    - name: Check for crashes
       id: check
       run: |
         CRASHES=$(find /mnt/ramdisk/artifacts -name 'crash-*' -o -name 'oom-*' 2>/dev/null | wc -l)
         echo "count=$CRASHES" >> $GITHUB_OUTPUT
-    - name: Upload crashes
+        if [ "$CRASHES" -gt 0 ]; then
+          echo "::warning::Found $CRASHES crash/OOM artifacts"
+          ls -la /mnt/ramdisk/artifacts/
+        fi
+
+    - name: Upload crash artifacts
       if: steps.check.outputs.count != '0'
       uses: actions/upload-artifact@v4
       with:
-        name: fuzz-crashes
+        name: fuzz-crashes-${{ github.run_id }}
         path: /mnt/ramdisk/artifacts
+        retention-days: 30
+
     - name: Fail on crashes
       if: steps.check.outputs.count != '0'
-      run: exit 1
+      run: |
+        echo "::error::Fuzzing found ${{ steps.check.outputs.count }} crash(es). See uploaded artifacts."
+        exit 1

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,20 +1,69 @@
 # Fuzz Testing for libvroom
 
-Fuzz testing infrastructure using libFuzzer.
+Fuzz testing infrastructure using libFuzzer with AddressSanitizer and
+UndefinedBehaviorSanitizer.
 
-## Building
+## Fuzz Targets
+
+| Target | Description | Max Input |
+|--------|-------------|-----------|
+| `fuzz_csv_parser` | Core two-pass CSV parser | 64 KB |
+| `fuzz_dialect_detection` | Dialect detection (delimiter, quoting, line endings) | 16 KB |
+| `fuzz_parse_auto` | Integrated parse_auto() combining detection + parsing | 64 KB |
+
+## Building Locally
+
+Requires Clang compiler:
 
 ```bash
-cmake -B build-fuzz -DENABLE_FUZZING=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+cmake -B build-fuzz -DENABLE_FUZZING=ON \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++
 cmake --build build-fuzz
 ```
 
-## Running
+## Running Locally
 
 ```bash
+# Run with corpus (recommended)
 ./build-fuzz/fuzz_csv_parser build-fuzz/fuzz_corpus -max_len=65536
+
+# Run for a specific duration (e.g., 60 seconds)
+timeout 60s ./build-fuzz/fuzz_csv_parser build-fuzz/fuzz_corpus -max_len=65536
+
+# Run all targets
+for t in fuzz_csv_parser fuzz_dialect_detection fuzz_parse_auto; do
+  timeout 60s ./build-fuzz/$t build-fuzz/fuzz_corpus -max_len=65536
+done
 ```
+
+## Seed Corpus
+
+The seed corpus is located in `test/data/fuzz/` and includes edge cases:
+- Binary data and null bytes
+- Invalid UTF-8 sequences
+- Mixed line endings (CR/LF/CRLF)
+- Deep quoting and escape sequences
+- Quote handling at EOF
+
+The corpus is automatically copied to `build/fuzz_corpus/` during the build.
+
+## CI Integration
+
+Fuzzing runs automatically in GitHub Actions:
+
+- **Weekly scheduled runs**: Every Sunday at 2:00 UTC (10 minutes per target)
+- **Manual dispatch**: Run on-demand via Actions UI with configurable duration
+
+See `.github/workflows/fuzz.yml` for the workflow configuration.
+
+### Viewing Results
+
+If crashes are found:
+1. The workflow fails with an error message
+2. Crash artifacts are uploaded and available for 30 days
+3. Download artifacts to reproduce locally
 
 ## OSS-Fuzz
 
-See `oss-fuzz/` for Google OSS-Fuzz integration.
+See `oss-fuzz/` for Google OSS-Fuzz integration files.


### PR DESCRIPTION
## Summary
- Add weekly scheduled fuzz testing (Sundays at 2:00 UTC) to run alongside manual dispatch
- 10 minutes per target for scheduled runs with configurable duration for manual runs
- Improved crash artifact handling with 30-day retention and unique run IDs
- Better logging with GitHub Actions groups and final statistics output

## Changes
- `.github/workflows/fuzz.yml`: Add `schedule` trigger, improve workflow structure
- `.github/workflows/README.md`: Document fuzz workflow configuration
- `fuzz/README.md`: Expand documentation with CI integration details

Closes #282

## Test plan
- [ ] Workflow syntax validated by GitHub Actions
- [ ] Manual workflow dispatch works correctly
- [ ] Scheduled run executes on Sunday 2:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)