### PR TITLE
cleanup: Remove printf debugging statements and LIBVROOM_BENCHMARK_MODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,9 +228,6 @@ target_link_libraries(vroom-cli PRIVATE
     pthread
 )
 
-# Suppress debug output for CLI
-target_compile_definitions(vroom-cli PRIVATE LIBVROOM_BENCHMARK_MODE)
-
 # =============================================================================
 # Testing (optional, controlled by BUILD_TESTING)
 # =============================================================================
@@ -789,9 +786,6 @@ target_include_directories(libvroom_benchmark PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Define benchmark mode to suppress debug output during benchmarking
-target_compile_definitions(libvroom_benchmark PRIVATE LIBVROOM_BENCHMARK_MODE)
-
 # Conditionally link external CSV parsers
 if(HAVE_ZSV)
     target_link_libraries(libvroom_benchmark PRIVATE zsv_lib)
@@ -850,21 +844,18 @@ if(ENABLE_FUZZING)
     target_include_directories(fuzz_csv_parser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     target_compile_options(fuzz_csv_parser PRIVATE ${FUZZ_FLAGS})
     target_link_options(fuzz_csv_parser PRIVATE ${FUZZ_LINK_FLAGS})
-    target_compile_definitions(fuzz_csv_parser PRIVATE LIBVROOM_BENCHMARK_MODE)
 
     add_executable(fuzz_dialect_detection fuzz/fuzz_dialect_detection.cpp)
     target_link_libraries(fuzz_dialect_detection PRIVATE vroom)
     target_include_directories(fuzz_dialect_detection PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     target_compile_options(fuzz_dialect_detection PRIVATE ${FUZZ_FLAGS})
     target_link_options(fuzz_dialect_detection PRIVATE ${FUZZ_LINK_FLAGS})
-    target_compile_definitions(fuzz_dialect_detection PRIVATE LIBVROOM_BENCHMARK_MODE)
 
     add_executable(fuzz_parse_auto fuzz/fuzz_parse_auto.cpp)
     target_link_libraries(fuzz_parse_auto PRIVATE vroom)
     target_include_directories(fuzz_parse_auto PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     target_compile_options(fuzz_parse_auto PRIVATE ${FUZZ_FLAGS})
     target_link_options(fuzz_parse_auto PRIVATE ${FUZZ_LINK_FLAGS})
-    target_compile_definitions(fuzz_parse_auto PRIVATE LIBVROOM_BENCHMARK_MODE)
 
     add_custom_command(TARGET fuzz_csv_parser POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/fuzz_corpus

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -54,7 +54,6 @@
 #include <cstring>  // for memcpy
 #include <unordered_set>
 #include <sstream>
-#include "inttypes.h"
 #include "simd_highway.h"
 #include "error.h"
 #include "dialect.h"
@@ -497,11 +496,6 @@ class two_pass {
   static stats first_pass_speculate(const uint8_t* buf, size_t start, size_t end,
                                     char delimiter = ',', char quote_char = '"') {
     auto is_quoted = get_quotation_state(buf, start, delimiter, quote_char);
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("start: %lu\tis_ambigious: %s\tstate: %s\n", start,
-           is_quoted == AMBIGUOUS ? "true" : "false",
-           is_quoted == QUOTED ? "quoted" : "unquoted");
-#endif
 
     for (size_t i = start; i < end; ++i) {
       // Support LF, CRLF, and CR-only line endings
@@ -957,17 +951,9 @@ class two_pass {
     }
 
     auto st = first_pass_fut[0].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
     chunk_pos[0] = 0;
     for (int i = 1; i < n_threads; ++i) {
       auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
       chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
     }
     chunk_pos[n_threads] = len;
@@ -1036,17 +1022,9 @@ class two_pass {
 
     auto st = first_pass_fut[0].get();
     size_t n_quotes = st.n_quotes;
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
     chunk_pos[0] = 0;
     for (int i = 1; i < n_threads; ++i) {
       auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
       chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
       n_quotes += st.n_quotes;
     }
@@ -1227,17 +1205,9 @@ class two_pass {
 
     auto st = first_pass_fut[0].get();
     size_t n_quotes = st.n_quotes;
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
     chunk_pos[0] = 0;
     for (int i = 1; i < n_threads; ++i) {
       auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
       chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
       n_quotes += st.n_quotes;
     }
@@ -1606,17 +1576,9 @@ class two_pass {
 
     auto st = first_pass_fut[0].get();
     size_t n_quotes = st.n_quotes;
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
     chunk_pos[0] = 0;
     for (int i = 1; i < n_threads; ++i) {
       auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
       chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
       n_quotes += st.n_quotes;
     }

--- a/oss-fuzz/build.sh
+++ b/oss-fuzz/build.sh
@@ -3,6 +3,6 @@ mkdir -p build && cd build
 cmake .. -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" -DCMAKE_BUILD_TYPE=Release
 cmake --build . --target vroom -j$(nproc)
 cd ..
-$CXX $CXXFLAGS -std=c++17 -I./include -DLIBVROOM_BENCHMARK_MODE fuzz/fuzz_csv_parser.cpp -o $OUT/fuzz_csv_parser build/libvroom.a build/_deps/highway-build/libhwy.a $LIB_FUZZING_ENGINE
-$CXX $CXXFLAGS -std=c++17 -I./include -DLIBVROOM_BENCHMARK_MODE fuzz/fuzz_dialect_detection.cpp -o $OUT/fuzz_dialect_detection build/libvroom.a build/_deps/highway-build/libhwy.a $LIB_FUZZING_ENGINE
-$CXX $CXXFLAGS -std=c++17 -I./include -DLIBVROOM_BENCHMARK_MODE fuzz/fuzz_parse_auto.cpp -o $OUT/fuzz_parse_auto build/libvroom.a build/_deps/highway-build/libhwy.a $LIB_FUZZING_ENGINE
+$CXX $CXXFLAGS -std=c++17 -I./include fuzz/fuzz_csv_parser.cpp -o $OUT/fuzz_csv_parser build/libvroom.a build/_deps/highway-build/libhwy.a $LIB_FUZZING_ENGINE
+$CXX $CXXFLAGS -std=c++17 -I./include fuzz/fuzz_dialect_detection.cpp -o $OUT/fuzz_dialect_detection build/libvroom.a build/_deps/highway-build/libhwy.a $LIB_FUZZING_ENGINE
+$CXX $CXXFLAGS -std=c++17 -I./include fuzz/fuzz_parse_auto.cpp -o $OUT/fuzz_parse_auto build/libvroom.a build/_deps/highway-build/libhwy.a $LIB_FUZZING_ENGINE


### PR DESCRIPTION
## Summary

- Remove printf debugging statements from `two_pass.h` that were gated with inverted logic (`#ifndef LIBVROOM_BENCHMARK_MODE`), causing debug output to pollute stdout by default
- Remove the `LIBVROOM_BENCHMARK_MODE` compile definition from all build targets as it's no longer needed
- Keep the well-designed `debug.h`/`debug_parser.h` opt-in debugging infrastructure for future use

## Test plan

- [x] All 1661 tests pass
- [x] Build succeeds with no new warnings related to the changes
- [x] Verify no remaining `LIBVROOM_BENCHMARK_MODE` references in codebase

Fixes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)