### PR TITLE
feat: Add input size limits for security (fixes #270)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,24 @@ add_custom_command(TARGET branchless_test POST_BUILD
 # Register branchless tests with CTest
 gtest_discover_tests(branchless_test)
 
+# Size limits test executable (security feature from issue #270)
+add_executable(size_limits_test
+    test/size_limits_test.cpp
+)
+
+target_link_libraries(size_limits_test PRIVATE
+    vroom
+    GTest::gtest_main
+    pthread
+)
+
+target_include_directories(size_limits_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+# Register size limits tests with CTest
+gtest_discover_tests(size_limits_test)
+
 # SIMD number parsing test executable
 add_executable(simd_number_parsing_test
     test/simd_number_parsing_test.cpp

--- a/include/error.h
+++ b/include/error.h
@@ -47,7 +47,7 @@ enum class ErrorCode {
 
     // Field structure errors
     INCONSISTENT_FIELD_COUNT,    ///< Row has different number of fields than header
-    FIELD_TOO_LARGE,             ///< [RESERVED] Field exceeds maximum size limit
+    FIELD_TOO_LARGE,             ///< Field exceeds maximum size limit
 
     // Line ending errors
     MIXED_LINE_ENDINGS,          ///< File uses inconsistent line endings (warning)
@@ -65,7 +65,8 @@ enum class ErrorCode {
     AMBIGUOUS_SEPARATOR,         ///< [RESERVED] Cannot determine separator reliably
 
     // General errors
-    FILE_TOO_LARGE,              ///< [RESERVED] File exceeds maximum size
+    FILE_TOO_LARGE,              ///< File exceeds maximum size limit
+    INDEX_ALLOCATION_OVERFLOW,   ///< Index allocation would overflow
     IO_ERROR,                    ///< [RESERVED] File I/O error
     INTERNAL_ERROR               ///< Internal parser error
 };

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -2018,6 +2018,88 @@ class two_pass {
     out.indexes = new uint64_t[allocation_size];
     return out;
   }
+
+  /**
+   * @brief Initialize an index structure with overflow validation.
+   *
+   * This is the safe version of init() that validates all size calculations
+   * before memory allocation to prevent integer overflow vulnerabilities.
+   *
+   * @param len Length of the CSV buffer in bytes. Determines maximum index capacity.
+   * @param n_threads Number of threads to use for parsing. Use 1 for single-threaded
+   *                  parsing, or a higher value for multi-threaded parsing.
+   * @param errors Optional ErrorCollector for reporting size limit violations.
+   *               If nullptr and an overflow would occur, an exception is thrown.
+   *
+   * @return An initialized index structure ready for parsing, or an empty index
+   *         with nullptr indexes if allocation would overflow.
+   *
+   * @throws std::runtime_error if overflow detected and errors is nullptr.
+   *
+   * @note For most use cases, prefer using Parser::parse() which calls this
+   *       method internally with appropriate size limit validation.
+   *
+   * @see init() For the non-validating version (deprecated for untrusted input).
+   * @see SizeLimits For file size limits that should be checked before calling this.
+   */
+  index init_safe(size_t len, size_t n_threads, ErrorCollector* errors = nullptr) {
+    index out;
+    // Ensure at least 1 thread for valid memory allocation
+    if (n_threads == 0) n_threads = 1;
+    out.n_threads = n_threads;
+
+    // Calculate allocation size with overflow checking
+    size_t allocation_size;
+    bool overflow = false;
+
+    if (n_threads == 1) {
+      // Single-threaded: simple allocation with padding for speculative writes
+      // allocation_size = len + 8
+      if (len > std::numeric_limits<size_t>::max() - 8) {
+        overflow = true;
+      } else {
+        allocation_size = len + 8;
+      }
+    } else {
+      // Multi-threaded: need space for interleaved storage
+      // allocation_size = (len + 8) * n_threads
+      size_t len_plus_8;
+      if (len > std::numeric_limits<size_t>::max() - 8) {
+        overflow = true;
+      } else {
+        len_plus_8 = len + 8;
+        // Check (len + 8) * n_threads for overflow
+        if (len_plus_8 > std::numeric_limits<size_t>::max() / n_threads) {
+          overflow = true;
+        } else {
+          allocation_size = len_plus_8 * n_threads;
+        }
+      }
+    }
+
+    // Check final allocation: allocation_size * sizeof(uint64_t)
+    if (!overflow && allocation_size > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
+      overflow = true;
+    }
+
+    if (overflow) {
+      std::string msg = "Index allocation would overflow: len=" + std::to_string(len) +
+                        ", n_threads=" + std::to_string(n_threads);
+      if (errors != nullptr) {
+        errors->add_error(ErrorCode::INDEX_ALLOCATION_OVERFLOW, ErrorSeverity::FATAL,
+                          1, 1, 0, msg);
+        // Return empty index to signal failure
+        return out;
+      } else {
+        throw std::runtime_error(msg);
+      }
+    }
+
+    // Safe to allocate
+    out.n_indexes = new uint64_t[n_threads];
+    out.indexes = new uint64_t[allocation_size];
+    return out;
+  }
 };
 
 class parser {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -19,6 +19,7 @@ const char* error_code_to_string(ErrorCode code) {
         case ErrorCode::DUPLICATE_COLUMN_NAMES: return "DUPLICATE_COLUMN_NAMES";
         case ErrorCode::AMBIGUOUS_SEPARATOR: return "AMBIGUOUS_SEPARATOR";
         case ErrorCode::FILE_TOO_LARGE: return "FILE_TOO_LARGE";
+        case ErrorCode::INDEX_ALLOCATION_OVERFLOW: return "INDEX_ALLOCATION_OVERFLOW";
         case ErrorCode::IO_ERROR: return "IO_ERROR";
         case ErrorCode::INTERNAL_ERROR: return "INTERNAL_ERROR";
         default: return "UNKNOWN";

--- a/test/error_handling_test.cpp
+++ b/test/error_handling_test.cpp
@@ -27,6 +27,7 @@ TEST(ErrorHandlingTest, ErrorCodeToString) {
     EXPECT_STREQ(error_code_to_string(ErrorCode::DUPLICATE_COLUMN_NAMES), "DUPLICATE_COLUMN_NAMES");
     EXPECT_STREQ(error_code_to_string(ErrorCode::AMBIGUOUS_SEPARATOR), "AMBIGUOUS_SEPARATOR");
     EXPECT_STREQ(error_code_to_string(ErrorCode::FILE_TOO_LARGE), "FILE_TOO_LARGE");
+    EXPECT_STREQ(error_code_to_string(ErrorCode::INDEX_ALLOCATION_OVERFLOW), "INDEX_ALLOCATION_OVERFLOW");
     EXPECT_STREQ(error_code_to_string(ErrorCode::IO_ERROR), "IO_ERROR");
     EXPECT_STREQ(error_code_to_string(ErrorCode::INTERNAL_ERROR), "INTERNAL_ERROR");
 

--- a/test/size_limits_test.cpp
+++ b/test/size_limits_test.cpp
@@ -1,0 +1,310 @@
+/**
+ * @file size_limits_test.cpp
+ * @brief Tests for input size limits security feature (issue #270).
+ *
+ * These tests verify that the library properly enforces size limits to prevent
+ * denial-of-service attacks through excessive memory allocation.
+ */
+
+#include <gtest/gtest.h>
+#include "libvroom.h"
+#include "streaming.h"
+#include <string>
+#include <cstring>
+#include <limits>
+
+using namespace libvroom;
+
+// ============================================================================
+// SizeLimits STRUCTURE TESTS
+// ============================================================================
+
+TEST(SizeLimitsTest, DefaultValues) {
+    SizeLimits limits;
+    EXPECT_EQ(limits.max_file_size, 10ULL * 1024 * 1024 * 1024);  // 10GB
+    EXPECT_EQ(limits.max_field_size, 16ULL * 1024 * 1024);  // 16MB
+}
+
+TEST(SizeLimitsTest, DefaultsFactory) {
+    auto limits = SizeLimits::defaults();
+    EXPECT_EQ(limits.max_file_size, 10ULL * 1024 * 1024 * 1024);
+    EXPECT_EQ(limits.max_field_size, 16ULL * 1024 * 1024);
+}
+
+TEST(SizeLimitsTest, UnlimitedFactory) {
+    auto limits = SizeLimits::unlimited();
+    EXPECT_EQ(limits.max_file_size, 0);
+    EXPECT_EQ(limits.max_field_size, 0);
+}
+
+TEST(SizeLimitsTest, StrictFactory) {
+    auto limits = SizeLimits::strict();
+    EXPECT_EQ(limits.max_file_size, 100ULL * 1024 * 1024);  // 100MB
+    EXPECT_EQ(limits.max_field_size, 1ULL * 1024 * 1024);  // 1MB
+}
+
+TEST(SizeLimitsTest, StrictFactoryCustomValues) {
+    auto limits = SizeLimits::strict(50ULL * 1024 * 1024, 512 * 1024);
+    EXPECT_EQ(limits.max_file_size, 50ULL * 1024 * 1024);  // 50MB
+    EXPECT_EQ(limits.max_field_size, 512 * 1024);  // 512KB
+}
+
+// ============================================================================
+// OVERFLOW DETECTION TESTS
+// ============================================================================
+
+TEST(OverflowTest, MultiplyNoOverflow) {
+    EXPECT_FALSE(would_overflow_multiply(0, 100));
+    EXPECT_FALSE(would_overflow_multiply(100, 0));
+    EXPECT_FALSE(would_overflow_multiply(1000, 1000));
+    EXPECT_FALSE(would_overflow_multiply(1, std::numeric_limits<size_t>::max()));
+}
+
+TEST(OverflowTest, MultiplyOverflow) {
+    size_t max = std::numeric_limits<size_t>::max();
+    EXPECT_TRUE(would_overflow_multiply(max, 2));
+    EXPECT_TRUE(would_overflow_multiply(max / 2 + 1, 2));
+    EXPECT_TRUE(would_overflow_multiply(1ULL << 32, 1ULL << 32));  // On 64-bit systems
+}
+
+TEST(OverflowTest, AddNoOverflow) {
+    EXPECT_FALSE(would_overflow_add(0, 100));
+    EXPECT_FALSE(would_overflow_add(100, 0));
+    EXPECT_FALSE(would_overflow_add(1000, 1000));
+}
+
+TEST(OverflowTest, AddOverflow) {
+    size_t max = std::numeric_limits<size_t>::max();
+    EXPECT_TRUE(would_overflow_add(max, 1));
+    EXPECT_TRUE(would_overflow_add(max - 10, 20));
+    EXPECT_TRUE(would_overflow_add(max / 2 + 1, max / 2 + 1));
+}
+
+// ============================================================================
+// FILE SIZE LIMIT TESTS
+// ============================================================================
+
+class FileSizeLimitTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create a simple CSV for testing
+        small_csv = "a,b,c\n1,2,3\n4,5,6\n";
+        small_csv_len = small_csv.size();
+
+        // Create a buffer with padding for SIMD operations
+        small_csv_buffer.resize(small_csv_len + 64, 0);
+        std::memcpy(small_csv_buffer.data(), small_csv.data(), small_csv_len);
+    }
+
+    std::string small_csv;
+    size_t small_csv_len;
+    std::vector<uint8_t> small_csv_buffer;
+};
+
+TEST_F(FileSizeLimitTest, AcceptsFileWithinLimit) {
+    Parser parser;
+    SizeLimits limits;
+    limits.max_file_size = 1000;  // 1KB limit
+
+    auto result = parser.parse(small_csv_buffer.data(), small_csv_len, {.limits = limits});
+
+    EXPECT_TRUE(result.success());
+}
+
+TEST_F(FileSizeLimitTest, RejectsFileTooLarge) {
+    Parser parser;
+    SizeLimits limits;
+    limits.max_file_size = 10;  // Very small limit
+
+    EXPECT_THROW({
+        parser.parse(small_csv_buffer.data(), small_csv_len, {.limits = limits});
+    }, std::runtime_error);
+}
+
+TEST_F(FileSizeLimitTest, RejectsFileTooLargeWithErrorCollector) {
+    Parser parser;
+    ErrorCollector errors(ErrorMode::PERMISSIVE);
+    SizeLimits limits;
+    limits.max_file_size = 10;  // Very small limit
+
+    auto result = parser.parse(small_csv_buffer.data(), small_csv_len,
+                               {.errors = &errors, .limits = limits});
+
+    EXPECT_FALSE(result.success());
+    EXPECT_TRUE(errors.has_fatal_errors());
+    EXPECT_EQ(errors.errors()[0].code, ErrorCode::FILE_TOO_LARGE);
+}
+
+TEST_F(FileSizeLimitTest, AllowsWithUnlimitedSize) {
+    Parser parser;
+    auto limits = SizeLimits::unlimited();
+
+    // Should not throw even with unlimited settings
+    auto result = parser.parse(small_csv_buffer.data(), small_csv_len, {.limits = limits});
+
+    EXPECT_TRUE(result.success());
+}
+
+// ============================================================================
+// INDEX ALLOCATION OVERFLOW TESTS
+// ============================================================================
+
+TEST(IndexAllocationTest, ThrowsOnOverflow) {
+    two_pass parser;
+
+    // Attempt to allocate with extreme size that would overflow
+    // SIZE_MAX / 8 would overflow when multiplied by sizeof(uint64_t)
+    size_t huge_len = std::numeric_limits<size_t>::max() - 10;
+
+    EXPECT_THROW({
+        parser.init_safe(huge_len, 1, nullptr);
+    }, std::runtime_error);
+}
+
+TEST(IndexAllocationTest, ReportsOverflowWithErrorCollector) {
+    two_pass parser;
+    ErrorCollector errors(ErrorMode::PERMISSIVE);
+
+    size_t huge_len = std::numeric_limits<size_t>::max() - 10;
+
+    auto idx = parser.init_safe(huge_len, 1, &errors);
+
+    EXPECT_EQ(idx.indexes, nullptr);
+    EXPECT_TRUE(errors.has_fatal_errors());
+    EXPECT_EQ(errors.errors()[0].code, ErrorCode::INDEX_ALLOCATION_OVERFLOW);
+}
+
+TEST(IndexAllocationTest, MultiThreadOverflow) {
+    two_pass parser;
+    ErrorCollector errors(ErrorMode::PERMISSIVE);
+
+    // A size that's fine for single thread but overflows with many threads
+    // (len + 8) * n_threads would overflow
+    size_t len = std::numeric_limits<size_t>::max() / 4;
+    size_t n_threads = 8;
+
+    auto idx = parser.init_safe(len, n_threads, &errors);
+
+    EXPECT_EQ(idx.indexes, nullptr);
+    EXPECT_TRUE(errors.has_fatal_errors());
+}
+
+TEST(IndexAllocationTest, AcceptsNormalSize) {
+    two_pass parser;
+
+    // Normal allocation should succeed
+    auto idx = parser.init_safe(1000, 4, nullptr);
+
+    EXPECT_NE(idx.indexes, nullptr);
+    EXPECT_NE(idx.n_indexes, nullptr);
+}
+
+// ============================================================================
+// STREAMING PARSER FIELD SIZE TESTS
+// ============================================================================
+
+TEST(StreamingFieldSizeTest, RejectsOversizeField) {
+    StreamConfig config;
+    config.max_field_size = 10;  // Very small limit
+    config.parse_header = false;
+
+    StreamParser parser(config);
+
+    // Create a CSV with a field larger than the limit
+    std::string csv = "short,thisfieldiswaytoolongandwillberejected,ok\n";
+
+    parser.parse_chunk(csv.data(), csv.size());
+    parser.finish();
+
+    const auto& errors = parser.errors();
+    EXPECT_TRUE(errors.has_errors());
+
+    // Find the FIELD_TOO_LARGE error
+    bool found_field_too_large = false;
+    for (const auto& err : errors.errors()) {
+        if (err.code == ErrorCode::FIELD_TOO_LARGE) {
+            found_field_too_large = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_field_too_large) << "Expected FIELD_TOO_LARGE error";
+}
+
+TEST(StreamingFieldSizeTest, AcceptsFieldWithinLimit) {
+    StreamConfig config;
+    config.max_field_size = 100;  // Reasonable limit
+    config.parse_header = false;
+
+    StreamParser parser(config);
+
+    std::string csv = "short,medium,ok\n";
+
+    parser.parse_chunk(csv.data(), csv.size());
+    parser.finish();
+
+    const auto& errors = parser.errors();
+    // Should not have any FIELD_TOO_LARGE errors
+    for (const auto& err : errors.errors()) {
+        EXPECT_NE(err.code, ErrorCode::FIELD_TOO_LARGE);
+    }
+}
+
+TEST(StreamingFieldSizeTest, DisabledWithZeroLimit) {
+    StreamConfig config;
+    config.max_field_size = 0;  // Disabled
+    config.parse_header = false;
+
+    StreamParser parser(config);
+
+    // Large field should be accepted when limit is disabled
+    std::string large_field(1000, 'x');
+    std::string csv = large_field + ",ok\n";
+
+    parser.parse_chunk(csv.data(), csv.size());
+    parser.finish();
+
+    const auto& errors = parser.errors();
+    for (const auto& err : errors.errors()) {
+        EXPECT_NE(err.code, ErrorCode::FIELD_TOO_LARGE);
+    }
+}
+
+// ============================================================================
+// ERROR CODE STRING TESTS
+// ============================================================================
+
+TEST(ErrorCodeTest, FileTooLargeString) {
+    EXPECT_STREQ(error_code_to_string(ErrorCode::FILE_TOO_LARGE), "FILE_TOO_LARGE");
+}
+
+TEST(ErrorCodeTest, IndexAllocationOverflowString) {
+    EXPECT_STREQ(error_code_to_string(ErrorCode::INDEX_ALLOCATION_OVERFLOW), "INDEX_ALLOCATION_OVERFLOW");
+}
+
+TEST(ErrorCodeTest, FieldTooLargeString) {
+    EXPECT_STREQ(error_code_to_string(ErrorCode::FIELD_TOO_LARGE), "FIELD_TOO_LARGE");
+}
+
+// ============================================================================
+// PARSE OPTIONS LIMITS INTEGRATION
+// ============================================================================
+
+TEST(ParseOptionsTest, DefaultLimits) {
+    ParseOptions opts;
+    EXPECT_EQ(opts.limits.max_file_size, SizeLimits::defaults().max_file_size);
+    EXPECT_EQ(opts.limits.max_field_size, SizeLimits::defaults().max_field_size);
+}
+
+TEST(ParseOptionsTest, CustomLimits) {
+    ParseOptions opts;
+    opts.limits.max_file_size = 1024;
+    opts.limits.max_field_size = 512;
+
+    EXPECT_EQ(opts.limits.max_file_size, 1024);
+    EXPECT_EQ(opts.limits.max_field_size, 512);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

Adds configurable input size limits to prevent denial-of-service attacks through excessive memory allocation. This addresses security vulnerabilities where:

- A 1GB malicious file could trigger 8GB of index allocation (one uint64_t per input byte)
- Integer overflow in size calculations could lead to undersized allocations and buffer overflows
- The `FIELD_TOO_LARGE` and `FILE_TOO_LARGE` error codes existed but were not implemented

## Changes

- **SizeLimits struct** with configurable `max_file_size` (10GB default) and `max_field_size` (16MB default)
- **Overflow detection** via `would_overflow_multiply()` and `would_overflow_add()` helper functions
- **New error code** `INDEX_ALLOCATION_OVERFLOW` for detecting allocation overflow
- **Safe index initialization** via `init_safe()` method with overflow validation
- **File size validation** in `Parser::parse()` before any memory allocation
- **Streaming parser fix** to use `FIELD_TOO_LARGE` error code (was incorrectly using `IO_ERROR`)
- **Comprehensive tests** (25 new tests) covering all size limit functionality

## Test plan

- [x] Run full test suite: `ctest --output-on-failure` (1686 tests pass)
- [x] Run size limits specific tests: `./build/size_limits_test` (25 tests pass)
- [x] Verify file size limit rejection with/without ErrorCollector
- [x] Verify index allocation overflow detection
- [x] Verify streaming field size limit enforcement

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)