### PR TITLE
refactor: Move two_pass.h implementations to source file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ add_library(vroom
     src/libvroom_c.cpp
     src/value_extraction.cpp
     src/streaming.cpp
+    src/two_pass.cpp
 )
 
 target_include_directories(vroom PUBLIC

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -192,23 +192,7 @@ class index {
    * @param filename Path to the output file.
    * @throws std::runtime_error If writing fails.
    */
-  void write(const std::string& filename) {
-    std::FILE* fp = std::fopen(filename.c_str(), "wb");
-    if (!((std::fwrite(&columns, sizeof(uint64_t), 1, fp) == 1) &&
-          (std::fwrite(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
-          (std::fwrite(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
-      throw std::runtime_error("error writing index");
-    }
-    size_t total_size = 0;
-    for (int i = 0; i < n_threads; ++i) {
-      total_size += n_indexes[i];
-    }
-    if (std::fwrite(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
-      throw std::runtime_error("error writing index2");
-    }
-
-    std::fclose(fp);
-  }
+  void write(const std::string& filename);
 
   /**
    * @brief Deserialize the index from a binary file.
@@ -220,23 +204,7 @@ class index {
    *
    * @warning The n_indexes and indexes arrays must be pre-allocated before calling.
    */
-  void read(const std::string& filename) {
-    std::FILE* fp = std::fopen(filename.c_str(), "rb");
-    if (!((std::fread(&columns, sizeof(uint64_t), 1, fp) == 1) &&
-          (std::fread(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
-          (std::fread(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
-      throw std::runtime_error("error reading index");
-    }
-    size_t total_size = 0;
-    for (int i = 0; i < n_threads; ++i) {
-      total_size += n_indexes[i];
-    }
-    if (std::fread(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
-      throw std::runtime_error("error reading index2");
-    }
-
-    std::fclose(fp);
-  }
+  void read(const std::string& filename);
 
   /**
    * @brief Destructor. Releases allocated index arrays.
@@ -386,62 +354,9 @@ class two_pass {
    * @brief First pass scalar scan with dialect-aware quote character.
    */
   static stats first_pass_chunk(const uint8_t* buf, size_t start, size_t end,
-                                char quote_char = '"') {
-    stats out;
-    uint64_t i = start;
-    bool needs_even = out.first_even_nl == null_pos;
-    bool needs_odd = out.first_odd_nl == null_pos;
-    while (i < end) {
-      // Support LF, CRLF, and CR-only line endings
-      // Check for line ending: \n, or \r not followed by \n
-      bool is_line_ending = false;
-      if (buf[i] == '\n') {
-        is_line_ending = true;
-      } else if (buf[i] == '\r') {
-        // CR is a line ending only if not followed by LF
-        if (i + 1 >= end || buf[i + 1] != '\n') {
-          is_line_ending = true;
-        }
-        // If followed by LF, skip this CR (the LF will be the line ending)
-      }
+                                char quote_char = '"');
 
-      if (is_line_ending) {
-        bool is_even = (out.n_quotes % 2) == 0;
-        if (needs_even && is_even) {
-          out.first_even_nl = i;
-          needs_even = false;
-        } else if (needs_odd && !is_even) {
-          out.first_odd_nl = i;
-          needs_odd = false;
-        }
-      } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        ++out.n_quotes;
-      }
-      ++i;
-    }
-    return out;
-  }
-
-  static stats first_pass_naive(const uint8_t* buf, size_t start, size_t end) {
-    stats out;
-    uint64_t i = start;
-    while (i < end) {
-      // Support LF, CRLF, and CR-only line endings
-      if (buf[i] == '\n') {
-        out.first_even_nl = i;
-        return out;
-      } else if (buf[i] == '\r') {
-        // CR is a line ending only if not followed by LF
-        if (i + 1 >= end || buf[i + 1] != '\n') {
-          out.first_even_nl = i;
-          return out;
-        }
-        // If followed by LF, continue - the LF will be the line ending
-      }
-      ++i;
-    }
-    return out;
-  }
+  static stats first_pass_naive(const uint8_t* buf, size_t start, size_t end);
 
   /**
    * @brief Check if character is not a delimiter, newline (LF or CR), or quote.
@@ -456,77 +371,13 @@ class two_pass {
    * @brief Determine quote state at a position using backward scanning.
    */
   static quote_state get_quotation_state(const uint8_t* buf, size_t start,
-                                         char delimiter = ',', char quote_char = '"') {
-    // 64kb
-    constexpr int SPECULATION_SIZE = 1 << 16;
-
-    if (start == 0) {
-      return UNQUOTED;
-    }
-
-    size_t end = start > SPECULATION_SIZE ? start - SPECULATION_SIZE : 0;
-    size_t i = start;
-    size_t num_quotes = 0;
-
-    // FIXED: Use i > end to avoid unsigned underflow when i reaches 0
-    while (i > end) {
-      if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        // q-o case
-        if (i + 1 < start && is_other(buf[i + 1], delimiter, quote_char)) {
-          return num_quotes % 2 == 0 ? QUOTED : UNQUOTED;
-        }
-
-        // o-q case
-        else if (i > end && is_other(buf[i - 1], delimiter, quote_char)) {
-          return num_quotes % 2 == 0 ? UNQUOTED : QUOTED;
-        }
-        ++num_quotes;
-      }
-      --i;
-    }
-    // Check the last position (i == end)
-    if (buf[end] == static_cast<uint8_t>(quote_char)) {
-      ++num_quotes;
-    }
-    return AMBIGUOUS;
-  }
+                                         char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Speculative first pass with dialect-aware quote character.
    */
   static stats first_pass_speculate(const uint8_t* buf, size_t start, size_t end,
-                                    char delimiter = ',', char quote_char = '"') {
-    auto is_quoted = get_quotation_state(buf, start, delimiter, quote_char);
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("start: %lu\tis_ambigious: %s\tstate: %s\n", start,
-           is_quoted == AMBIGUOUS ? "true" : "false",
-           is_quoted == QUOTED ? "quoted" : "unquoted");
-#endif
-
-    for (size_t i = start; i < end; ++i) {
-      // Support LF, CRLF, and CR-only line endings
-      bool is_line_ending = false;
-      if (buf[i] == '\n') {
-        is_line_ending = true;
-      } else if (buf[i] == '\r') {
-        // CR is a line ending only if not followed by LF
-        if (i + 1 >= end || buf[i + 1] != '\n') {
-          is_line_ending = true;
-        }
-      }
-
-      if (is_line_ending) {
-        if (is_quoted == UNQUOTED || is_quoted == AMBIGUOUS) {
-          return {0, i, null_pos};
-        } else {
-          return {1, null_pos, i};
-        }
-      } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        is_quoted = is_quoted == UNQUOTED ? QUOTED : UNQUOTED;
-      }
-    }
-    return {0, null_pos, null_pos};
-  }
+                                    char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Second pass SIMD scan with dialect-aware delimiter and quote character.
@@ -711,46 +562,12 @@ class two_pass {
   // Helper to get context around an error position
   // Returns a string representation of the buffer content near the given position
   static std::string get_context(const uint8_t* buf, size_t len, size_t pos,
-                                 size_t context_size = DEFAULT_ERROR_CONTEXT_SIZE) {
-    // Handle empty buffer case
-    if (len == 0 || buf == nullptr) return "";
-
-    // Bounds check
-    size_t safe_pos = pos < len ? pos : len - 1;
-    size_t ctx_start = safe_pos > context_size ? safe_pos - context_size : 0;
-    size_t ctx_end = std::min(safe_pos + context_size, len);
-
-    std::string ctx;
-    // Reserve space to avoid reallocations (worst case: every char becomes 2 chars like \n)
-    ctx.reserve((ctx_end - ctx_start) * 2);
-
-    for (size_t i = ctx_start; i < ctx_end; ++i) {
-      char c = static_cast<char>(buf[i]);
-      if (c == '\n') ctx += "\\n";
-      else if (c == '\r') ctx += "\\r";
-      else if (c == '\0') ctx += "\\0";
-      else if (c >= 32 && c < 127) ctx += c;
-      else ctx += "?";
-    }
-    return ctx;
-  }
+                                 size_t context_size = DEFAULT_ERROR_CONTEXT_SIZE);
 
   // Helper to calculate line and column from byte offset
   // SECURITY: buf_len parameter ensures we never read past buffer bounds
-  static void get_line_column(const uint8_t* buf, size_t buf_len, size_t offset, size_t& line, size_t& column) {
-    line = 1;
-    column = 1;
-    // Ensure we don't read past buffer bounds
-    size_t safe_offset = offset < buf_len ? offset : buf_len;
-    for (size_t i = 0; i < safe_offset; ++i) {
-      if (buf[i] == '\n') {
-        ++line;
-        column = 1;
-      } else if (buf[i] != '\r') {
-        ++column;
-      }
-    }
-  }
+  static void get_line_column(const uint8_t* buf, size_t buf_len, size_t offset,
+                              size_t& line, size_t& column);
 
   /**
    * @brief Second pass with error collection and dialect support.
@@ -759,164 +576,14 @@ class two_pass {
                                     index* out, size_t thread_id,
                                     ErrorCollector* errors = nullptr,
                                     size_t total_len = 0,
-                                    char delimiter = ',', char quote_char = '"') {
-    uint64_t pos = start;
-    size_t n_indexes = 0;
-    size_t i = thread_id;
-    csv_state s = RECORD_START;
-
-    while (pos < end) {
-      uint8_t value = buf[pos];
-
-      // Use effective buffer length for bounds checking
-      size_t buf_len = total_len > 0 ? total_len : end;
-
-      // Check for null bytes
-      if (value == '\0' && errors) {
-        size_t line, col;
-        get_line_column(buf, buf_len, pos, line, col);
-        errors->add_error(ErrorCode::NULL_BYTE, ErrorSeverity::ERROR,
-                          line, col, pos, "Null byte in data",
-                          get_context(buf, buf_len, pos));
-        if (errors->should_stop()) return n_indexes;
-        ++pos;
-        continue;
-      }
-
-      state_result result;
-      if (value == static_cast<uint8_t>(quote_char)) {
-        result = quoted_state(s);
-        if (result.error != ErrorCode::NONE && errors) {
-          size_t line, col;
-          get_line_column(buf, buf_len, pos, line, col);
-          std::string msg = "Quote character '";
-          msg += quote_char;
-          msg += "' in unquoted field";
-          errors->add_error(result.error, ErrorSeverity::ERROR,
-                            line, col, pos, msg,
-                            get_context(buf, buf_len, pos));
-          if (errors->should_stop()) return n_indexes;
-        }
-        s = result.state;
-      } else if (value == static_cast<uint8_t>(delimiter)) {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        result = comma_state(s);
-        s = result.state;
-      } else if (value == '\n') {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        result = newline_state(s);
-        s = result.state;
-      } else if (value == '\r') {
-        // Support CR-only line endings: CR is a line ending if not followed by LF
-        bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
-        if (is_line_ending && s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-          result = newline_state(s);
-          s = result.state;
-        }
-        // If CR is followed by LF (CRLF), treat CR as regular character
-        // The LF will be the line ending; CR will be stripped during value extraction
-      } else {
-        result = other_state(s);
-        if (result.error != ErrorCode::NONE && errors) {
-          size_t line, col;
-          get_line_column(buf, buf_len, pos, line, col);
-          std::string msg = "Invalid character after closing quote '";
-          msg += quote_char;
-          msg += "'";
-          errors->add_error(result.error, ErrorSeverity::ERROR,
-                            line, col, pos, msg,
-                            get_context(buf, buf_len, pos));
-          if (errors->should_stop()) return n_indexes;
-        }
-        s = result.state;
-      }
-      ++pos;
-    }
-
-    // Use effective buffer length for bounds checking
-    size_t buf_len = total_len > 0 ? total_len : end;
-
-    // Check for unclosed quote at end of chunk
-    if (s == QUOTED_FIELD && errors && end == buf_len) {
-      size_t line, col;
-      get_line_column(buf, buf_len, pos > 0 ? pos - 1 : 0, line, col);
-      std::string msg = "Unclosed quote '";
-      msg += quote_char;
-      msg += "' at end of file";
-      errors->add_error(ErrorCode::UNCLOSED_QUOTE, ErrorSeverity::FATAL,
-                        line, col, pos, msg,
-                        get_context(buf, buf_len, pos > 20 ? pos - 20 : 0));
-    }
-
-    return n_indexes;
-  }
+                                    char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Second pass that throws on error (backward compatible), with dialect support.
    */
   static uint64_t second_pass_chunk_throwing(const uint8_t* buf, size_t start, size_t end,
                                              index* out, size_t thread_id,
-                                             char delimiter = ',', char quote_char = '"') {
-    uint64_t pos = start;
-    size_t n_indexes = 0;
-    size_t i = thread_id;
-    csv_state s = RECORD_START;
-
-    while (pos < end) {
-      uint8_t value = buf[pos];
-      state_result result;
-      if (value == static_cast<uint8_t>(quote_char)) {
-        result = quoted_state(s);
-        if (result.error != ErrorCode::NONE) {
-          std::string msg = "Quote character '";
-          msg += quote_char;
-          msg += "' in unquoted field";
-          throw std::runtime_error(msg);
-        }
-        s = result.state;
-      } else if (value == static_cast<uint8_t>(delimiter)) {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        s = comma_state(s).state;
-      } else if (value == '\n') {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        s = newline_state(s).state;
-      } else if (value == '\r') {
-        // Support CR-only line endings: CR is a line ending if not followed by LF
-        bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
-        if (is_line_ending && s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-          s = newline_state(s).state;
-        }
-        // If CR is followed by LF (CRLF), treat CR as regular character
-      } else {
-        result = other_state(s);
-        if (result.error != ErrorCode::NONE) {
-          std::string msg = "Invalid character after closing quote '";
-          msg += quote_char;
-          msg += "'";
-          throw std::runtime_error(msg);
-        }
-        s = result.state;
-      }
-      ++pos;
-    }
-    return n_indexes;
-  }
+                                             char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Parse using speculative multi-threading with dialect support.
@@ -926,75 +593,7 @@ class two_pass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::SPECULATIVE instead")
   bool parse_speculate(const uint8_t* buf, index& out, size_t len,
-                       const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    uint8_t n_threads = out.n_threads;
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    size_t chunk_size = len / n_threads;
-    // If chunk size is too small, small chunks may not contain any newlines,
-    // causing first_pass_speculate to return null_pos. Fall back to single-threaded.
-    if (chunk_size < 64) {
-      // CRITICAL: Must update n_threads to 1 for correct stride in write()
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, delim, quote]() {
-            return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-      chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        // CRITICAL: Must update n_threads to 1 for correct stride in write()
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-      }
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [buf, &out, &chunk_pos, i, delim, quote]() {
-            return second_pass_simd(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
-          });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
-    return true;
-  }
+                       const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse using two-pass algorithm with dialect support.
@@ -1004,77 +603,7 @@ class two_pass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::TWO_PASS instead")
   bool parse_two_pass(const uint8_t* buf, index& out, size_t len,
-                      const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    uint8_t n_threads = out.n_threads;
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    size_t chunk_size = len / n_threads;
-    // If chunk size is too small, small chunks may not contain any newlines,
-    // causing first_pass_chunk to return null_pos. Fall back to single-threaded.
-    if (chunk_size < 64) {
-      // CRITICAL: Must update n_threads to 1 for correct stride in write()
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, quote]() {
-            return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-      chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-      n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        // CRITICAL: Must update n_threads to 1 for correct stride in write()
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-      }
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [buf, &out, &chunk_pos, i, delim, quote]() {
-            return second_pass_chunk_throwing(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
-          });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
-    return true;
-  }
+                      const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer and build the field index.
@@ -1116,11 +645,7 @@ class two_pass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() from libvroom.h instead")
   bool parse(const uint8_t* buf, index& out, size_t len,
-             const Dialect& dialect = Dialect::csv()) {
-    LIBVROOM_SUPPRESS_DEPRECATION_START
-    return parse_speculate(buf, out, len, dialect);
-    LIBVROOM_SUPPRESS_DEPRECATION_END
-  }
+             const Dialect& dialect = Dialect::csv());
 
   // Result from multi-threaded branchless parsing with error collection
   struct branchless_chunk_result {
@@ -1136,14 +661,7 @@ class two_pass {
   static branchless_chunk_result second_pass_branchless_chunk_with_errors(
       const BranchlessStateMachine& sm,
       const uint8_t* buf, size_t start, size_t end,
-      index* out, size_t thread_id, size_t total_len, ErrorMode mode) {
-    branchless_chunk_result result;
-    result.errors.set_mode(mode);
-    result.n_indexes = second_pass_branchless_with_errors(
-        sm, buf, start, end, out->indexes, thread_id, out->n_threads,
-        &result.errors, total_len);
-    return result;
-  }
+      index* out, size_t thread_id, size_t total_len, ErrorMode mode);
 
   /**
    * @brief Parse a CSV buffer using branchless state machine with error collection.
@@ -1171,117 +689,7 @@ class two_pass {
    */
   bool parse_branchless_with_errors(const uint8_t* buf, index& out, size_t len,
                                     ErrorCollector& errors,
-                                    const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // Handle empty input
-    if (len == 0) return true;
-
-    // Check structural issues first (single-threaded, fast)
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    BranchlessStateMachine sm(delim, quote);
-    uint8_t n_threads = out.n_threads;
-
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-
-    // For single-threaded, use the simpler path
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_branchless_with_errors(
-          sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-      check_field_counts(buf, len, errors, delim, quote);
-      return !errors.has_fatal_errors();
-    }
-
-    size_t chunk_size = len / n_threads;
-
-    // If chunk size is too small, fall back to single-threaded
-    if (chunk_size < 64) {
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_branchless_with_errors(
-          sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-      check_field_counts(buf, len, errors, delim, quote);
-      return !errors.has_fatal_errors();
-    }
-
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<stats>> first_pass_fut(n_threads);
-    std::vector<std::future<branchless_chunk_result>> second_pass_fut(n_threads);
-
-    // First pass: find chunk boundaries
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, quote]() {
-            return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-      chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-      n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_branchless_with_errors(
-            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-        check_field_counts(buf, len, errors, delim, quote);
-        return !errors.has_fatal_errors();
-      }
-    }
-
-    // Second pass: parse with thread-local error collectors using branchless
-    ErrorMode mode = errors.mode();
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [sm, buf, &out, &chunk_pos, i, len, mode]() {
-            return second_pass_branchless_chunk_with_errors(
-                sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i, len, mode);
-          });
-    }
-
-    // Collect results and merge errors
-    std::vector<ErrorCollector> thread_errors;
-    thread_errors.reserve(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      auto result = second_pass_fut[i].get();
-      out.n_indexes[i] = result.n_indexes;
-      thread_errors.push_back(std::move(result.errors));
-    }
-
-    // Merge all thread-local errors, sorted by byte offset
-    errors.merge_sorted(thread_errors);
-
-    // Check field counts after parsing (single-threaded, scans file linearly)
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                                    const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer using branchless state machine (optimized).
@@ -1323,75 +731,7 @@ class two_pass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with ParseOptions::branchless() instead")
   bool parse_branchless(const uint8_t* buf, index& out, size_t len,
-                        const Dialect& dialect = Dialect::csv()) {
-    BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char);
-    uint8_t n_threads = out.n_threads;
-
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-      return true;
-    }
-
-    // Multi-threaded parsing with branchless second pass
-    size_t chunk_size = len / n_threads;
-
-    // If chunk size is too small, fall back to single-threaded
-    if (chunk_size < 64) {
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-      return true;
-    }
-
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // First pass: find chunk boundaries (reuse existing implementation)
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, delim, quote]() {
-            return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-      chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-        return true;
-      }
-    }
-
-    // Second pass: branchless parsing of each chunk
-    // Capture sm by value since it's small (~300 bytes) and we need thread safety
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [sm, buf, &out, &chunk_pos, i]() {
-            return second_pass_simd_branchless(sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i);
-          });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
-    return true;
-  }
+                        const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with automatic dialect detection.
@@ -1427,36 +767,7 @@ class two_pass {
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.errors = &errors} instead (auto-detects dialect)")
   bool parse_auto(const uint8_t* buf, index& out, size_t len,
                   ErrorCollector& errors, DetectionResult* detected = nullptr,
-                  const DetectionOptions& detection_options = DetectionOptions()) {
-    // Perform dialect detection
-    DialectDetector detector(detection_options);
-    DetectionResult result = detector.detect(buf, len);
-
-    // Store detection result if requested
-    if (detected != nullptr) {
-      *detected = result;
-    }
-
-    // Use detected dialect if successful, otherwise fall back to standard CSV
-    Dialect dialect = result.success() ? result.dialect : Dialect::csv();
-
-    // Add info message about detected dialect
-    if (result.success()) {
-      Dialect csv = Dialect::csv();
-      if (result.dialect.delimiter != csv.delimiter ||
-          result.dialect.quote_char != csv.quote_char) {
-        std::string msg = "Auto-detected dialect: " + result.dialect.to_string();
-        errors.add_error(ErrorCode::NONE, ErrorSeverity::WARNING,
-                         1, 1, 0, msg, "");
-      }
-    }
-
-    // Parse with detected dialect
-    // Suppress internal deprecation warning (parse_auto is itself deprecated)
-    LIBVROOM_SUPPRESS_DEPRECATION_START
-    return parse_two_pass_with_errors(buf, out, len, errors, dialect);
-    LIBVROOM_SUPPRESS_DEPRECATION_END
-  }
+                  const DetectionOptions& detection_options = DetectionOptions());
 
   /**
    * @brief Detect the dialect of a CSV buffer without parsing.
@@ -1481,10 +792,7 @@ class two_pass {
    * @endcode
    */
   static DetectionResult detect_dialect(const uint8_t* buf, size_t len,
-                                         const DetectionOptions& options = DetectionOptions()) {
-    DialectDetector detector(options);
-    return detector.detect(buf, len);
-  }
+                                         const DetectionOptions& options = DetectionOptions());
 
   // Result from multi-threaded parsing with error collection
   struct chunk_result {
@@ -1500,13 +808,7 @@ class two_pass {
   static chunk_result second_pass_chunk_with_errors(
       const uint8_t* buf, size_t start, size_t end,
       index* out, size_t thread_id, size_t total_len, ErrorMode mode,
-      char delimiter = ',', char quote_char = '"') {
-    chunk_result result;
-    result.errors.set_mode(mode);
-    result.n_indexes = second_pass_chunk(buf, start, end, out, thread_id,
-                                         &result.errors, total_len, delimiter, quote_char);
-    return result;
-  }
+      char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Parse a CSV buffer with error collection using multi-threading.
@@ -1562,104 +864,7 @@ class two_pass {
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_two_pass_with_errors(const uint8_t* buf, index& out, size_t len,
                                   ErrorCollector& errors,
-                                  const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // Handle empty input
-    if (len == 0) return true;
-
-    // Check structural issues first (single-threaded, fast)
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    uint8_t n_threads = out.n_threads;
-
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-
-    // For single-threaded, use the simpler path
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-      check_field_counts(buf, len, errors, delim, quote);
-      return !errors.has_fatal_errors();
-    }
-
-    size_t chunk_size = len / n_threads;
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<stats>> first_pass_fut(n_threads);
-    std::vector<std::future<chunk_result>> second_pass_fut(n_threads);
-
-    // First pass: find chunk boundaries
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, quote]() {
-            return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-#ifndef LIBVROOM_BENCHMARK_MODE
-    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
-           st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-#ifndef LIBVROOM_BENCHMARK_MODE
-      printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
-             st.first_even_nl, st.first_odd_nl, st.n_quotes);
-#endif
-      chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-      n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-        check_field_counts(buf, len, errors, delim, quote);
-        return !errors.has_fatal_errors();
-      }
-    }
-
-    // Second pass: parse with thread-local error collectors
-    ErrorMode mode = errors.mode();
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [buf, &out, &chunk_pos, i, len, mode, delim, quote]() {
-            return second_pass_chunk_with_errors(buf, chunk_pos[i], chunk_pos[i + 1],
-                                                  &out, i, len, mode, delim, quote);
-          });
-    }
-
-    // Collect results and merge errors
-    std::vector<ErrorCollector> thread_errors;
-    thread_errors.reserve(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      auto result = second_pass_fut[i].get();
-      out.n_indexes[i] = result.n_indexes;
-      thread_errors.push_back(std::move(result.errors));
-    }
-
-    // Merge all thread-local errors, sorted by byte offset
-    errors.merge_sorted(thread_errors);
-
-    // Check field counts after parsing (single-threaded, scans file linearly)
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                                  const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with detailed error collection (single-threaded).
@@ -1727,157 +932,25 @@ class two_pass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_with_errors(const uint8_t* buf, index& out, size_t len, ErrorCollector& errors,
-                         const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // Check structural issues first
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    // Single-threaded parsing for accurate error position tracking
-    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-
-    // Check field counts after parsing
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                         const Dialect& dialect = Dialect::csv());
 
   // Check for empty header
-  static bool check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors) {
-    if (len == 0) return true;
-    if (buf[0] == '\n' || buf[0] == '\r') {
-      errors.add_error(ErrorCode::EMPTY_HEADER, ErrorSeverity::ERROR,
-                       1, 1, 0, "Header row is empty", "");
-      return false;
-    }
-    return true;
-  }
+  static bool check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors);
 
   /**
    * @brief Check for duplicate column names in header with dialect support.
    */
   static void check_duplicate_columns(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                      char delimiter = ',', char quote_char = '"') {
-    if (len == 0) return;
-
-    // Find end of first line
-    size_t header_end = 0;
-    bool in_quote = false;
-    while (header_end < len) {
-      if (buf[header_end] == static_cast<uint8_t>(quote_char)) in_quote = !in_quote;
-      else if (!in_quote && (buf[header_end] == '\n' || buf[header_end] == '\r')) break;
-      ++header_end;
-    }
-
-    // Parse header fields
-    std::vector<std::string> fields;
-    std::string current;
-    in_quote = false;
-    for (size_t i = 0; i < header_end; ++i) {
-      if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        in_quote = !in_quote;
-      } else if (!in_quote && buf[i] == static_cast<uint8_t>(delimiter)) {
-        fields.push_back(current);
-        current.clear();
-      } else if (buf[i] != '\r') {
-        current += static_cast<char>(buf[i]);
-      }
-    }
-    fields.push_back(current);
-
-    // Check for duplicates
-    std::unordered_set<std::string> seen;
-    for (size_t i = 0; i < fields.size(); ++i) {
-      if (seen.count(fields[i]) > 0) {
-        errors.add_error(ErrorCode::DUPLICATE_COLUMN_NAMES, ErrorSeverity::WARNING,
-                         1, i + 1, 0, "Duplicate column name: '" + fields[i] + "'", fields[i]);
-      }
-      seen.insert(fields[i]);
-    }
-  }
+                                      char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Check for inconsistent field counts with dialect support.
    */
   static void check_field_counts(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                 char delimiter = ',', char quote_char = '"') {
-    if (len == 0) return;
-
-    size_t expected_fields = 0;
-    size_t current_fields = 1;
-    size_t current_line = 1;
-    size_t line_start = 0;
-    bool in_quote = false;
-    bool header_done = false;
-
-    for (size_t i = 0; i < len; ++i) {
-      if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        in_quote = !in_quote;
-      } else if (!in_quote) {
-        if (buf[i] == static_cast<uint8_t>(delimiter)) {
-          ++current_fields;
-        } else if (buf[i] == '\n') {
-          if (!header_done) {
-            expected_fields = current_fields;
-            header_done = true;
-          } else if (current_fields != expected_fields) {
-            std::ostringstream msg;
-            msg << "Expected " << expected_fields << " fields but found " << current_fields;
-            errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
-                             current_line, 1, line_start, msg.str(),
-                             get_context(buf, len, line_start, 40));
-            if (errors.should_stop()) return;
-          }
-          current_fields = 1;
-          ++current_line;
-          line_start = i + 1;
-        }
-      }
-    }
-
-    // Check last line if no trailing newline
-    if (header_done && current_fields != expected_fields && line_start < len) {
-      std::ostringstream msg;
-      msg << "Expected " << expected_fields << " fields but found " << current_fields;
-      errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
-                       current_line, 1, line_start, msg.str(),
-                       get_context(buf, len, line_start, 40));
-    }
-  }
+                                 char delimiter = ',', char quote_char = '"');
 
   // Check for mixed line endings
-  static void check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors) {
-    bool has_crlf = false;
-    bool has_lf = false;
-    bool has_cr = false;
-
-    for (size_t i = 0; i < len; ++i) {
-      if (buf[i] == '\r') {
-        if (i + 1 < len && buf[i + 1] == '\n') {
-          has_crlf = true;
-          ++i;
-        } else {
-          has_cr = true;
-        }
-      } else if (buf[i] == '\n') {
-        has_lf = true;
-      }
-    }
-
-    int types = (has_crlf ? 1 : 0) + (has_lf ? 1 : 0) + (has_cr ? 1 : 0);
-    if (types > 1) {
-      errors.add_error(ErrorCode::MIXED_LINE_ENDINGS, ErrorSeverity::WARNING,
-                       1, 1, 0, "Mixed line endings detected", "");
-    }
-  }
+  static void check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors);
 
   /**
    * @brief Perform full CSV validation with comprehensive error checking.
@@ -1918,28 +991,7 @@ class two_pass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_validate(const uint8_t* buf, index& out, size_t len, ErrorCollector& errors,
-                      const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // Check structural issues first
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    // Parse with error collection
-    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-
-    // Check field counts after parsing
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                      const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Initialize an index structure for parsing.
@@ -1976,48 +1028,7 @@ class two_pass {
    *                                   std::thread::hardware_concurrency());
    * @endcode
    */
-  index init(size_t len, size_t n_threads) {
-    index out;
-    // Ensure at least 1 thread for valid memory allocation
-    if (n_threads == 0) n_threads = 1;
-    out.n_threads = n_threads;
-    out.n_indexes = new uint64_t[n_threads];
-
-    // Allocate space for interleaved index storage.
-    //
-    // With multi-threaded parsing, indexes are stored in an interleaved pattern:
-    // thread 0 writes to positions 0, n_threads, 2*n_threads, ...
-    // thread 1 writes to positions 1, n_threads+1, 2*n_threads+1, ...
-    //
-    // For a file with len bytes, the maximum number of separators is len (worst case:
-    // every byte is a separator). In multi-threaded mode, if one thread finds m
-    // separators, it writes to positions thread_id, thread_id + n_threads, ...,
-    // thread_id + (m-1) * n_threads.
-    //
-    // The maximum index accessed is: (n_threads - 1) + (len - 1) * n_threads + 7 * n_threads
-    // (the +7*n_threads is for speculative SIMD writes that always write 8 elements).
-    //
-    // This simplifies to approximately len * n_threads + 8 * n_threads.
-    //
-    // For single-threaded parsing (n_threads == 1), we only need len + 8 elements.
-    // For multi-threaded parsing, we need the full interleaved size.
-    //
-    // See GitHub issues #264 and #265 for details.
-    size_t allocation_size;
-    if (n_threads == 1) {
-      // Single-threaded: simple allocation with padding for speculative writes
-      allocation_size = len + 8;
-    } else {
-      // Multi-threaded: need space for interleaved storage
-      // Maximum index = (len - 1) * n_threads + (n_threads - 1) + 7 * n_threads
-      //               = len * n_threads - n_threads + n_threads - 1 + 7 * n_threads
-      //               = len * n_threads + 7 * n_threads - 1
-      //               < (len + 8) * n_threads
-      allocation_size = (len + 8) * n_threads;
-    }
-    out.indexes = new uint64_t[allocation_size];
-    return out;
-  }
+  index init(size_t len, size_t n_threads);
 };
 
 class parser {

--- a/src/two_pass.cpp
+++ b/src/two_pass.cpp
@@ -1,0 +1,1129 @@
+/**
+ * @file two_pass.cpp
+ * @brief Implementation of two_pass parser methods.
+ *
+ * This file contains non-performance-critical implementations from two_pass.h,
+ * including orchestration logic, validation functions, error handling, and
+ * scalar parsing fallbacks. SIMD hot-path functions remain in the header
+ * for inlining.
+ */
+
+#include "two_pass.h"
+#include <cstring>
+#include <sstream>
+#include <algorithm>
+
+namespace libvroom {
+
+//-----------------------------------------------------------------------------
+// index class implementations
+//-----------------------------------------------------------------------------
+
+void index::write(const std::string& filename) {
+    std::FILE* fp = std::fopen(filename.c_str(), "wb");
+    if (!((std::fwrite(&columns, sizeof(uint64_t), 1, fp) == 1) &&
+          (std::fwrite(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
+          (std::fwrite(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
+        std::fclose(fp);
+        throw std::runtime_error("error writing index");
+    }
+    size_t total_size = 0;
+    for (int i = 0; i < n_threads; ++i) {
+        total_size += n_indexes[i];
+    }
+    if (std::fwrite(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
+        std::fclose(fp);
+        throw std::runtime_error("error writing index2");
+    }
+
+    std::fclose(fp);
+}
+
+void index::read(const std::string& filename) {
+    std::FILE* fp = std::fopen(filename.c_str(), "rb");
+    if (!((std::fread(&columns, sizeof(uint64_t), 1, fp) == 1) &&
+          (std::fread(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
+          (std::fread(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
+        std::fclose(fp);
+        throw std::runtime_error("error reading index");
+    }
+    size_t total_size = 0;
+    for (int i = 0; i < n_threads; ++i) {
+        total_size += n_indexes[i];
+    }
+    if (std::fread(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
+        std::fclose(fp);
+        throw std::runtime_error("error reading index2");
+    }
+
+    std::fclose(fp);
+}
+
+//-----------------------------------------------------------------------------
+// two_pass scalar first pass implementations
+//-----------------------------------------------------------------------------
+
+two_pass::stats two_pass::first_pass_chunk(const uint8_t* buf, size_t start, size_t end,
+                                            char quote_char) {
+    stats out;
+    uint64_t i = start;
+    bool needs_even = out.first_even_nl == null_pos;
+    bool needs_odd = out.first_odd_nl == null_pos;
+    while (i < end) {
+        // Support LF, CRLF, and CR-only line endings
+        // Check for line ending: \n, or \r not followed by \n
+        bool is_line_ending = false;
+        if (buf[i] == '\n') {
+            is_line_ending = true;
+        } else if (buf[i] == '\r') {
+            // CR is a line ending only if not followed by LF
+            if (i + 1 >= end || buf[i + 1] != '\n') {
+                is_line_ending = true;
+            }
+            // If followed by LF, skip this CR (the LF will be the line ending)
+        }
+
+        if (is_line_ending) {
+            bool is_even = (out.n_quotes % 2) == 0;
+            if (needs_even && is_even) {
+                out.first_even_nl = i;
+                needs_even = false;
+            } else if (needs_odd && !is_even) {
+                out.first_odd_nl = i;
+                needs_odd = false;
+            }
+        } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            ++out.n_quotes;
+        }
+        ++i;
+    }
+    return out;
+}
+
+two_pass::stats two_pass::first_pass_naive(const uint8_t* buf, size_t start, size_t end) {
+    stats out;
+    uint64_t i = start;
+    while (i < end) {
+        // Support LF, CRLF, and CR-only line endings
+        if (buf[i] == '\n') {
+            out.first_even_nl = i;
+            return out;
+        } else if (buf[i] == '\r') {
+            // CR is a line ending only if not followed by LF
+            if (i + 1 >= end || buf[i + 1] != '\n') {
+                out.first_even_nl = i;
+                return out;
+            }
+            // If followed by LF, continue - the LF will be the line ending
+        }
+        ++i;
+    }
+    return out;
+}
+
+two_pass::quote_state two_pass::get_quotation_state(const uint8_t* buf, size_t start,
+                                                     char delimiter, char quote_char) {
+    // 64kb
+    constexpr int SPECULATION_SIZE = 1 << 16;
+
+    if (start == 0) {
+        return UNQUOTED;
+    }
+
+    size_t end = start > SPECULATION_SIZE ? start - SPECULATION_SIZE : 0;
+    size_t i = start;
+    size_t num_quotes = 0;
+
+    // FIXED: Use i > end to avoid unsigned underflow when i reaches 0
+    while (i > end) {
+        if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            // q-o case
+            if (i + 1 < start && is_other(buf[i + 1], delimiter, quote_char)) {
+                return num_quotes % 2 == 0 ? QUOTED : UNQUOTED;
+            }
+
+            // o-q case
+            else if (i > end && is_other(buf[i - 1], delimiter, quote_char)) {
+                return num_quotes % 2 == 0 ? UNQUOTED : QUOTED;
+            }
+            ++num_quotes;
+        }
+        --i;
+    }
+    // Check the last position (i == end)
+    if (buf[end] == static_cast<uint8_t>(quote_char)) {
+        ++num_quotes;
+    }
+    return AMBIGUOUS;
+}
+
+two_pass::stats two_pass::first_pass_speculate(const uint8_t* buf, size_t start, size_t end,
+                                                char delimiter, char quote_char) {
+    auto is_quoted = get_quotation_state(buf, start, delimiter, quote_char);
+#ifndef LIBVROOM_BENCHMARK_MODE
+    printf("start: %lu\tis_ambigious: %s\tstate: %s\n", start,
+           is_quoted == AMBIGUOUS ? "true" : "false",
+           is_quoted == QUOTED ? "quoted" : "unquoted");
+#endif
+
+    for (size_t i = start; i < end; ++i) {
+        // Support LF, CRLF, and CR-only line endings
+        bool is_line_ending = false;
+        if (buf[i] == '\n') {
+            is_line_ending = true;
+        } else if (buf[i] == '\r') {
+            // CR is a line ending only if not followed by LF
+            if (i + 1 >= end || buf[i + 1] != '\n') {
+                is_line_ending = true;
+            }
+        }
+
+        if (is_line_ending) {
+            if (is_quoted == UNQUOTED || is_quoted == AMBIGUOUS) {
+                return {0, i, null_pos};
+            } else {
+                return {1, null_pos, i};
+            }
+        } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            is_quoted = is_quoted == UNQUOTED ? QUOTED : UNQUOTED;
+        }
+    }
+    return {0, null_pos, null_pos};
+}
+
+//-----------------------------------------------------------------------------
+// two_pass helper functions
+//-----------------------------------------------------------------------------
+
+std::string two_pass::get_context(const uint8_t* buf, size_t len, size_t pos,
+                                   size_t context_size) {
+    // Handle empty buffer case
+    if (len == 0 || buf == nullptr) return "";
+
+    // Bounds check
+    size_t safe_pos = pos < len ? pos : len - 1;
+    size_t ctx_start = safe_pos > context_size ? safe_pos - context_size : 0;
+    size_t ctx_end = std::min(safe_pos + context_size, len);
+
+    std::string ctx;
+    // Reserve space to avoid reallocations (worst case: every char becomes 2 chars like \n)
+    ctx.reserve((ctx_end - ctx_start) * 2);
+
+    for (size_t i = ctx_start; i < ctx_end; ++i) {
+        char c = static_cast<char>(buf[i]);
+        if (c == '\n') ctx += "\\n";
+        else if (c == '\r') ctx += "\\r";
+        else if (c == '\0') ctx += "\\0";
+        else if (c >= 32 && c < 127) ctx += c;
+        else ctx += "?";
+    }
+    return ctx;
+}
+
+void two_pass::get_line_column(const uint8_t* buf, size_t buf_len, size_t offset,
+                                size_t& line, size_t& column) {
+    line = 1;
+    column = 1;
+    // Ensure we don't read past buffer bounds
+    size_t safe_offset = offset < buf_len ? offset : buf_len;
+    for (size_t i = 0; i < safe_offset; ++i) {
+        if (buf[i] == '\n') {
+            ++line;
+            column = 1;
+        } else if (buf[i] != '\r') {
+            ++column;
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// two_pass scalar second pass implementations
+//-----------------------------------------------------------------------------
+
+uint64_t two_pass::second_pass_chunk(const uint8_t* buf, size_t start, size_t end,
+                                      index* out, size_t thread_id,
+                                      ErrorCollector* errors,
+                                      size_t total_len,
+                                      char delimiter, char quote_char) {
+    uint64_t pos = start;
+    size_t n_indexes = 0;
+    size_t i = thread_id;
+    csv_state s = RECORD_START;
+
+    while (pos < end) {
+        uint8_t value = buf[pos];
+
+        // Use effective buffer length for bounds checking
+        size_t buf_len = total_len > 0 ? total_len : end;
+
+        // Check for null bytes
+        if (value == '\0' && errors) {
+            size_t line, col;
+            get_line_column(buf, buf_len, pos, line, col);
+            errors->add_error(ErrorCode::NULL_BYTE, ErrorSeverity::ERROR,
+                              line, col, pos, "Null byte in data",
+                              get_context(buf, buf_len, pos));
+            if (errors->should_stop()) return n_indexes;
+            ++pos;
+            continue;
+        }
+
+        state_result result;
+        if (value == static_cast<uint8_t>(quote_char)) {
+            result = quoted_state(s);
+            if (result.error != ErrorCode::NONE && errors) {
+                size_t line, col;
+                get_line_column(buf, buf_len, pos, line, col);
+                std::string msg = "Quote character '";
+                msg += quote_char;
+                msg += "' in unquoted field";
+                errors->add_error(result.error, ErrorSeverity::ERROR,
+                                  line, col, pos, msg,
+                                  get_context(buf, buf_len, pos));
+                if (errors->should_stop()) return n_indexes;
+            }
+            s = result.state;
+        } else if (value == static_cast<uint8_t>(delimiter)) {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            result = comma_state(s);
+            s = result.state;
+        } else if (value == '\n') {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            result = newline_state(s);
+            s = result.state;
+        } else if (value == '\r') {
+            // Support CR-only line endings: CR is a line ending if not followed by LF
+            bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
+            if (is_line_ending && s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+                result = newline_state(s);
+                s = result.state;
+            }
+            // If CR is followed by LF (CRLF), treat CR as regular character
+            // The LF will be the line ending; CR will be stripped during value extraction
+        } else {
+            result = other_state(s);
+            if (result.error != ErrorCode::NONE && errors) {
+                size_t line, col;
+                get_line_column(buf, buf_len, pos, line, col);
+                std::string msg = "Invalid character after closing quote '";
+                msg += quote_char;
+                msg += "'";
+                errors->add_error(result.error, ErrorSeverity::ERROR,
+                                  line, col, pos, msg,
+                                  get_context(buf, buf_len, pos));
+                if (errors->should_stop()) return n_indexes;
+            }
+            s = result.state;
+        }
+        ++pos;
+    }
+
+    // Use effective buffer length for bounds checking
+    size_t buf_len = total_len > 0 ? total_len : end;
+
+    // Check for unclosed quote at end of chunk
+    if (s == QUOTED_FIELD && errors && end == buf_len) {
+        size_t line, col;
+        get_line_column(buf, buf_len, pos > 0 ? pos - 1 : 0, line, col);
+        std::string msg = "Unclosed quote '";
+        msg += quote_char;
+        msg += "' at end of file";
+        errors->add_error(ErrorCode::UNCLOSED_QUOTE, ErrorSeverity::FATAL,
+                          line, col, pos, msg,
+                          get_context(buf, buf_len, pos > 20 ? pos - 20 : 0));
+    }
+
+    return n_indexes;
+}
+
+uint64_t two_pass::second_pass_chunk_throwing(const uint8_t* buf, size_t start, size_t end,
+                                               index* out, size_t thread_id,
+                                               char delimiter, char quote_char) {
+    uint64_t pos = start;
+    size_t n_indexes = 0;
+    size_t i = thread_id;
+    csv_state s = RECORD_START;
+
+    while (pos < end) {
+        uint8_t value = buf[pos];
+        state_result result;
+        if (value == static_cast<uint8_t>(quote_char)) {
+            result = quoted_state(s);
+            if (result.error != ErrorCode::NONE) {
+                std::string msg = "Quote character '";
+                msg += quote_char;
+                msg += "' in unquoted field";
+                throw std::runtime_error(msg);
+            }
+            s = result.state;
+        } else if (value == static_cast<uint8_t>(delimiter)) {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            s = comma_state(s).state;
+        } else if (value == '\n') {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            s = newline_state(s).state;
+        } else if (value == '\r') {
+            // Support CR-only line endings: CR is a line ending if not followed by LF
+            bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
+            if (is_line_ending && s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+                s = newline_state(s).state;
+            }
+            // If CR is followed by LF (CRLF), treat CR as regular character
+        } else {
+            result = other_state(s);
+            if (result.error != ErrorCode::NONE) {
+                std::string msg = "Invalid character after closing quote '";
+                msg += quote_char;
+                msg += "'";
+                throw std::runtime_error(msg);
+            }
+            s = result.state;
+        }
+        ++pos;
+    }
+    return n_indexes;
+}
+
+//-----------------------------------------------------------------------------
+// two_pass validation functions
+//-----------------------------------------------------------------------------
+
+bool two_pass::check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors) {
+    if (len == 0) return true;
+    if (buf[0] == '\n' || buf[0] == '\r') {
+        errors.add_error(ErrorCode::EMPTY_HEADER, ErrorSeverity::ERROR,
+                         1, 1, 0, "Header row is empty", "");
+        return false;
+    }
+    return true;
+}
+
+void two_pass::check_duplicate_columns(const uint8_t* buf, size_t len, ErrorCollector& errors,
+                                        char delimiter, char quote_char) {
+    if (len == 0) return;
+
+    // Find end of first line
+    size_t header_end = 0;
+    bool in_quote = false;
+    while (header_end < len) {
+        if (buf[header_end] == static_cast<uint8_t>(quote_char)) in_quote = !in_quote;
+        else if (!in_quote && (buf[header_end] == '\n' || buf[header_end] == '\r')) break;
+        ++header_end;
+    }
+
+    // Parse header fields
+    std::vector<std::string> fields;
+    std::string current;
+    in_quote = false;
+    for (size_t i = 0; i < header_end; ++i) {
+        if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            in_quote = !in_quote;
+        } else if (!in_quote && buf[i] == static_cast<uint8_t>(delimiter)) {
+            fields.push_back(current);
+            current.clear();
+        } else if (buf[i] != '\r') {
+            current += static_cast<char>(buf[i]);
+        }
+    }
+    fields.push_back(current);
+
+    // Check for duplicates
+    std::unordered_set<std::string> seen;
+    for (size_t i = 0; i < fields.size(); ++i) {
+        if (seen.count(fields[i]) > 0) {
+            errors.add_error(ErrorCode::DUPLICATE_COLUMN_NAMES, ErrorSeverity::WARNING,
+                             1, i + 1, 0, "Duplicate column name: '" + fields[i] + "'", fields[i]);
+        }
+        seen.insert(fields[i]);
+    }
+}
+
+void two_pass::check_field_counts(const uint8_t* buf, size_t len, ErrorCollector& errors,
+                                   char delimiter, char quote_char) {
+    if (len == 0) return;
+
+    size_t expected_fields = 0;
+    size_t current_fields = 1;
+    size_t current_line = 1;
+    size_t line_start = 0;
+    bool in_quote = false;
+    bool header_done = false;
+
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            in_quote = !in_quote;
+        } else if (!in_quote) {
+            if (buf[i] == static_cast<uint8_t>(delimiter)) {
+                ++current_fields;
+            } else if (buf[i] == '\n') {
+                if (!header_done) {
+                    expected_fields = current_fields;
+                    header_done = true;
+                } else if (current_fields != expected_fields) {
+                    std::ostringstream msg;
+                    msg << "Expected " << expected_fields << " fields but found " << current_fields;
+                    errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
+                                     current_line, 1, line_start, msg.str(),
+                                     get_context(buf, len, line_start, 40));
+                    if (errors.should_stop()) return;
+                }
+                current_fields = 1;
+                ++current_line;
+                line_start = i + 1;
+            }
+        }
+    }
+
+    // Check last line if no trailing newline
+    if (header_done && current_fields != expected_fields && line_start < len) {
+        std::ostringstream msg;
+        msg << "Expected " << expected_fields << " fields but found " << current_fields;
+        errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
+                         current_line, 1, line_start, msg.str(),
+                         get_context(buf, len, line_start, 40));
+    }
+}
+
+void two_pass::check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors) {
+    bool has_crlf = false;
+    bool has_lf = false;
+    bool has_cr = false;
+
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] == '\r') {
+            if (i + 1 < len && buf[i + 1] == '\n') {
+                has_crlf = true;
+                ++i;
+            } else {
+                has_cr = true;
+            }
+        } else if (buf[i] == '\n') {
+            has_lf = true;
+        }
+    }
+
+    int types = (has_crlf ? 1 : 0) + (has_lf ? 1 : 0) + (has_cr ? 1 : 0);
+    if (types > 1) {
+        errors.add_error(ErrorCode::MIXED_LINE_ENDINGS, ErrorSeverity::WARNING,
+                         1, 1, 0, "Mixed line endings detected", "");
+    }
+}
+
+//-----------------------------------------------------------------------------
+// two_pass orchestration methods
+//-----------------------------------------------------------------------------
+
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
+bool two_pass::parse_speculate(const uint8_t* buf, index& out, size_t len,
+                                const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+    uint8_t n_threads = out.n_threads;
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    size_t chunk_size = len / n_threads;
+    // If chunk size is too small, small chunks may not contain any newlines,
+    // causing first_pass_speculate to return null_pos. Fall back to single-threaded.
+    if (chunk_size < 64) {
+        // CRITICAL: Must update n_threads to 1 for correct stride in write()
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<stats>> first_pass_fut(n_threads);
+    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, delim, quote]() {
+                return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+#ifndef LIBVROOM_BENCHMARK_MODE
+    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
+           st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+#ifndef LIBVROOM_BENCHMARK_MODE
+        printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
+               st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+        chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            // CRITICAL: Must update n_threads to 1 for correct stride in write()
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+            return true;
+        }
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [buf, &out, &chunk_pos, i, delim, quote]() {
+                return second_pass_simd(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
+            });
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        out.n_indexes[i] = second_pass_fut[i].get();
+    }
+
+    return true;
+}
+
+bool two_pass::parse_two_pass(const uint8_t* buf, index& out, size_t len,
+                               const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+    uint8_t n_threads = out.n_threads;
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    size_t chunk_size = len / n_threads;
+    // If chunk size is too small, small chunks may not contain any newlines,
+    // causing first_pass_chunk to return null_pos. Fall back to single-threaded.
+    if (chunk_size < 64) {
+        // CRITICAL: Must update n_threads to 1 for correct stride in write()
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<stats>> first_pass_fut(n_threads);
+    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, quote]() {
+                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    size_t n_quotes = st.n_quotes;
+#ifndef LIBVROOM_BENCHMARK_MODE
+    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
+           st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+#ifndef LIBVROOM_BENCHMARK_MODE
+        printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
+               st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+        n_quotes += st.n_quotes;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            // CRITICAL: Must update n_threads to 1 for correct stride in write()
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+            return true;
+        }
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [buf, &out, &chunk_pos, i, delim, quote]() {
+                return second_pass_chunk_throwing(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
+            });
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        out.n_indexes[i] = second_pass_fut[i].get();
+    }
+
+    return true;
+}
+
+bool two_pass::parse(const uint8_t* buf, index& out, size_t len,
+                      const Dialect& dialect) {
+    return parse_speculate(buf, out, len, dialect);
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_END
+
+bool two_pass::parse_branchless_with_errors(const uint8_t* buf, index& out, size_t len,
+                                             ErrorCollector& errors,
+                                             const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // Handle empty input
+    if (len == 0) return true;
+
+    // Check structural issues first (single-threaded, fast)
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    BranchlessStateMachine sm(delim, quote);
+    uint8_t n_threads = out.n_threads;
+
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+
+    // For single-threaded, use the simpler path
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_branchless_with_errors(
+            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+        check_field_counts(buf, len, errors, delim, quote);
+        return !errors.has_fatal_errors();
+    }
+
+    size_t chunk_size = len / n_threads;
+
+    // If chunk size is too small, fall back to single-threaded
+    if (chunk_size < 64) {
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_branchless_with_errors(
+            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+        check_field_counts(buf, len, errors, delim, quote);
+        return !errors.has_fatal_errors();
+    }
+
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<stats>> first_pass_fut(n_threads);
+    std::vector<std::future<branchless_chunk_result>> second_pass_fut(n_threads);
+
+    // First pass: find chunk boundaries
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, quote]() {
+                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    size_t n_quotes = st.n_quotes;
+#ifndef LIBVROOM_BENCHMARK_MODE
+    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
+           st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+#ifndef LIBVROOM_BENCHMARK_MODE
+        printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
+               st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+        n_quotes += st.n_quotes;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_branchless_with_errors(
+                sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+            check_field_counts(buf, len, errors, delim, quote);
+            return !errors.has_fatal_errors();
+        }
+    }
+
+    // Second pass: parse with thread-local error collectors using branchless
+    ErrorMode mode = errors.mode();
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [sm, buf, &out, &chunk_pos, i, len, mode]() {
+                return second_pass_branchless_chunk_with_errors(
+                    sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i, len, mode);
+            });
+    }
+
+    // Collect results and merge errors
+    std::vector<ErrorCollector> thread_errors;
+    thread_errors.reserve(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        auto result = second_pass_fut[i].get();
+        out.n_indexes[i] = result.n_indexes;
+        thread_errors.push_back(std::move(result.errors));
+    }
+
+    // Merge all thread-local errors, sorted by byte offset
+    errors.merge_sorted(thread_errors);
+
+    // Check field counts after parsing (single-threaded, scans file linearly)
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
+bool two_pass::parse_branchless(const uint8_t* buf, index& out, size_t len,
+                                 const Dialect& dialect) {
+    BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char);
+    uint8_t n_threads = out.n_threads;
+
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+        return true;
+    }
+
+    // Multi-threaded parsing with branchless second pass
+    size_t chunk_size = len / n_threads;
+
+    // If chunk size is too small, fall back to single-threaded
+    if (chunk_size < 64) {
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+        return true;
+    }
+
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<stats>> first_pass_fut(n_threads);
+    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // First pass: find chunk boundaries (reuse existing implementation)
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, delim, quote]() {
+                return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+        chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+            return true;
+        }
+    }
+
+    // Second pass: branchless parsing of each chunk
+    // Capture sm by value since it's small (~300 bytes) and we need thread safety
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [sm, buf, &out, &chunk_pos, i]() {
+                return second_pass_simd_branchless(sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i);
+            });
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        out.n_indexes[i] = second_pass_fut[i].get();
+    }
+
+    return true;
+}
+
+bool two_pass::parse_auto(const uint8_t* buf, index& out, size_t len,
+                           ErrorCollector& errors, DetectionResult* detected,
+                           const DetectionOptions& detection_options) {
+    // Perform dialect detection
+    DialectDetector detector(detection_options);
+    DetectionResult result = detector.detect(buf, len);
+
+    // Store detection result if requested
+    if (detected != nullptr) {
+        *detected = result;
+    }
+
+    // Use detected dialect if successful, otherwise fall back to standard CSV
+    Dialect dialect = result.success() ? result.dialect : Dialect::csv();
+
+    // Add info message about detected dialect
+    if (result.success()) {
+        Dialect csv = Dialect::csv();
+        if (result.dialect.delimiter != csv.delimiter ||
+            result.dialect.quote_char != csv.quote_char) {
+            std::string msg = "Auto-detected dialect: " + result.dialect.to_string();
+            errors.add_error(ErrorCode::NONE, ErrorSeverity::WARNING,
+                             1, 1, 0, msg, "");
+        }
+    }
+
+    // Parse with detected dialect
+    return parse_two_pass_with_errors(buf, out, len, errors, dialect);
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_END
+
+two_pass::branchless_chunk_result two_pass::second_pass_branchless_chunk_with_errors(
+    const BranchlessStateMachine& sm,
+    const uint8_t* buf, size_t start, size_t end,
+    index* out, size_t thread_id, size_t total_len, ErrorMode mode) {
+    branchless_chunk_result result;
+    result.errors.set_mode(mode);
+    result.n_indexes = second_pass_branchless_with_errors(
+        sm, buf, start, end, out->indexes, thread_id, out->n_threads,
+        &result.errors, total_len);
+    return result;
+}
+
+two_pass::chunk_result two_pass::second_pass_chunk_with_errors(
+    const uint8_t* buf, size_t start, size_t end,
+    index* out, size_t thread_id, size_t total_len, ErrorMode mode,
+    char delimiter, char quote_char) {
+    chunk_result result;
+    result.errors.set_mode(mode);
+    result.n_indexes = second_pass_chunk(buf, start, end, out, thread_id,
+                                         &result.errors, total_len, delimiter, quote_char);
+    return result;
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
+bool two_pass::parse_two_pass_with_errors(const uint8_t* buf, index& out, size_t len,
+                                           ErrorCollector& errors,
+                                           const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // Handle empty input
+    if (len == 0) return true;
+
+    // Check structural issues first (single-threaded, fast)
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    uint8_t n_threads = out.n_threads;
+
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+
+    // For single-threaded, use the simpler path
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+        check_field_counts(buf, len, errors, delim, quote);
+        return !errors.has_fatal_errors();
+    }
+
+    size_t chunk_size = len / n_threads;
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<stats>> first_pass_fut(n_threads);
+    std::vector<std::future<chunk_result>> second_pass_fut(n_threads);
+
+    // First pass: find chunk boundaries
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, quote]() {
+                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    size_t n_quotes = st.n_quotes;
+#ifndef LIBVROOM_BENCHMARK_MODE
+    printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", 0,
+           st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+#ifndef LIBVROOM_BENCHMARK_MODE
+        printf("i: %i\teven: %" PRIu64 "\todd: %" PRIu64 "\tquotes: %" PRIu64 "\n", i,
+               st.first_even_nl, st.first_odd_nl, st.n_quotes);
+#endif
+        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+        n_quotes += st.n_quotes;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+            check_field_counts(buf, len, errors, delim, quote);
+            return !errors.has_fatal_errors();
+        }
+    }
+
+    // Second pass: parse with thread-local error collectors
+    ErrorMode mode = errors.mode();
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [buf, &out, &chunk_pos, i, len, mode, delim, quote]() {
+                return second_pass_chunk_with_errors(buf, chunk_pos[i], chunk_pos[i + 1],
+                                                      &out, i, len, mode, delim, quote);
+            });
+    }
+
+    // Collect results and merge errors
+    std::vector<ErrorCollector> thread_errors;
+    thread_errors.reserve(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        auto result = second_pass_fut[i].get();
+        out.n_indexes[i] = result.n_indexes;
+        thread_errors.push_back(std::move(result.errors));
+    }
+
+    // Merge all thread-local errors, sorted by byte offset
+    errors.merge_sorted(thread_errors);
+
+    // Check field counts after parsing (single-threaded, scans file linearly)
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+bool two_pass::parse_with_errors(const uint8_t* buf, index& out, size_t len, ErrorCollector& errors,
+                                  const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // Check structural issues first
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    // Single-threaded parsing for accurate error position tracking
+    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+
+    // Check field counts after parsing
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+bool two_pass::parse_validate(const uint8_t* buf, index& out, size_t len, ErrorCollector& errors,
+                               const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // Check structural issues first
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    // Parse with error collection
+    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+
+    // Check field counts after parsing
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_END
+
+DetectionResult two_pass::detect_dialect(const uint8_t* buf, size_t len,
+                                          const DetectionOptions& options) {
+    DialectDetector detector(options);
+    return detector.detect(buf, len);
+}
+
+index two_pass::init(size_t len, size_t n_threads) {
+    index out;
+    // Ensure at least 1 thread for valid memory allocation
+    if (n_threads == 0) n_threads = 1;
+    out.n_threads = n_threads;
+    out.n_indexes = new uint64_t[n_threads];
+
+    // Allocate space for interleaved index storage.
+    //
+    // With multi-threaded parsing, indexes are stored in an interleaved pattern:
+    // thread 0 writes to positions 0, n_threads, 2*n_threads, ...
+    // thread 1 writes to positions 1, n_threads+1, 2*n_threads+1, ...
+    //
+    // For a file with len bytes, the maximum number of separators is len (worst case:
+    // every byte is a separator). In multi-threaded mode, if one thread finds m
+    // separators, it writes to positions thread_id, thread_id + n_threads, ...,
+    // thread_id + (m-1) * n_threads.
+    //
+    // The maximum index accessed is: (n_threads - 1) + (len - 1) * n_threads + 7 * n_threads
+    // (the +7*n_threads is for speculative SIMD writes that always write 8 elements).
+    //
+    // This simplifies to approximately len * n_threads + 8 * n_threads.
+    //
+    // For single-threaded parsing (n_threads == 1), we only need len + 8 elements.
+    // For multi-threaded parsing, we need the full interleaved size.
+    //
+    // See GitHub issues #264 and #265 for details.
+    size_t allocation_size;
+    if (n_threads == 1) {
+        // Single-threaded: simple allocation with padding for speculative writes
+        allocation_size = len + 8;
+    } else {
+        // Multi-threaded: need space for interleaved storage
+        // Maximum index = (len - 1) * n_threads + (n_threads - 1) + 7 * n_threads
+        //               = len * n_threads - n_threads + n_threads - 1 + 7 * n_threads
+        //               = len * n_threads + 7 * n_threads - 1
+        //               < (len + 8) * n_threads
+        allocation_size = (len + 8) * n_threads;
+    }
+    out.indexes = new uint64_t[allocation_size];
+    return out;
+}
+
+}  // namespace libvroom


### PR DESCRIPTION
## Summary

Addresses #280 by moving non-performance-critical implementations from `two_pass.h` to a new `src/two_pass.cpp` source file. This reduces compilation overhead while preserving SIMD performance.

### Changes
- **Header reduced from 2,030 to 1,013 lines** (~50% reduction)
- Created `src/two_pass.cpp` with implementations moved from header
- Updated `CMakeLists.txt` to include new source file

### What was moved to .cpp:
- `index::write/read` - serialization methods
- `first_pass_chunk`, `first_pass_naive`, `first_pass_speculate` - scalar parsing
- `second_pass_chunk`, `second_pass_chunk_throwing` - scalar second pass
- All `parse_*` orchestration methods
- Validation functions (`check_empty_header`, `check_duplicate_columns`, etc.)
- Error helpers (`get_context`, `get_line_column`)

### What remains inline (SIMD hot paths):
- `first_pass_simd()` - SIMD first pass scanning
- `second_pass_simd()` - SIMD field indexing
- `second_pass_simd_branchless()` - Branchless SIMD parsing
- `really_inline` state machine functions

## Test plan
- [x] All 1,661 tests pass
- [x] Benchmarks confirm no performance regression (~272-574 Mi/s throughput maintained)
- [x] Build succeeds on local machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)