### PR TITLE
fix: Remove single-threaded workaround from macOS CLI tests

### DIFF
--- a/test/cli_test.cpp
+++ b/test/cli_test.cpp
@@ -916,8 +916,8 @@ TEST_F(CliTest, TailNoHeader) {
 
 TEST_F(CliTest, TailManyRows) {
   // Test with file that has 20 data rows
-  // Use single-threaded parsing (-t 1) to avoid platform-specific threading differences
-  auto result = CliRunner::run("tail -n 5 -t 1 " + testDataPath("basic/many_rows.csv"));
+  // Uses default multi-threaded parsing (PR #303 fixed SIMD delimiter masking on macOS)
+  auto result = CliRunner::run("tail -n 5 " + testDataPath("basic/many_rows.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have header
   EXPECT_TRUE(result.output.find("ID,Value,Label") != std::string::npos);
@@ -1029,8 +1029,8 @@ TEST_F(CliTest, SampleNoHeader) {
 
 TEST_F(CliTest, SampleManyRows) {
   // Sample from file with 20 data rows
-  // Use single-threaded parsing (-t 1) to avoid platform-specific threading differences
-  auto result = CliRunner::run("sample -n 5 -s 42 -t 1 " + testDataPath("basic/many_rows.csv"));
+  // Uses default multi-threaded parsing (PR #303 fixed SIMD delimiter masking on macOS)
+  auto result = CliRunner::run("sample -n 5 -s 42 " + testDataPath("basic/many_rows.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have header
   EXPECT_TRUE(result.output.find("ID,Value,Label") != std::string::npos);


### PR DESCRIPTION
## Summary
- Removes the `-t 1` (single-threaded) workaround from `TailManyRows` and `SampleManyRows` tests
- Tests now use the default multi-threaded parsing behavior on all platforms

## Background

Issue #289 reported that CLI tests failed on macOS when using the unified Parser API. The tests were passing on Ubuntu but failing on macOS with output that included the header row but missing data rows.

The root cause was identified in issue #297 as a SIMD delimiter masking bug - multi-threaded parsing produced corrupted output on macOS where fields had extra commas (e.g., `9,,900,,I` instead of `9,900,I`).

PR #303 fixed the root cause by properly masking delimiter detection in the SIMD second pass, which prevented garbage bytes beyond valid data from being incorrectly detected as field separators.

## Changes

With the underlying bug fixed, this PR removes the single-threaded workaround from the affected tests, allowing them to use the default multi-threaded parsing behavior that the rest of the codebase uses.

## Test plan
- [x] All 1661 tests pass locally
- [x] `TailManyRows` and `SampleManyRows` pass with multi-threaded parsing
- [ ] CI passes on both Ubuntu and macOS

Fixes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)