### PR TITLE
refactor: Migrate internal code from deprecated two_pass methods to Parser API

### DIFF
--- a/benchmark/basic_benchmarks.cpp
+++ b/benchmark/basic_benchmarks.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <memory>
 
 extern std::map<std::string, std::basic_string_view<uint8_t>> test_data;

--- a/benchmark/benchmark_main.cpp
+++ b/benchmark/benchmark_main.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 
 // Global variables for shared test data
 std::map<std::string, std::basic_string_view<uint8_t>> test_data;
@@ -43,5 +46,7 @@ static void CleanupBenchmarkData() {
   delete global_parser;
   global_parser = nullptr;
 }
+
+LIBVROOM_SUPPRESS_DEPRECATION_END
 
 BENCHMARK_MAIN();

--- a/benchmark/comparison_benchmarks.cpp
+++ b/benchmark/comparison_benchmarks.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <fstream>
 #include <sstream>
 #include <string>

--- a/benchmark/dimensions_benchmarks.cpp
+++ b/benchmark/dimensions_benchmarks.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <fstream>
 #include <sstream>
 #include <random>

--- a/benchmark/energy_benchmarks.cpp
+++ b/benchmark/energy_benchmarks.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <fstream>
 #include <chrono>
 #include <thread>

--- a/benchmark/external_parser_benchmarks.cpp
+++ b/benchmark/external_parser_benchmarks.cpp
@@ -38,11 +38,14 @@
 //
 // =============================================================================
 
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <fstream>
 #include <sstream>
 #include <string>

--- a/benchmark/performance_metrics.cpp
+++ b/benchmark/performance_metrics.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <fstream>
 #include <chrono>
 #include <thread>

--- a/benchmark/real_world_benchmarks.cpp
+++ b/benchmark/real_world_benchmarks.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <fstream>
 #include <random>
 #include <algorithm>

--- a/benchmark/simd_benchmarks.cpp
+++ b/benchmark/simd_benchmarks.cpp
@@ -1,8 +1,11 @@
+// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+#include "two_pass.h"
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
 #include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
-#include "two_pass.h"
 #include <fstream>
 #include <random>
 #include <cstring>

--- a/src/libvroom_c.cpp
+++ b/src/libvroom_c.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "libvroom_c.h"
-#include "two_pass.h"
+#include "libvroom.h"
 #include "error.h"
 #include "dialect.h"
 #include "io_util.h"
@@ -19,20 +19,18 @@
 
 // Internal structures wrapping C++ objects
 struct libvroom_parser {
-    libvroom::two_pass parser;
+    libvroom::Parser parser;
+
+    libvroom_parser(size_t num_threads = 1) : parser(num_threads) {}
 };
 
 struct libvroom_index {
     libvroom::index idx;
     size_t num_threads;
 
-    libvroom_index(size_t buffer_length, size_t threads)
-        : idx(), num_threads(threads) {
-        // Pre-allocate the index arrays
-        idx.n_threads = threads;
-        idx.n_indexes = new uint64_t[threads]();  // Zero-initialize
-        idx.indexes = new uint64_t[buffer_length];
-    }
+    // Default constructor - index will be populated by Parser::parse()
+    libvroom_index(size_t threads)
+        : idx(), num_threads(threads) {}
 
     // Note: No explicit destructor needed - libvroom::index has its own destructor
     // that handles cleanup of n_indexes and indexes arrays
@@ -302,10 +300,12 @@ void libvroom_error_collector_destroy(libvroom_error_collector_t* collector) {
 
 // Index Structure
 libvroom_index_t* libvroom_index_create(size_t buffer_length, size_t num_threads) {
-    if (buffer_length == 0 || num_threads == 0) return nullptr;
+    // Note: buffer_length is now ignored since Parser allocates the index internally
+    (void)buffer_length;  // Suppress unused parameter warning
+    if (num_threads == 0) return nullptr;
 
     try {
-        return new (std::nothrow) libvroom_index(buffer_length, num_threads);
+        return new (std::nothrow) libvroom_index(num_threads);
     } catch (...) {
         return nullptr;
     }
@@ -350,7 +350,7 @@ void libvroom_index_destroy(libvroom_index_t* index) {
 // Parser
 libvroom_parser_t* libvroom_parser_create(void) {
     try {
-        return new (std::nothrow) libvroom_parser();
+        return new (std::nothrow) libvroom_parser(1);
     } catch (...) {
         return nullptr;
     }
@@ -363,15 +363,22 @@ libvroom_error_t libvroom_parse(libvroom_parser_t* parser, const libvroom_buffer
 
     try {
         libvroom::Dialect d = dialect ? dialect->dialect : libvroom::Dialect::csv();
-        index->idx = parser->parser.init(buffer->data.size(), index->num_threads);
 
-        bool success;
+        // Configure parser with the number of threads from the index
+        parser->parser.set_num_threads(index->num_threads);
+
+        // Build parse options
+        libvroom::ParseOptions options;
+        options.dialect = d;
         if (errors) {
-            success = parser->parser.parse_with_errors(buffer->data.data(), index->idx,
-                                             buffer->data.size(), errors->collector, d);
-        } else {
-            success = parser->parser.parse(buffer->data.data(), index->idx, buffer->data.size(), d);
+            options.errors = &errors->collector;
         }
+
+        // Parse using the unified Parser API
+        auto result = parser->parser.parse(buffer->data.data(), buffer->data.size(), options);
+
+        // Move the index from the result
+        index->idx = std::move(result.idx);
 
         if (errors && errors->collector.has_fatal_errors()) {
             const auto& errs = errors->collector.errors();
@@ -382,7 +389,7 @@ libvroom_error_t libvroom_parse(libvroom_parser_t* parser, const libvroom_buffer
             }
         }
 
-        return success ? LIBVROOM_OK : LIBVROOM_ERROR_INTERNAL;
+        return result.success() ? LIBVROOM_OK : LIBVROOM_ERROR_INTERNAL;
     } catch (...) {
         return LIBVROOM_ERROR_INTERNAL;
     }
@@ -457,29 +464,33 @@ libvroom_error_t libvroom_parse_auto(libvroom_parser_t* parser, const libvroom_b
     if (!parser || !buffer || !index) return LIBVROOM_ERROR_NULL_POINTER;
 
     try {
-        // First detect the dialect
-        libvroom::DialectDetector detector;
-        auto result = detector.detect(buffer->data.data(), buffer->data.size());
+        // Configure parser with the number of threads from the index
+        parser->parser.set_num_threads(index->num_threads);
 
-        if (detected) {
-            *detected = new (std::nothrow) libvroom_detection_result(result);
+        // Build parse options for auto-detection (dialect = nullopt)
+        libvroom::ParseOptions options;
+        // Leave dialect as nullopt for auto-detection
+        if (errors) {
+            options.errors = &errors->collector;
         }
 
-        if (!result.success()) {
+        // Parse using the unified Parser API with auto-detection
+        auto result = parser->parser.parse(buffer->data.data(), buffer->data.size(), options);
+
+        // Store detection result if requested
+        if (detected) {
+            *detected = new (std::nothrow) libvroom_detection_result(result.detection);
+        }
+
+        // Check if detection succeeded
+        if (!result.detection.success()) {
             return LIBVROOM_ERROR_AMBIGUOUS_SEPARATOR;
         }
 
-        // Parse with detected dialect
-        index->idx = parser->parser.init(buffer->data.size(), index->num_threads);
+        // Move the index from the result
+        index->idx = std::move(result.idx);
 
-        if (errors) {
-            parser->parser.parse_with_errors(buffer->data.data(), index->idx,
-                                             buffer->data.size(), errors->collector, result.dialect);
-        } else {
-            parser->parser.parse(buffer->data.data(), index->idx, buffer->data.size(), result.dialect);
-        }
-
-        return LIBVROOM_OK;
+        return result.success() ? LIBVROOM_OK : LIBVROOM_ERROR_INTERNAL;
     } catch (...) {
         return LIBVROOM_ERROR_INTERNAL;
     }

--- a/test/c_api_test.cpp
+++ b/test/c_api_test.cpp
@@ -255,16 +255,23 @@ TEST_F(CAPITest, ErrorCollectorNullHandling) {
 
 // Index Tests
 TEST_F(CAPITest, IndexCreate) {
+    // Note: With the new Parser API, buffer_length is ignored since Parser
+    // allocates the index internally during parse(). The index positions will
+    // be nullptr until parse() is called.
     libvroom_index_t* idx = libvroom_index_create(1000, 1);
     ASSERT_NE(idx, nullptr);
     EXPECT_EQ(libvroom_index_num_threads(idx), 1u);
-    EXPECT_NE(libvroom_index_positions(idx), nullptr);
+    // Positions are nullptr until parse() is called
+    EXPECT_EQ(libvroom_index_positions(idx), nullptr);
     libvroom_index_destroy(idx);
 }
 
 TEST_F(CAPITest, IndexCreateInvalid) {
-    EXPECT_EQ(libvroom_index_create(0, 1), nullptr);
-    EXPECT_EQ(libvroom_index_create(1000, 0), nullptr);
+    // Note: buffer_length=0 is now valid since it's ignored (Parser allocates internally)
+    // Only num_threads=0 should return nullptr
+    EXPECT_NE(libvroom_index_create(0, 1), nullptr);  // Valid: buffer_length ignored
+    libvroom_index_destroy(libvroom_index_create(0, 1));  // Clean up
+    EXPECT_EQ(libvroom_index_create(1000, 0), nullptr);   // Invalid: num_threads=0
 }
 
 TEST_F(CAPITest, IndexColumnsAndTotalCount) {


### PR DESCRIPTION
## Summary

This PR addresses issue #287 by migrating internal codebase files from deprecated `two_pass` methods to the new unified `Parser` API introduced in PR #284.

### Changes

- **C API (`src/libvroom_c.cpp`)**: Migrated `libvroom_parse()` and `libvroom_parse_auto()` to use `Parser::parse()` with `ParseOptions`. The `libvroom_parser` struct now wraps `libvroom::Parser` instead of `libvroom::two_pass`. Index allocation is now handled internally by the Parser, so the `buffer_length` parameter in `libvroom_index_create()` is now ignored.

- **Benchmark files**: Added `LIBVROOM_SUPPRESS_DEPRECATION_START` macro at the top of all benchmark files. Benchmarks intentionally continue using the deprecated `two_pass` methods for performance comparison purposes, as this allows direct benchmarking of the low-level parsing implementation.

- **Test updates**: Updated C API tests (`IndexCreate`, `IndexCreateInvalid`) to reflect the new API semantics where index positions are allocated during `parse()` rather than `index_create()`.

### Notes

- The CLI tool (`src/cli.cpp`) was already using the new Parser API
- Test files intentionally continue using deprecated methods for backward compatibility verification, with deprecation warnings expected during compilation

## Test plan

- [x] Run full test suite locally: `cd build && ctest --output-on-failure`
- [x] All 1661 tests pass
- [ ] CI tests pass

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)