### PR TITLE
feat: Complete escape character support beyond RFC 4180

### DIFF
--- a/include/branchless_state_machine.h
+++ b/include/branchless_state_machine.h
@@ -37,30 +37,33 @@ namespace libvroom {
 /**
  * @brief Character classification for branchless CSV parsing.
  *
- * Characters are classified into 4 categories that determine state transitions:
+ * Characters are classified into 5 categories that determine state transitions:
  * - DELIMITER (0): Field separator (typically comma)
  * - QUOTE (1): Quote character (typically double-quote)
  * - NEWLINE (2): Line terminator (\n)
  * - OTHER (3): All other characters
+ * - ESCAPE (4): Escape character (typically backslash when not using double-quote escaping)
  */
 enum CharClass : uint8_t {
     CHAR_DELIMITER = 0,
     CHAR_QUOTE = 1,
     CHAR_NEWLINE = 2,
-    CHAR_OTHER = 3
+    CHAR_OTHER = 3,
+    CHAR_ESCAPE = 4
 };
 
 /**
  * @brief CSV parser state for branchless state machine.
  *
- * Uses numeric values 0-4 for direct indexing into lookup tables.
+ * Uses numeric values 0-5 for direct indexing into lookup tables.
  */
 enum BranchlessState : uint8_t {
     STATE_RECORD_START = 0,    // At the beginning of a new record (row)
     STATE_FIELD_START = 1,     // At the beginning of a new field (after comma)
     STATE_UNQUOTED_FIELD = 2,  // Inside an unquoted field
     STATE_QUOTED_FIELD = 3,    // Inside a quoted field
-    STATE_QUOTED_END = 4       // Just saw a quote inside a quoted field
+    STATE_QUOTED_END = 4,      // Just saw a quote inside a quoted field
+    STATE_ESCAPED = 5          // Just saw an escape character (next char is literal)
 };
 
 /**
@@ -107,26 +110,39 @@ struct alignas(1) PackedResult {
  *
  * The state machine processes characters without branches by using:
  * 1. A character classification table (256 bytes) for O(1) character -> class mapping
- * 2. A state transition table (5 states × 4 char classes = 20 bytes) for O(1) transitions
+ * 2. A state transition table (6 states × 5 char classes = 30 bytes) for O(1) transitions
  *
  * This eliminates the switch statements in the original implementation that caused
  * significant branch mispredictions (64+ possible mispredictions per 64-byte block).
+ *
+ * Escape character handling:
+ * - When double_quote=true (RFC 4180): escape_char is ignored, "" escapes to "
+ * - When double_quote=false: escape_char (e.g., backslash) escapes the next character
+ *   - Inside quotes: \" becomes literal "
+ *   - Escape char can also escape delimiters, newlines, itself
  */
 class BranchlessStateMachine {
 public:
     /**
-     * @brief Initialize the state machine with given delimiter and quote characters.
+     * @brief Initialize the state machine with given delimiter, quote, and escape characters.
+     *
+     * @param delimiter Field separator character (default: comma)
+     * @param quote_char Quote character (default: double-quote)
+     * @param escape_char Escape character (default: same as quote_char for RFC 4180)
+     * @param double_quote If true, use RFC 4180 double-quote escaping; if false, use escape_char
      */
-    explicit BranchlessStateMachine(char delimiter = ',', char quote_char = '"') {
-        init_char_class_table(delimiter, quote_char);
-        init_transition_table();
+    explicit BranchlessStateMachine(char delimiter = ',', char quote_char = '"',
+                                     char escape_char = '"', bool double_quote = true) {
+        init_char_class_table(delimiter, quote_char, escape_char, double_quote);
+        init_transition_table(double_quote);
     }
 
     /**
-     * @brief Reinitialize with new delimiter and quote characters.
+     * @brief Reinitialize with new delimiter, quote, and escape characters.
      */
-    void reinit(char delimiter, char quote_char) {
-        init_char_class_table(delimiter, quote_char);
+    void reinit(char delimiter, char quote_char, char escape_char = '"', bool double_quote = true) {
+        init_char_class_table(delimiter, quote_char, escape_char, double_quote);
+        init_transition_table(double_quote);
     }
 
     /**
@@ -140,7 +156,7 @@ public:
      * @brief Get the next state for a given current state and character class (branchless).
      */
     really_inline PackedResult transition(BranchlessState state, CharClass char_class) const {
-        return transition_table_[state * 4 + char_class];
+        return transition_table_[state * 5 + char_class];
     }
 
     /**
@@ -198,27 +214,56 @@ public:
      */
     really_inline char quote_char() const { return quote_char_; }
 
+    /**
+     * @brief Get current escape character.
+     */
+    really_inline char escape_char() const { return escape_char_; }
+
+    /**
+     * @brief Check if using double-quote escaping (RFC 4180).
+     */
+    really_inline bool uses_double_quote() const { return double_quote_; }
+
+    /**
+     * @brief Create 64-bit bitmask for characters matching the escape character.
+     * Only meaningful when not using double-quote mode.
+     */
+    really_inline uint64_t escape_mask(const simd_input& in) const {
+        return cmp_mask_against_input(in, static_cast<uint8_t>(escape_char_));
+    }
+
 private:
     // Character classification table (256 entries for O(1) lookup)
     alignas(64) uint8_t char_class_table_[256];
 
-    // State transition table (5 states × 4 char classes = 20 entries)
+    // State transition table (6 states × 5 char classes = 30 entries)
     // Packed results for efficient access
-    alignas(32) PackedResult transition_table_[20];
+    alignas(32) PackedResult transition_table_[30];
 
-    // Store delimiter and quote for SIMD operations
+    // Store delimiter, quote, and escape for SIMD operations
     char delimiter_;
     char quote_char_;
+    char escape_char_;
+    bool double_quote_;
 
     /**
      * @brief Initialize the character classification table.
      *
-     * Default classification is OTHER (3). Only delimiter, quote, and newline
-     * get special classifications.
+     * Default classification is OTHER (3). Special characters get their own
+     * classifications: delimiter, quote, newline, and optionally escape.
+     *
+     * When double_quote=true (RFC 4180 mode), escape_char is not classified
+     * as ESCAPE since escaping is handled by quote doubling.
+     *
+     * When double_quote=false (escape char mode), escape_char is classified
+     * as ESCAPE so the state machine can handle backslash escaping.
      */
-    void init_char_class_table(char delimiter, char quote_char) {
+    void init_char_class_table(char delimiter, char quote_char,
+                                char escape_char, bool double_quote) {
         delimiter_ = delimiter;
         quote_char_ = quote_char;
+        escape_char_ = escape_char;
+        double_quote_ = double_quote;
 
         // Initialize all characters as OTHER
         for (int i = 0; i < 256; ++i) {
@@ -229,95 +274,162 @@ private:
         char_class_table_[static_cast<uint8_t>(delimiter)] = CHAR_DELIMITER;
         char_class_table_[static_cast<uint8_t>(quote_char)] = CHAR_QUOTE;
         char_class_table_[static_cast<uint8_t>('\n')] = CHAR_NEWLINE;
+
+        // Only classify escape character as ESCAPE when not using double-quote mode
+        // and escape_char is different from quote_char
+        if (!double_quote && escape_char != quote_char && escape_char != '\0') {
+            char_class_table_[static_cast<uint8_t>(escape_char)] = CHAR_ESCAPE;
+        }
     }
 
     /**
      * @brief Initialize the state transition table.
      *
-     * This table encodes all valid CSV state transitions:
+     * This table encodes all valid CSV state transitions.
      *
-     * State transitions based on RFC 4180:
+     * For RFC 4180 mode (double_quote=true):
+     * - Escaping is done by doubling quotes: "" -> "
+     * - ESCAPE char class is never used (escape char not classified)
+     *
+     * For escape char mode (double_quote=false):
+     * - Escaping is done with escape char: \" -> "
+     * - ESCAPE transitions to STATE_ESCAPED, next char is literal
+     *
+     * State transitions:
      *
      * From RECORD_START:
      *   - DELIMITER -> FIELD_START (record separator)
      *   - QUOTE -> QUOTED_FIELD (start quoted field)
      *   - NEWLINE -> RECORD_START (empty row, record separator)
      *   - OTHER -> UNQUOTED_FIELD (start unquoted field)
+     *   - ESCAPE -> UNQUOTED_FIELD (escape at field start, treat as content)
      *
      * From FIELD_START:
      *   - DELIMITER -> FIELD_START (empty field, field separator)
      *   - QUOTE -> QUOTED_FIELD (start quoted field)
      *   - NEWLINE -> RECORD_START (empty field at end of row, record separator)
      *   - OTHER -> UNQUOTED_FIELD (start unquoted field)
+     *   - ESCAPE -> UNQUOTED_FIELD (escape at field start, treat as content)
      *
      * From UNQUOTED_FIELD:
      *   - DELIMITER -> FIELD_START (end field, field separator)
-     *   - QUOTE -> ERROR (quote in unquoted field)
+     *   - QUOTE -> ERROR (quote in unquoted field) [RFC 4180 mode]
+     *            or UNQUOTED_FIELD (literal quote in escape mode if no escape)
      *   - NEWLINE -> RECORD_START (end field and row, record separator)
      *   - OTHER -> UNQUOTED_FIELD (continue field)
+     *   - ESCAPE -> UNQUOTED_FIELD (in escape mode, next char literal but stay unquoted)
      *
      * From QUOTED_FIELD:
      *   - DELIMITER -> QUOTED_FIELD (literal comma in field)
-     *   - QUOTE -> QUOTED_END (potential end or escape)
+     *   - QUOTE -> QUOTED_END (potential end or RFC 4180 escape)
      *   - NEWLINE -> QUOTED_FIELD (literal newline in field)
      *   - OTHER -> QUOTED_FIELD (continue field)
+     *   - ESCAPE -> STATE_ESCAPED (in escape mode, next char is literal)
      *
      * From QUOTED_END:
      *   - DELIMITER -> FIELD_START (end quoted field, field separator)
-     *   - QUOTE -> QUOTED_FIELD (escaped quote, continue)
+     *   - QUOTE -> QUOTED_FIELD (RFC 4180 escaped quote, continue)
      *   - NEWLINE -> RECORD_START (end quoted field and row, record separator)
      *   - OTHER -> ERROR (invalid char after closing quote)
+     *   - ESCAPE -> ERROR (invalid, escape after closing quote)
+     *
+     * From STATE_ESCAPED (only used in escape char mode):
+     *   - Any char -> QUOTED_FIELD (literal char, continue quoted field)
+     *   Note: The escaped character is consumed as a literal, regardless of what it is
      */
-    void init_transition_table() {
-        // RECORD_START transitions (index 0-3)
-        transition_table_[STATE_RECORD_START * 4 + CHAR_DELIMITER] =
+    void init_transition_table(bool double_quote) {
+        // RECORD_START transitions (index 0-4)
+        transition_table_[STATE_RECORD_START * 5 + CHAR_DELIMITER] =
             PackedResult::make(STATE_FIELD_START, ERR_NONE, true);
-        transition_table_[STATE_RECORD_START * 4 + CHAR_QUOTE] =
+        transition_table_[STATE_RECORD_START * 5 + CHAR_QUOTE] =
             PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
-        transition_table_[STATE_RECORD_START * 4 + CHAR_NEWLINE] =
+        transition_table_[STATE_RECORD_START * 5 + CHAR_NEWLINE] =
             PackedResult::make(STATE_RECORD_START, ERR_NONE, true);
-        transition_table_[STATE_RECORD_START * 4 + CHAR_OTHER] =
+        transition_table_[STATE_RECORD_START * 5 + CHAR_OTHER] =
+            PackedResult::make(STATE_UNQUOTED_FIELD, ERR_NONE, false);
+        // ESCAPE at record start: start unquoted field (escape is just content)
+        transition_table_[STATE_RECORD_START * 5 + CHAR_ESCAPE] =
             PackedResult::make(STATE_UNQUOTED_FIELD, ERR_NONE, false);
 
-        // FIELD_START transitions (index 4-7)
-        transition_table_[STATE_FIELD_START * 4 + CHAR_DELIMITER] =
+        // FIELD_START transitions (index 5-9)
+        transition_table_[STATE_FIELD_START * 5 + CHAR_DELIMITER] =
             PackedResult::make(STATE_FIELD_START, ERR_NONE, true);
-        transition_table_[STATE_FIELD_START * 4 + CHAR_QUOTE] =
+        transition_table_[STATE_FIELD_START * 5 + CHAR_QUOTE] =
             PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
-        transition_table_[STATE_FIELD_START * 4 + CHAR_NEWLINE] =
+        transition_table_[STATE_FIELD_START * 5 + CHAR_NEWLINE] =
             PackedResult::make(STATE_RECORD_START, ERR_NONE, true);
-        transition_table_[STATE_FIELD_START * 4 + CHAR_OTHER] =
+        transition_table_[STATE_FIELD_START * 5 + CHAR_OTHER] =
+            PackedResult::make(STATE_UNQUOTED_FIELD, ERR_NONE, false);
+        // ESCAPE at field start: start unquoted field (escape is just content)
+        transition_table_[STATE_FIELD_START * 5 + CHAR_ESCAPE] =
             PackedResult::make(STATE_UNQUOTED_FIELD, ERR_NONE, false);
 
-        // UNQUOTED_FIELD transitions (index 8-11)
-        transition_table_[STATE_UNQUOTED_FIELD * 4 + CHAR_DELIMITER] =
+        // UNQUOTED_FIELD transitions (index 10-14)
+        transition_table_[STATE_UNQUOTED_FIELD * 5 + CHAR_DELIMITER] =
             PackedResult::make(STATE_FIELD_START, ERR_NONE, true);
-        transition_table_[STATE_UNQUOTED_FIELD * 4 + CHAR_QUOTE] =
+        // In double-quote mode, quote in unquoted field is an error
+        // In escape mode, quote in unquoted field is also an error (should be preceded by escape)
+        transition_table_[STATE_UNQUOTED_FIELD * 5 + CHAR_QUOTE] =
             PackedResult::make(STATE_UNQUOTED_FIELD, ERR_QUOTE_IN_UNQUOTED, false);
-        transition_table_[STATE_UNQUOTED_FIELD * 4 + CHAR_NEWLINE] =
+        transition_table_[STATE_UNQUOTED_FIELD * 5 + CHAR_NEWLINE] =
             PackedResult::make(STATE_RECORD_START, ERR_NONE, true);
-        transition_table_[STATE_UNQUOTED_FIELD * 4 + CHAR_OTHER] =
+        transition_table_[STATE_UNQUOTED_FIELD * 5 + CHAR_OTHER] =
+            PackedResult::make(STATE_UNQUOTED_FIELD, ERR_NONE, false);
+        // ESCAPE in unquoted field: stay in unquoted field (escape is content in unquoted)
+        // We don't support escaping in unquoted fields - the escape is just literal content
+        transition_table_[STATE_UNQUOTED_FIELD * 5 + CHAR_ESCAPE] =
             PackedResult::make(STATE_UNQUOTED_FIELD, ERR_NONE, false);
 
-        // QUOTED_FIELD transitions (index 12-15)
-        transition_table_[STATE_QUOTED_FIELD * 4 + CHAR_DELIMITER] =
+        // QUOTED_FIELD transitions (index 15-19)
+        transition_table_[STATE_QUOTED_FIELD * 5 + CHAR_DELIMITER] =
             PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
-        transition_table_[STATE_QUOTED_FIELD * 4 + CHAR_QUOTE] =
+        transition_table_[STATE_QUOTED_FIELD * 5 + CHAR_QUOTE] =
             PackedResult::make(STATE_QUOTED_END, ERR_NONE, false);
-        transition_table_[STATE_QUOTED_FIELD * 4 + CHAR_NEWLINE] =
+        transition_table_[STATE_QUOTED_FIELD * 5 + CHAR_NEWLINE] =
             PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
-        transition_table_[STATE_QUOTED_FIELD * 4 + CHAR_OTHER] =
+        transition_table_[STATE_QUOTED_FIELD * 5 + CHAR_OTHER] =
             PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
+        // ESCAPE in quoted field: go to escaped state (next char is literal)
+        // Note: In double_quote mode, ESCAPE char class is never assigned, so this won't be reached
+        transition_table_[STATE_QUOTED_FIELD * 5 + CHAR_ESCAPE] =
+            PackedResult::make(STATE_ESCAPED, ERR_NONE, false);
 
-        // QUOTED_END transitions (index 16-19)
-        transition_table_[STATE_QUOTED_END * 4 + CHAR_DELIMITER] =
+        // QUOTED_END transitions (index 20-24)
+        transition_table_[STATE_QUOTED_END * 5 + CHAR_DELIMITER] =
             PackedResult::make(STATE_FIELD_START, ERR_NONE, true);
-        transition_table_[STATE_QUOTED_END * 4 + CHAR_QUOTE] =
-            PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
-        transition_table_[STATE_QUOTED_END * 4 + CHAR_NEWLINE] =
+        // In double_quote mode: quote after quote = escaped quote, back to quoted field
+        // In escape mode: this state means quote closed the field, another quote is an error
+        if (double_quote) {
+            transition_table_[STATE_QUOTED_END * 5 + CHAR_QUOTE] =
+                PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
+        } else {
+            // In escape mode, we shouldn't see quote after closing quote
+            // This would be ""  which in escape mode means empty closing followed by opening
+            // But we're already past the closing quote, so this is an error
+            transition_table_[STATE_QUOTED_END * 5 + CHAR_QUOTE] =
+                PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);  // Allow for compatibility
+        }
+        transition_table_[STATE_QUOTED_END * 5 + CHAR_NEWLINE] =
             PackedResult::make(STATE_RECORD_START, ERR_NONE, true);
-        transition_table_[STATE_QUOTED_END * 4 + CHAR_OTHER] =
+        transition_table_[STATE_QUOTED_END * 5 + CHAR_OTHER] =
             PackedResult::make(STATE_UNQUOTED_FIELD, ERR_INVALID_AFTER_QUOTE, false);
+        // ESCAPE after closing quote: error (should not have escape after closing quote)
+        transition_table_[STATE_QUOTED_END * 5 + CHAR_ESCAPE] =
+            PackedResult::make(STATE_UNQUOTED_FIELD, ERR_INVALID_AFTER_QUOTE, false);
+
+        // STATE_ESCAPED transitions (index 25-29)
+        // After escape char, any character is literal and we return to quoted field
+        // This is the key for backslash escaping: \" becomes literal "
+        transition_table_[STATE_ESCAPED * 5 + CHAR_DELIMITER] =
+            PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
+        transition_table_[STATE_ESCAPED * 5 + CHAR_QUOTE] =
+            PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
+        transition_table_[STATE_ESCAPED * 5 + CHAR_NEWLINE] =
+            PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
+        transition_table_[STATE_ESCAPED * 5 + CHAR_OTHER] =
+            PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);
+        transition_table_[STATE_ESCAPED * 5 + CHAR_ESCAPE] =
+            PackedResult::make(STATE_QUOTED_FIELD, ERR_NONE, false);  // \\ is escaped backslash
     }
 };
 
@@ -377,13 +489,15 @@ really_inline size_t process_block_branchless(
  * The approach:
  * 1. Use SIMD to find all delimiter, quote, and newline positions (bitmasks)
  * 2. Compute quote mask to identify positions inside quoted strings
- * 3. Extract valid separator positions using bitwise operations
- * 4. Update state machine only at quote boundaries
+ * 3. For escape char mode: mask out escaped quotes before computing quote parity
+ * 4. Extract valid separator positions using bitwise operations
+ * 5. Update state machine only at quote boundaries
  *
  * @param sm The branchless state machine
  * @param in SIMD input block (64 bytes)
  * @param len Actual length to process
  * @param prev_quote_state Previous iteration's inside-quote state (all 0s or 1s)
+ * @param prev_escape_carry For escape char mode: whether previous block ended with unmatched escape
  * @param indexes Output array for field separator positions
  * @param base Base position in the full buffer
  * @param idx Current index in indexes array
@@ -395,6 +509,7 @@ really_inline size_t process_block_simd_branchless(
     const simd_input& in,
     size_t len,
     uint64_t& prev_quote_state,
+    uint64_t& prev_escape_carry,
     uint64_t* indexes,
     uint64_t base,
     uint64_t& idx,
@@ -409,9 +524,38 @@ really_inline size_t process_block_simd_branchless(
     // Use newline_mask with valid_mask for proper CR/CRLF handling
     uint64_t newlines = sm.newline_mask(in, valid_mask);
 
+    // Handle escape character mode (e.g., backslash escaping)
+    // In escape mode, we need to ignore quotes that are preceded by an escape char
+    uint64_t escaped_positions = 0;
+    if (!sm.uses_double_quote()) {
+        uint64_t escapes = sm.escape_mask(in) & valid_mask;
+        escaped_positions = compute_escaped_mask(escapes, prev_escape_carry);
+
+        // Remove escaped quotes from the quote mask
+        // An escaped quote doesn't toggle quote state
+        quotes &= ~escaped_positions;
+        // Also remove escaped delimiters and newlines (they're literal content)
+        delimiters &= ~escaped_positions;
+        newlines &= ~escaped_positions;
+    }
+
     // Compute quote mask: positions that are inside quotes
     // Uses XOR prefix sum to track quote parity
     uint64_t inside_quote = find_quote_mask2(quotes, prev_quote_state);
+
+    // Debug output for escape mode
+    (void)escaped_positions;  // Silence unused warning when debug disabled
+#if 0
+    if (!sm.uses_double_quote() && base == 0) {
+        fprintf(stderr, "DEBUG SIMD escape processing:\n");
+        fprintf(stderr, "  valid_mask=0x%016llx\n", (unsigned long long)valid_mask);
+        fprintf(stderr, "  escapes=0x%016llx\n", (unsigned long long)(sm.escape_mask(in) & valid_mask));
+        fprintf(stderr, "  escaped_positions=0x%016llx\n", (unsigned long long)escaped_positions);
+        fprintf(stderr, "  quotes (after masking)=0x%016llx\n", (unsigned long long)quotes);
+        fprintf(stderr, "  inside_quote=0x%016llx\n", (unsigned long long)inside_quote);
+        fprintf(stderr, "  prev_quote_state=0x%016llx\n", (unsigned long long)prev_quote_state);
+    }
+#endif
 
     // Field separators are delimiters/newlines that are NOT inside quotes
     uint64_t field_seps = (delimiters | newlines) & ~inside_quote & valid_mask;
@@ -469,6 +613,9 @@ inline uint64_t second_pass_branchless(
  * This is the main performance-optimized function that combines SIMD
  * character detection with branchless state tracking.
  *
+ * Supports both RFC 4180 double-quote escaping and custom escape character
+ * modes (e.g., backslash escaping).
+ *
  * @param sm The branchless state machine
  * @param buf Input buffer
  * @param start Start position
@@ -492,6 +639,7 @@ inline uint64_t second_pass_simd_branchless(
     size_t pos = 0;
     uint64_t idx = thread_id;
     uint64_t prev_quote_state = 0ULL;
+    uint64_t prev_escape_carry = 0ULL;  // For escape char mode
     uint64_t count = 0;
     const uint8_t* data = buf + start;
 
@@ -501,7 +649,7 @@ inline uint64_t second_pass_simd_branchless(
 
         simd_input in = fill_input(data + pos);
         count += process_block_simd_branchless(
-            sm, in, 64, prev_quote_state,
+            sm, in, 64, prev_quote_state, prev_escape_carry,
             indexes, start + pos, idx, n_threads
         );
     }
@@ -510,7 +658,7 @@ inline uint64_t second_pass_simd_branchless(
     if (pos < len) {
         simd_input in = fill_input(data + pos);
         count += process_block_simd_branchless(
-            sm, in, len - pos, prev_quote_state,
+            sm, in, len - pos, prev_quote_state, prev_escape_carry,
             indexes, start + pos, idx, n_threads
         );
     }

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -1174,6 +1174,8 @@ class two_pass {
                                     const Dialect& dialect = Dialect::csv()) {
     char delim = dialect.delimiter;
     char quote = dialect.quote_char;
+    char escape = dialect.escape_char;
+    bool double_quote = dialect.double_quote;
 
     // Handle empty input
     if (len == 0) return true;
@@ -1188,7 +1190,7 @@ class two_pass {
     check_line_endings(buf, len, errors);
     if (errors.should_stop()) return false;
 
-    BranchlessStateMachine sm(delim, quote);
+    BranchlessStateMachine sm(delim, quote, escape, double_quote);
     uint8_t n_threads = out.n_threads;
 
     // Validate n_threads: treat 0 as single-threaded to avoid division by zero
@@ -1324,7 +1326,8 @@ class two_pass {
   LIBVROOM_DEPRECATED("Use Parser::parse() with ParseOptions::branchless() instead")
   bool parse_branchless(const uint8_t* buf, index& out, size_t len,
                         const Dialect& dialect = Dialect::csv()) {
-    BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char);
+    BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char,
+                               dialect.escape_char, dialect.double_quote);
     uint8_t n_threads = out.n_threads;
 
     // Validate n_threads: treat 0 as single-threaded to avoid division by zero

--- a/test/branchless_test.cpp
+++ b/test/branchless_test.cpp
@@ -741,6 +741,315 @@ TEST_F(BranchlessErrorCollectionTest, ParserAPIWithErrorsDetectsProblems) {
     EXPECT_TRUE(found_quote_error) << "Should find QUOTE_IN_UNQUOTED_FIELD error";
 }
 
+// ============================================================================
+// ESCAPE CHARACTER SUPPORT TESTS
+// ============================================================================
+
+class EscapeCharacterTest : public ::testing::Test {
+protected:
+    std::string getTestDataPath(const std::string& category, const std::string& filename) {
+        return "test/data/" + category + "/" + filename;
+    }
+
+    // Helper to create a dialect with backslash escaping
+    Dialect backslashDialect() {
+        Dialect d;
+        d.delimiter = ',';
+        d.quote_char = '"';
+        d.escape_char = '\\';
+        d.double_quote = false;
+        return d;
+    }
+};
+
+TEST_F(EscapeCharacterTest, BackslashEscapedQuote) {
+    // Test backslash-escaped quotes: \"
+    // CSV content: Name,Value<newline>"Hello \"World\"",100<newline>
+    // After C++ escaping: \\\" -> \" (backslash + quote)
+    std::string content = "Name,Value\n\"Hello \\\"World\\\"\",100\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should parse backslash-escaped quotes";
+    // Should find 4 separators: comma after Name, newline after Value, comma after quoted, newline at end
+    EXPECT_EQ(idx.n_indexes[0], 4) << "Should find 4 field separators";
+}
+
+TEST_F(EscapeCharacterTest, BackslashEscapedBackslash) {
+    // Test escaped backslash: \\
+    // Content: Path,Value<newline>"C:\\Users\\test",100<newline>
+    // Separators: comma(4), newline(10), comma(28), newline(32) = 4 separators
+    std::string content2 = std::string("Path,Value\n") + "\"C:\\\\Users\\\\test\",100\n";
+    std::vector<uint8_t> data(content2.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content2.data(), content2.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content2.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should parse escaped backslashes";
+    EXPECT_EQ(idx.n_indexes[0], 4) << "Should find 4 field separators";
+}
+
+TEST_F(EscapeCharacterTest, BackslashEscapedDelimiter) {
+    // Test escaped delimiter within quoted field: \,
+    // Content: Text,Value<newline>"Hello\, World",100<newline>
+    // Separators: comma(4), newline(10), comma(26), newline(30) = 4 separators
+    std::string content = "Text,Value\n\"Hello\\, World\",100\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should parse escaped delimiters";
+    EXPECT_EQ(idx.n_indexes[0], 4) << "Should find 4 field separators (comma in quotes is escaped)";
+}
+
+TEST_F(EscapeCharacterTest, BackslashEscapedNewline) {
+    // Test escaped newline: \n (literal backslash-n in the string, which becomes embedded newline)
+    // Note: In C++, \n in string literal becomes actual newline char (0x0A)
+    // Content: Text,Value<newline>"Line1<newline>Line2",100<newline>
+    // Separators: comma(4), newline(10), comma(25), newline(29) = 4 separators
+    std::string content = "Text,Value\n\"Line1\\nLine2\",100\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should parse escaped newlines";
+    EXPECT_EQ(idx.n_indexes[0], 4) << "Should find 4 field separators";
+}
+
+TEST_F(EscapeCharacterTest, MixedEscapeSequences) {
+    // Test multiple escape sequences in one field
+    std::string content = "Data\n\"\\\"test\\\\path\\,value\\\"\"\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should parse mixed escape sequences";
+}
+
+TEST_F(EscapeCharacterTest, ConsecutiveEscapes) {
+    // Test consecutive escapes: \\\\ (two escaped backslashes)
+    std::string content = "Path\n\"C:\\\\\\\\\"\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should parse consecutive escape sequences";
+}
+
+TEST_F(EscapeCharacterTest, BackslashAtEndOfQuotedField) {
+    // Test backslash before closing quote: "value\" should close at "
+    // In escape mode, \" is an escaped quote, so the field continues
+    std::string content = "A,B\n\"val\",\"test\\\"\"\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should handle backslash before quote correctly";
+}
+
+TEST_F(EscapeCharacterTest, ParseBackslashEscapeTestFile) {
+    // Parse the test file with backslash escapes
+    std::string path = getTestDataPath("escape", "backslash_escape.csv");
+    auto data = get_corpus(path, LIBVROOM_PADDING);
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, data.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should parse backslash_escape.csv successfully";
+}
+
+TEST_F(EscapeCharacterTest, BranchlessStateMachineEscapeTransitions) {
+    // Test state machine transitions with escape character
+    BranchlessStateMachine sm(',', '"', '\\', false);
+
+    // Verify escape char is classified correctly
+    EXPECT_EQ(sm.classify('\\'), CHAR_ESCAPE);
+    EXPECT_EQ(sm.classify(','), CHAR_DELIMITER);
+    EXPECT_EQ(sm.classify('"'), CHAR_QUOTE);
+
+    // Test escape transition from QUOTED_FIELD
+    PackedResult r = sm.transition(STATE_QUOTED_FIELD, CHAR_ESCAPE);
+    EXPECT_EQ(r.state(), STATE_ESCAPED);
+    EXPECT_EQ(r.error(), ERR_NONE);
+
+    // Test that any char after escape returns to QUOTED_FIELD
+    r = sm.transition(STATE_ESCAPED, CHAR_QUOTE);
+    EXPECT_EQ(r.state(), STATE_QUOTED_FIELD);
+    EXPECT_EQ(r.error(), ERR_NONE);
+
+    r = sm.transition(STATE_ESCAPED, CHAR_DELIMITER);
+    EXPECT_EQ(r.state(), STATE_QUOTED_FIELD);
+    EXPECT_EQ(r.error(), ERR_NONE);
+
+    r = sm.transition(STATE_ESCAPED, CHAR_ESCAPE);
+    EXPECT_EQ(r.state(), STATE_QUOTED_FIELD);
+    EXPECT_EQ(r.error(), ERR_NONE);
+}
+
+TEST_F(EscapeCharacterTest, RFC4180ModeIgnoresEscape) {
+    // In double_quote=true mode, backslash should be treated as OTHER
+    BranchlessStateMachine sm(',', '"', '\\', true);
+
+    // Backslash should be classified as OTHER in RFC 4180 mode
+    EXPECT_EQ(sm.classify('\\'), CHAR_OTHER);
+}
+
+TEST_F(EscapeCharacterTest, ComputeEscapedMaskBasic) {
+    // Test the compute_escaped_mask function directly
+    // escape_mask with bit 10 set (backslash at position 10)
+    uint64_t escape_mask = 1ULL << 10;
+    uint64_t carry = 0;
+
+    uint64_t escaped = compute_escaped_mask(escape_mask, carry);
+
+    // Position 11 should be escaped (right after position 10)
+    EXPECT_TRUE((escaped & (1ULL << 11)) != 0) << "Position 11 should be escaped";
+    EXPECT_FALSE((escaped & (1ULL << 10)) != 0) << "Position 10 should NOT be escaped (it's the escape char)";
+    EXPECT_FALSE((escaped & (1ULL << 12)) != 0) << "Position 12 should NOT be escaped";
+}
+
+TEST_F(EscapeCharacterTest, ComputeEscapedMaskConsecutive) {
+    // Test consecutive escapes: \\ should escape the second backslash
+    // Bits 10 and 11 set (backslashes at positions 10 and 11)
+    uint64_t escape_mask = (1ULL << 10) | (1ULL << 11);
+    uint64_t carry = 0;
+
+    uint64_t escaped = compute_escaped_mask(escape_mask, carry);
+
+    // Position 11 should be escaped (the second backslash is escaped by the first)
+    EXPECT_TRUE((escaped & (1ULL << 11)) != 0) << "Position 11 should be escaped";
+    // Position 12 should NOT be escaped (no escape before it)
+    EXPECT_FALSE((escaped & (1ULL << 12)) != 0) << "Position 12 should NOT be escaped";
+}
+
+TEST_F(EscapeCharacterTest, ComputeEscapedMaskQuadBackslash) {
+    // Test \\\\ (four backslashes) - should result in two literal backslashes
+    // Bits 10, 11, 12, 13 set
+    uint64_t escape_mask = (1ULL << 10) | (1ULL << 11) | (1ULL << 12) | (1ULL << 13);
+    uint64_t carry = 0;
+
+    uint64_t escaped = compute_escaped_mask(escape_mask, carry);
+
+    // Positions 11 and 13 should be escaped (escaped by 10 and 12)
+    EXPECT_TRUE((escaped & (1ULL << 11)) != 0) << "Position 11 should be escaped";
+    EXPECT_TRUE((escaped & (1ULL << 13)) != 0) << "Position 13 should be escaped";
+    // Positions 10, 12 should NOT be escaped (they are the escape chars)
+    EXPECT_FALSE((escaped & (1ULL << 10)) != 0) << "Position 10 should NOT be escaped";
+    EXPECT_FALSE((escaped & (1ULL << 12)) != 0) << "Position 12 should NOT be escaped";
+}
+
+TEST_F(EscapeCharacterTest, ConsistencyWithScalarParsing) {
+    // Verify SIMD branchless produces same results as scalar for escape sequences
+    // Content: A,B,C<newline>"val\"1","val\\2",3<newline>"x","y\,z",4<newline>
+    // Expected separators for escape mode:
+    //   comma after A (pos 1), comma after B (pos 3), newline after C (pos 5)
+    //   comma after "val\"1" (pos 14), comma after "val\\2" (pos 24), newline after 3 (pos 26)
+    //   comma after "x" (pos 30), comma after "y\,z" (pos 38), newline after 4 (pos 40)
+    // Total = 9 separators
+    std::string content = "A,B,C\n\"val\\\"1\",\"val\\\\2\",3\n\"x\",\"y\\,z\",4\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    Dialect dialect = backslashDialect();
+
+    // Parse with branchless (SIMD)
+    libvroom::index idx1 = parser.init(data.size(), 1);
+    parser.parse_branchless(data.data(), idx1, content.size(), dialect);
+
+    // Parse with error collection (uses scalar path)
+    libvroom::index idx2 = parser.init(data.size(), 1);
+    libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
+    parser.parse_branchless_with_errors(data.data(), idx2, content.size(), errors, dialect);
+
+    // Results should match
+    EXPECT_EQ(idx1.n_indexes[0], idx2.n_indexes[0])
+        << "SIMD and scalar should find same number of separators";
+
+    for (size_t i = 0; i < std::min(idx1.n_indexes[0], idx2.n_indexes[0]); ++i) {
+        EXPECT_EQ(idx1.indexes[i], idx2.indexes[i])
+            << "Separator position mismatch at index " << i;
+    }
+}
+
+TEST_F(EscapeCharacterTest, MultiThreadedEscapeParsing) {
+    // Test multi-threaded parsing with escape characters
+    std::string content;
+    content = "Name,Value,Path\n";
+    for (int i = 0; i < 5000; i++) {
+        content += "\"Name" + std::to_string(i) + "\",";
+        content += "\"val\\\"" + std::to_string(i) + "\",";
+        content += "\"C:\\\\path\\\\" + std::to_string(i) + "\"\n";
+    }
+
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 4);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Multi-threaded escape parsing should succeed";
+}
+
+TEST_F(EscapeCharacterTest, CrossBlockEscapeSequence) {
+    // Create content where escape sequence crosses 64-byte block boundary
+    std::string padding(62, 'a');  // 62 bytes of 'a'
+    std::string content = "X\n\"" + padding + "\\\"\"\n";  // Escape at position 63-64
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    libvroom::two_pass parser;
+    libvroom::index idx = parser.init(data.size(), 1);
+
+    bool success = parser.parse_branchless(data.data(), idx, content.size(), backslashDialect());
+
+    EXPECT_TRUE(success) << "Should handle escape sequences crossing block boundaries";
+}
+
+TEST_F(EscapeCharacterTest, ParserAPIWithEscapeDialect) {
+    // Test the high-level Parser API with escape dialect
+    std::string content = "Name,Value\n\"Hello \\\"World\\\"\",100\n";
+    std::vector<uint8_t> data(content.size() + LIBVROOM_PADDING);
+    std::memcpy(data.data(), content.data(), content.size());
+
+    Parser parser(1);
+    auto result = parser.parse(data.data(), content.size(), {.dialect = backslashDialect()});
+
+    EXPECT_TRUE(result.success()) << "Parser API should work with escape dialect";
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary

- Add support for backslash escape character mode (e.g., `\"` instead of `""`) as an alternative to RFC 4180 double-quote escaping
- Implement `compute_escaped_mask()` function in SIMD path to identify escaped character positions
- Update `process_block_simd_branchless()` to mask escaped characters from delimiter/quote/newline detection
- Pass `escape_char` and `double_quote` from Dialect to BranchlessStateMachine for consistent behavior
- Add comprehensive test suite (17 new tests) for escape character handling

## Test plan

- [x] All 1678 existing tests pass
- [x] New escape character tests cover:
  - Basic escape sequences (`\"`, `\\`, `\,`, `\n`)
  - Consecutive escapes (`\\\\` → two literal backslashes)
  - Cross-block escape sequences (escape at block boundary)
  - Multi-threaded parsing with escapes
  - Consistency between SIMD and scalar parsing paths
  - RFC 4180 mode correctly ignores escape character

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)