### PR TITLE
refactor: Move large implementations from two_pass.h to two_pass.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ add_library(vroom
     src/libvroom_c.cpp
     src/value_extraction.cpp
     src/streaming.cpp
+    src/two_pass.cpp
 )
 
 target_include_directories(vroom PUBLIC

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -199,23 +199,7 @@ class ParseIndex {
    * @param filename Path to the output file.
    * @throws std::runtime_error If writing fails.
    */
-  void write(const std::string& filename) {
-    std::FILE* fp = std::fopen(filename.c_str(), "wb");
-    if (!((std::fwrite(&columns, sizeof(uint64_t), 1, fp) == 1) &&
-          (std::fwrite(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
-          (std::fwrite(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
-      throw std::runtime_error("error writing index");
-    }
-    size_t total_size = 0;
-    for (int i = 0; i < n_threads; ++i) {
-      total_size += n_indexes[i];
-    }
-    if (std::fwrite(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
-      throw std::runtime_error("error writing index2");
-    }
-
-    std::fclose(fp);
-  }
+  void write(const std::string& filename);
 
   /**
    * @brief Deserialize the index from a binary file.
@@ -227,23 +211,7 @@ class ParseIndex {
    *
    * @warning The n_indexes and indexes arrays must be pre-allocated before calling.
    */
-  void read(const std::string& filename) {
-    std::FILE* fp = std::fopen(filename.c_str(), "rb");
-    if (!((std::fread(&columns, sizeof(uint64_t), 1, fp) == 1) &&
-          (std::fread(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
-          (std::fread(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
-      throw std::runtime_error("error reading index");
-    }
-    size_t total_size = 0;
-    for (int i = 0; i < n_threads; ++i) {
-      total_size += n_indexes[i];
-    }
-    if (std::fread(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
-      throw std::runtime_error("error reading index2");
-    }
-
-    std::fclose(fp);
-  }
+  void read(const std::string& filename);
 
   /**
    * @brief Destructor. Releases allocated index arrays via RAII.
@@ -402,62 +370,9 @@ class TwoPass {
    * @brief First pass scalar scan with dialect-aware quote character.
    */
   static Stats first_pass_chunk(const uint8_t* buf, size_t start, size_t end,
-                                char quote_char = '"') {
-    Stats out;
-    uint64_t i = start;
-    bool needs_even = out.first_even_nl == null_pos;
-    bool needs_odd = out.first_odd_nl == null_pos;
-    while (i < end) {
-      // Support LF, CRLF, and CR-only line endings
-      // Check for line ending: \n, or \r not followed by \n
-      bool is_line_ending = false;
-      if (buf[i] == '\n') {
-        is_line_ending = true;
-      } else if (buf[i] == '\r') {
-        // CR is a line ending only if not followed by LF
-        if (i + 1 >= end || buf[i + 1] != '\n') {
-          is_line_ending = true;
-        }
-        // If followed by LF, skip this CR (the LF will be the line ending)
-      }
+                                char quote_char = '"');
 
-      if (is_line_ending) {
-        bool is_even = (out.n_quotes % 2) == 0;
-        if (needs_even && is_even) {
-          out.first_even_nl = i;
-          needs_even = false;
-        } else if (needs_odd && !is_even) {
-          out.first_odd_nl = i;
-          needs_odd = false;
-        }
-      } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        ++out.n_quotes;
-      }
-      ++i;
-    }
-    return out;
-  }
-
-  static Stats first_pass_naive(const uint8_t* buf, size_t start, size_t end) {
-    Stats out;
-    uint64_t i = start;
-    while (i < end) {
-      // Support LF, CRLF, and CR-only line endings
-      if (buf[i] == '\n') {
-        out.first_even_nl = i;
-        return out;
-      } else if (buf[i] == '\r') {
-        // CR is a line ending only if not followed by LF
-        if (i + 1 >= end || buf[i + 1] != '\n') {
-          out.first_even_nl = i;
-          return out;
-        }
-        // If followed by LF, continue - the LF will be the line ending
-      }
-      ++i;
-    }
-    return out;
-  }
+  static Stats first_pass_naive(const uint8_t* buf, size_t start, size_t end);
 
   /**
    * @brief Check if character is not a delimiter, newline (LF or CR), or quote.
@@ -472,72 +387,13 @@ class TwoPass {
    * @brief Determine quote state at a position using backward scanning.
    */
   static quote_state get_quotation_state(const uint8_t* buf, size_t start,
-                                         char delimiter = ',', char quote_char = '"') {
-    // 64kb
-    constexpr int SPECULATION_SIZE = 1 << 16;
-
-    if (start == 0) {
-      return UNQUOTED;
-    }
-
-    size_t end = start > SPECULATION_SIZE ? start - SPECULATION_SIZE : 0;
-    size_t i = start;
-    size_t num_quotes = 0;
-
-    // FIXED: Use i > end to avoid unsigned underflow when i reaches 0
-    while (i > end) {
-      if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        // q-o case
-        if (i + 1 < start && is_other(buf[i + 1], delimiter, quote_char)) {
-          return num_quotes % 2 == 0 ? QUOTED : UNQUOTED;
-        }
-
-        // o-q case
-        else if (i > end && is_other(buf[i - 1], delimiter, quote_char)) {
-          return num_quotes % 2 == 0 ? UNQUOTED : QUOTED;
-        }
-        ++num_quotes;
-      }
-      --i;
-    }
-    // Check the last position (i == end)
-    if (buf[end] == static_cast<uint8_t>(quote_char)) {
-      ++num_quotes;
-    }
-    return AMBIGUOUS;
-  }
+                                         char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Speculative first pass with dialect-aware quote character.
    */
   static Stats first_pass_speculate(const uint8_t* buf, size_t start, size_t end,
-                                    char delimiter = ',', char quote_char = '"') {
-    auto is_quoted = get_quotation_state(buf, start, delimiter, quote_char);
-
-    for (size_t i = start; i < end; ++i) {
-      // Support LF, CRLF, and CR-only line endings
-      bool is_line_ending = false;
-      if (buf[i] == '\n') {
-        is_line_ending = true;
-      } else if (buf[i] == '\r') {
-        // CR is a line ending only if not followed by LF
-        if (i + 1 >= end || buf[i + 1] != '\n') {
-          is_line_ending = true;
-        }
-      }
-
-      if (is_line_ending) {
-        if (is_quoted == UNQUOTED || is_quoted == AMBIGUOUS) {
-          return {0, i, null_pos};
-        } else {
-          return {1, null_pos, i};
-        }
-      } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        is_quoted = is_quoted == UNQUOTED ? QUOTED : UNQUOTED;
-      }
-    }
-    return {0, null_pos, null_pos};
-  }
+                                    char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Second pass SIMD scan with dialect-aware delimiter and quote character.
@@ -722,46 +578,12 @@ class TwoPass {
   // Helper to get context around an error position
   // Returns a string representation of the buffer content near the given position
   static std::string get_context(const uint8_t* buf, size_t len, size_t pos,
-                                 size_t context_size = DEFAULT_ERROR_CONTEXT_SIZE) {
-    // Handle empty buffer case
-    if (len == 0 || buf == nullptr) return "";
-
-    // Bounds check
-    size_t safe_pos = pos < len ? pos : len - 1;
-    size_t ctx_start = safe_pos > context_size ? safe_pos - context_size : 0;
-    size_t ctx_end = std::min(safe_pos + context_size, len);
-
-    std::string ctx;
-    // Reserve space to avoid reallocations (worst case: every char becomes 2 chars like \n)
-    ctx.reserve((ctx_end - ctx_start) * 2);
-
-    for (size_t i = ctx_start; i < ctx_end; ++i) {
-      char c = static_cast<char>(buf[i]);
-      if (c == '\n') ctx += "\\n";
-      else if (c == '\r') ctx += "\\r";
-      else if (c == '\0') ctx += "\\0";
-      else if (c >= 32 && c < 127) ctx += c;
-      else ctx += "?";
-    }
-    return ctx;
-  }
+                                 size_t context_size = DEFAULT_ERROR_CONTEXT_SIZE);
 
   // Helper to calculate line and column from byte offset
   // SECURITY: buf_len parameter ensures we never read past buffer bounds
-  static void get_line_column(const uint8_t* buf, size_t buf_len, size_t offset, size_t& line, size_t& column) {
-    line = 1;
-    column = 1;
-    // Ensure we don't read past buffer bounds
-    size_t safe_offset = offset < buf_len ? offset : buf_len;
-    for (size_t i = 0; i < safe_offset; ++i) {
-      if (buf[i] == '\n') {
-        ++line;
-        column = 1;
-      } else if (buf[i] != '\r') {
-        ++column;
-      }
-    }
-  }
+  static void get_line_column(const uint8_t* buf, size_t buf_len, size_t offset,
+                               size_t& line, size_t& column);
 
   /**
    * @brief Second pass with error collection and dialect support.
@@ -770,164 +592,14 @@ class TwoPass {
                                     ParseIndex* out, size_t thread_id,
                                     ErrorCollector* errors = nullptr,
                                     size_t total_len = 0,
-                                    char delimiter = ',', char quote_char = '"') {
-    uint64_t pos = start;
-    size_t n_indexes = 0;
-    size_t i = thread_id;
-    csv_state s = RECORD_START;
-
-    while (pos < end) {
-      uint8_t value = buf[pos];
-
-      // Use effective buffer length for bounds checking
-      size_t buf_len = total_len > 0 ? total_len : end;
-
-      // Check for null bytes
-      if (value == '\0' && errors) {
-        size_t line, col;
-        get_line_column(buf, buf_len, pos, line, col);
-        errors->add_error(ErrorCode::NULL_BYTE, ErrorSeverity::ERROR,
-                          line, col, pos, "Null byte in data",
-                          get_context(buf, buf_len, pos));
-        if (errors->should_stop()) return n_indexes;
-        ++pos;
-        continue;
-      }
-
-      StateResult result;
-      if (value == static_cast<uint8_t>(quote_char)) {
-        result = quoted_state(s);
-        if (result.error != ErrorCode::NONE && errors) {
-          size_t line, col;
-          get_line_column(buf, buf_len, pos, line, col);
-          std::string msg = "Quote character '";
-          msg += quote_char;
-          msg += "' in unquoted field";
-          errors->add_error(result.error, ErrorSeverity::ERROR,
-                            line, col, pos, msg,
-                            get_context(buf, buf_len, pos));
-          if (errors->should_stop()) return n_indexes;
-        }
-        s = result.state;
-      } else if (value == static_cast<uint8_t>(delimiter)) {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        result = comma_state(s);
-        s = result.state;
-      } else if (value == '\n') {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        result = newline_state(s);
-        s = result.state;
-      } else if (value == '\r') {
-        // Support CR-only line endings: CR is a line ending if not followed by LF
-        bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
-        if (is_line_ending && s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-          result = newline_state(s);
-          s = result.state;
-        }
-        // If CR is followed by LF (CRLF), treat CR as regular character
-        // The LF will be the line ending; CR will be stripped during value extraction
-      } else {
-        result = other_state(s);
-        if (result.error != ErrorCode::NONE && errors) {
-          size_t line, col;
-          get_line_column(buf, buf_len, pos, line, col);
-          std::string msg = "Invalid character after closing quote '";
-          msg += quote_char;
-          msg += "'";
-          errors->add_error(result.error, ErrorSeverity::ERROR,
-                            line, col, pos, msg,
-                            get_context(buf, buf_len, pos));
-          if (errors->should_stop()) return n_indexes;
-        }
-        s = result.state;
-      }
-      ++pos;
-    }
-
-    // Use effective buffer length for bounds checking
-    size_t buf_len = total_len > 0 ? total_len : end;
-
-    // Check for unclosed quote at end of chunk
-    if (s == QUOTED_FIELD && errors && end == buf_len) {
-      size_t line, col;
-      get_line_column(buf, buf_len, pos > 0 ? pos - 1 : 0, line, col);
-      std::string msg = "Unclosed quote '";
-      msg += quote_char;
-      msg += "' at end of file";
-      errors->add_error(ErrorCode::UNCLOSED_QUOTE, ErrorSeverity::FATAL,
-                        line, col, pos, msg,
-                        get_context(buf, buf_len, pos > 20 ? pos - 20 : 0));
-    }
-
-    return n_indexes;
-  }
+                                    char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Second pass that throws on error (backward compatible), with dialect support.
    */
   static uint64_t second_pass_chunk_throwing(const uint8_t* buf, size_t start, size_t end,
                                              ParseIndex* out, size_t thread_id,
-                                             char delimiter = ',', char quote_char = '"') {
-    uint64_t pos = start;
-    size_t n_indexes = 0;
-    size_t i = thread_id;
-    csv_state s = RECORD_START;
-
-    while (pos < end) {
-      uint8_t value = buf[pos];
-      StateResult result;
-      if (value == static_cast<uint8_t>(quote_char)) {
-        result = quoted_state(s);
-        if (result.error != ErrorCode::NONE) {
-          std::string msg = "Quote character '";
-          msg += quote_char;
-          msg += "' in unquoted field";
-          throw std::runtime_error(msg);
-        }
-        s = result.state;
-      } else if (value == static_cast<uint8_t>(delimiter)) {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        s = comma_state(s).state;
-      } else if (value == '\n') {
-        if (s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-        }
-        s = newline_state(s).state;
-      } else if (value == '\r') {
-        // Support CR-only line endings: CR is a line ending if not followed by LF
-        bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
-        if (is_line_ending && s != QUOTED_FIELD) {
-          i = add_position(out, i, pos);
-          ++n_indexes;
-          s = newline_state(s).state;
-        }
-        // If CR is followed by LF (CRLF), treat CR as regular character
-      } else {
-        result = other_state(s);
-        if (result.error != ErrorCode::NONE) {
-          std::string msg = "Invalid character after closing quote '";
-          msg += quote_char;
-          msg += "'";
-          throw std::runtime_error(msg);
-        }
-        s = result.state;
-      }
-      ++pos;
-    }
-    return n_indexes;
-  }
+                                             char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Parse using speculative multi-threading with dialect support.
@@ -937,67 +609,7 @@ class TwoPass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::SPECULATIVE instead")
   bool parse_speculate(const uint8_t* buf, ParseIndex& out, size_t len,
-                       const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    uint8_t n_threads = out.n_threads;
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    size_t chunk_size = len / n_threads;
-    // If chunk size is too small, small chunks may not contain any newlines,
-    // causing first_pass_speculate to return null_pos. Fall back to single-threaded.
-    if (chunk_size < 64) {
-      // CRITICAL: Must update n_threads to 1 for correct stride in write()
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, delim, quote]() {
-            return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-      chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        // CRITICAL: Must update n_threads to 1 for correct stride in write()
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-      }
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [buf, &out, &chunk_pos, i, delim, quote]() {
-            return second_pass_simd(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
-          });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
-    return true;
-  }
+                       const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse using two-pass algorithm with dialect support.
@@ -1007,115 +619,17 @@ class TwoPass {
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::TWO_PASS instead")
   bool parse_two_pass(const uint8_t* buf, ParseIndex& out, size_t len,
-                      const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    uint8_t n_threads = out.n_threads;
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    size_t chunk_size = len / n_threads;
-    // If chunk size is too small, small chunks may not contain any newlines,
-    // causing first_pass_chunk to return null_pos. Fall back to single-threaded.
-    if (chunk_size < 64) {
-      // CRITICAL: Must update n_threads to 1 for correct stride in write()
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-      return true;
-    }
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, quote]() {
-            return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-      chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-      n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        // CRITICAL: Must update n_threads to 1 for correct stride in write()
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-      }
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [buf, &out, &chunk_pos, i, delim, quote]() {
-            return second_pass_chunk_throwing(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
-          });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
-    return true;
-  }
+                      const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer and build the field index.
    *
-   * This is the primary parsing method for fast CSV parsing without detailed
-   * error collection. It uses the speculative multi-threaded algorithm for
-   * optimal performance on large files.
-   *
-   * The method populates the index structure with byte offsets of all field
-   * separators (commas and newlines) found in the CSV data.
-   *
-   * @param buf Pointer to the CSV data buffer. Must remain valid during parsing.
-   *            Should have at least 32 bytes of padding beyond len for SIMD safety.
-   * @param out The index structure to populate. Must be initialized via init().
-   * @param len Length of the CSV data in bytes (excluding any padding).
-   * @param dialect The dialect to use for parsing (default: CSV with comma and double-quote).
-   *
-   * @return true if parsing completed successfully, false otherwise.
-   *
-   * @throws std::runtime_error On parsing errors (e.g., malformed quotes).
-   *
-   * @note For error-tolerant parsing with detailed error information, use
-   *       parse_with_errors() or parse_two_pass_with_errors() instead.
-   *
-   * @note The buffer should be loaded using io_util.h functions which ensure
-   *       proper SIMD-aligned padding.
-   *
    * @deprecated Use Parser::parse() from libvroom.h instead. The Parser class
    *             provides a simpler, unified API with automatic index management.
-   *             Example:
-   *             ```cpp
-   *             libvroom::Parser parser(num_threads);
-   *             auto result = parser.parse(buf, len, {.dialect = dialect});
-   *             ```
-   *
-   * @see Parser For the recommended high-level API.
-   * @see parse_with_errors() For single-threaded parsing with error collection.
-   * @see parse_two_pass_with_errors() For multi-threaded parsing with error collection.
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() from libvroom.h instead")
   bool parse(const uint8_t* buf, ParseIndex& out, size_t len,
-             const Dialect& dialect = Dialect::csv()) {
-    LIBVROOM_SUPPRESS_DEPRECATION_START
-    return parse_speculate(buf, out, len, dialect);
-    LIBVROOM_SUPPRESS_DEPRECATION_END
-  }
+             const Dialect& dialect = Dialect::csv());
 
   // Result from multi-threaded branchless parsing with error collection
   struct branchless_chunk_result {
@@ -1131,350 +645,39 @@ class TwoPass {
   static branchless_chunk_result second_pass_branchless_chunk_with_errors(
       const BranchlessStateMachine& sm,
       const uint8_t* buf, size_t start, size_t end,
-      ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode) {
-    branchless_chunk_result result;
-    result.errors.set_mode(mode);
-    result.n_indexes = second_pass_branchless_with_errors(
-        sm, buf, start, end, out->indexes, thread_id, out->n_threads,
-        &result.errors, total_len);
-    return result;
-  }
+      ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode);
 
   /**
    * @brief Parse a CSV buffer using branchless state machine with error collection.
-   *
-   * This method combines the performance benefits of the branchless state machine
-   * with comprehensive error collection. It uses the unified branchless implementation
-   * for all parsing paths.
-   *
-   * The method performs the following checks:
-   * - Empty header detection
-   * - Duplicate column name detection
-   * - Mixed line ending warnings
-   * - Quote errors (unclosed quotes, quotes in unquoted fields)
-   * - Inconsistent field counts across rows
-   * - Null byte detection
-   *
-   * @param buf Pointer to the CSV data buffer. Must remain valid during parsing.
-   * @param out The index structure to populate. Must be initialized via init().
-   * @param len Length of the CSV data in bytes.
-   * @param errors ErrorCollector to accumulate parsing errors.
-   * @param dialect The dialect to use for parsing (default: CSV with comma and double-quote).
-   *
-   * @return true if parsing completed without fatal errors, false if fatal
-   *         errors occurred.
    */
   bool parse_branchless_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
                                     ErrorCollector& errors,
-                                    const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    char escape = dialect.escape_char;
-    bool double_quote = dialect.double_quote;
-
-    // Handle empty input
-    if (len == 0) return true;
-
-    // Check structural issues first (single-threaded, fast)
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    BranchlessStateMachine sm(delim, quote, escape, double_quote);
-    uint8_t n_threads = out.n_threads;
-
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-
-    // For single-threaded, use the simpler path
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_branchless_with_errors(
-          sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-      check_field_counts(buf, len, errors, delim, quote);
-      return !errors.has_fatal_errors();
-    }
-
-    size_t chunk_size = len / n_threads;
-
-    // If chunk size is too small, fall back to single-threaded
-    if (chunk_size < 64) {
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_branchless_with_errors(
-          sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-      check_field_counts(buf, len, errors, delim, quote);
-      return !errors.has_fatal_errors();
-    }
-
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<branchless_chunk_result>> second_pass_fut(n_threads);
-
-    // First pass: find chunk boundaries
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, quote]() {
-            return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-      chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-      n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_branchless_with_errors(
-            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-        check_field_counts(buf, len, errors, delim, quote);
-        return !errors.has_fatal_errors();
-      }
-    }
-
-    // Second pass: parse with thread-local error collectors using branchless
-    ErrorMode mode = errors.mode();
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [sm, buf, &out, &chunk_pos, i, len, mode]() {
-            return second_pass_branchless_chunk_with_errors(
-                sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i, len, mode);
-          });
-    }
-
-    // Collect results and merge errors
-    std::vector<ErrorCollector> thread_errors;
-    thread_errors.reserve(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      auto result = second_pass_fut[i].get();
-      out.n_indexes[i] = result.n_indexes;
-      thread_errors.push_back(std::move(result.errors));
-    }
-
-    // Merge all thread-local errors, sorted by byte offset
-    errors.merge_sorted(thread_errors);
-
-    // Check field counts after parsing (single-threaded, scans file linearly)
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                                    const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer using branchless state machine (optimized).
    *
-   * This method uses the branchless state machine implementation for improved
-   * performance by eliminating branch mispredictions. It's recommended for
-   * large files where the branch misprediction overhead is significant.
-   *
-   * The branchless implementation uses:
-   * - Lookup table character classification (O(1) per character)
-   * - Lookup table state transitions (O(1) per character)
-   * - SIMD-accelerated character detection
-   *
-   * @param buf Pointer to the CSV data buffer. Must remain valid during parsing.
-   *            Should have at least 32 bytes of padding beyond len for SIMD safety.
-   * @param out The index structure to populate. Must be initialized via init().
-   * @param len Length of the CSV data in bytes (excluding any padding).
-   * @param dialect The dialect to use for parsing (default: CSV with comma and double-quote).
-   *
-   * @return true if parsing completed successfully, false otherwise.
-   *
-   * @note This method is optimized for performance over error reporting.
-   *       It does NOT collect errors like unclosed quotes, null bytes, or
-   *       invalid escape sequences. For detailed error information, use
-   *       parse_branchless_with_errors() instead.
-   *
-   * @warning When parsing untrusted input, consider using parse_branchless_with_errors()
-   *          to detect malformed CSV that this method may silently accept.
-   *
    * @deprecated Use Parser::parse() with ParseOptions::branchless() instead.
-   *             Example:
-   *             ```cpp
-   *             libvroom::Parser parser(num_threads);
-   *             auto result = parser.parse(buf, len, ParseOptions::branchless());
-   *             ```
-   *
-   * @see Parser For the recommended high-level API.
-   * @see ParseAlgorithm::BRANCHLESS For algorithm selection.
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with ParseOptions::branchless() instead")
   bool parse_branchless(const uint8_t* buf, ParseIndex& out, size_t len,
-                        const Dialect& dialect = Dialect::csv()) {
-    BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char,
-                               dialect.escape_char, dialect.double_quote);
-    uint8_t n_threads = out.n_threads;
-
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-      return true;
-    }
-
-    // Multi-threaded parsing with branchless second pass
-    size_t chunk_size = len / n_threads;
-
-    // If chunk size is too small, fall back to single-threaded
-    if (chunk_size < 64) {
-      out.n_threads = 1;
-      out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-      return true;
-    }
-
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // First pass: find chunk boundaries (reuse existing implementation)
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, delim, quote]() {
-            return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-      chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-        return true;
-      }
-    }
-
-    // Second pass: branchless parsing of each chunk
-    // Capture sm by value since it's small (~300 bytes) and we need thread safety
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [sm, buf, &out, &chunk_pos, i]() {
-            return second_pass_simd_branchless(sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i);
-          });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-      out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
-    return true;
-  }
+                        const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with automatic dialect detection.
    *
-   * This method first detects the CSV dialect (delimiter, quote character, etc.)
-   * and then parses the file using the detected dialect. It combines dialect
-   * detection with parsing in a single convenient call.
-   *
-   * The detection uses a CleverCSV-inspired algorithm that analyzes pattern
-   * consistency and cell type inference to identify the most likely dialect.
-   *
-   * @param buf Pointer to the CSV data buffer. Must remain valid during parsing.
-   *            Should have at least 32 bytes of padding beyond len for SIMD safety.
-   * @param out The index structure to populate. Must be initialized via init().
-   * @param len Length of the CSV data in bytes (excluding any padding).
-   * @param errors ErrorCollector to accumulate parsing errors.
-   * @param detected Optional pointer to receive the detected dialect result.
-   *                 If nullptr, detection result is not returned.
-   *
-   * @return true if parsing completed successfully, false otherwise.
-   *
-   * @deprecated Use Parser::parse() with default ParseOptions (auto-detects dialect):
-   *             ```cpp
-   *             libvroom::Parser parser(num_threads);
-   *             libvroom::ErrorCollector errors(ErrorMode::PERMISSIVE);
-   *             auto result = parser.parse(buf, len, {.errors = &errors});
-   *             // result.detection contains dialect detection info
-   *             ```
-   *
-   * @see Parser For the recommended high-level API.
-   * @see Dialect For dialect configuration options.
+   * @deprecated Use Parser::parse() with default ParseOptions (auto-detects dialect).
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.errors = &errors} instead (auto-detects dialect)")
   bool parse_auto(const uint8_t* buf, ParseIndex& out, size_t len,
                   ErrorCollector& errors, DetectionResult* detected = nullptr,
-                  const DetectionOptions& detection_options = DetectionOptions()) {
-    // Perform dialect detection
-    DialectDetector detector(detection_options);
-    DetectionResult result = detector.detect(buf, len);
-
-    // Store detection result if requested
-    if (detected != nullptr) {
-      *detected = result;
-    }
-
-    // Use detected dialect if successful, otherwise fall back to standard CSV
-    Dialect dialect = result.success() ? result.dialect : Dialect::csv();
-
-    // Add info message about detected dialect
-    if (result.success()) {
-      Dialect csv = Dialect::csv();
-      if (result.dialect.delimiter != csv.delimiter ||
-          result.dialect.quote_char != csv.quote_char) {
-        std::string msg = "Auto-detected dialect: " + result.dialect.to_string();
-        errors.add_error(ErrorCode::NONE, ErrorSeverity::WARNING,
-                         1, 1, 0, msg, "");
-      }
-    }
-
-    // Parse with detected dialect
-    // Suppress internal deprecation warning (parse_auto is itself deprecated)
-    LIBVROOM_SUPPRESS_DEPRECATION_START
-    return parse_two_pass_with_errors(buf, out, len, errors, dialect);
-    LIBVROOM_SUPPRESS_DEPRECATION_END
-  }
+                  const DetectionOptions& detection_options = DetectionOptions());
 
   /**
    * @brief Detect the dialect of a CSV buffer without parsing.
-   *
-   * This is a convenience method that performs only dialect detection without
-   * full parsing. Use this when you need to determine the file format before
-   * deciding how to process it.
-   *
-   * @param buf Pointer to the CSV data buffer.
-   * @param len Length of the data in bytes.
-   * @param options Optional detection options (sample size, candidate delimiters, etc.).
-   *
-   * @return DetectionResult containing the detected dialect and confidence.
-   *
-   * @example
-   * @code
-   * auto result = libvroom::two_pass::detect_dialect(buffer, length);
-   * if (result.success()) {
-   *     std::cout << "Delimiter: " << result.dialect.delimiter << "\n";
-   *     std::cout << "Confidence: " << result.confidence << "\n";
-   * }
-   * @endcode
    */
   static DetectionResult detect_dialect(const uint8_t* buf, size_t len,
-                                         const DetectionOptions& options = DetectionOptions()) {
-    DialectDetector detector(options);
-    return detector.detect(buf, len);
-  }
+                                         const DetectionOptions& options = DetectionOptions());
 
   // Result from multi-threaded parsing with error collection
   struct chunk_result {
@@ -1490,605 +693,63 @@ class TwoPass {
   static chunk_result second_pass_chunk_with_errors(
       const uint8_t* buf, size_t start, size_t end,
       ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode,
-      char delimiter = ',', char quote_char = '"') {
-    chunk_result result;
-    result.errors.set_mode(mode);
-    result.n_indexes = second_pass_chunk(buf, start, end, out, thread_id,
-                                         &result.errors, total_len, delimiter, quote_char);
-    return result;
-  }
+      char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Parse a CSV buffer with error collection using multi-threading.
    *
-   * This method combines the performance of multi-threaded parsing with
-   * comprehensive error collection. Each thread maintains its own local
-   * error collector, and errors are merged and sorted by byte offset after
-   * parsing completes.
-   *
-   * The method performs the same checks as parse_with_errors():
-   * - Empty header detection
-   * - Duplicate column name detection
-   * - Mixed line ending warnings
-   * - Quote errors (unclosed quotes, quotes in unquoted fields)
-   * - Inconsistent field counts across rows
-   * - Null byte detection
-   *
-   * @param buf Pointer to the CSV data buffer. Must remain valid during parsing.
-   * @param out The index structure to populate. Must be initialized via init()
-   *            with the desired number of threads.
-   * @param len Length of the CSV data in bytes.
-   * @param errors ErrorCollector to accumulate parsing errors. Thread-local
-   *               errors are merged into this collector after parsing.
-   * @param dialect The dialect to use for parsing (default: CSV with comma and double-quote).
-   *
-   * @return true if parsing completed without fatal errors, false if fatal
-   *         errors occurred.
-   *
-   * @note Thread Safety: The provided ErrorCollector must not be accessed by
-   *       other threads during parsing. After this method returns, all errors
-   *       have been merged and sorted by byte offset.
-   *
-   * @note This method automatically falls back to single-threaded parsing for
-   *       small files or when chunk boundaries cannot be safely determined.
-   *
-   * @warning Error ordering: Due to parallel execution, errors may not be
-   *          discovered in file order during parsing. However, the final
-   *          error list is sorted by byte offset for consistent output.
-   *
-   * @deprecated Use Parser::parse() with error collection instead:
-   *             ```cpp
-   *             libvroom::Parser parser(num_threads);
-   *             libvroom::ErrorCollector errors(ErrorMode::PERMISSIVE);
-   *             auto result = parser.parse(buf, len, {
-   *                 .dialect = dialect,
-   *                 .errors = &errors
-   *             });
-   *             ```
-   *
-   * @see Parser For the recommended high-level API.
-   * @see ErrorCollector::merge_sorted() For error merging details.
+   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors} instead.
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_two_pass_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
                                   ErrorCollector& errors,
-                                  const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // Handle empty input
-    if (len == 0) return true;
-
-    // Check structural issues first (single-threaded, fast)
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    uint8_t n_threads = out.n_threads;
-
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-
-    // For single-threaded, use the simpler path
-    if (n_threads == 1) {
-      out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-      check_field_counts(buf, len, errors, delim, quote);
-      return !errors.has_fatal_errors();
-    }
-
-    size_t chunk_size = len / n_threads;
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<chunk_result>> second_pass_fut(n_threads);
-
-    // First pass: find chunk boundaries
-    for (int i = 0; i < n_threads; ++i) {
-      first_pass_fut[i] = std::async(std::launch::async,
-          [buf, chunk_size, i, quote]() {
-            return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-          });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-      auto st = first_pass_fut[i].get();
-      chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-      n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-      if (chunk_pos[i] == null_pos) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-        check_field_counts(buf, len, errors, delim, quote);
-        return !errors.has_fatal_errors();
-      }
-    }
-
-    // Second pass: parse with thread-local error collectors
-    ErrorMode mode = errors.mode();
-    for (int i = 0; i < n_threads; ++i) {
-      second_pass_fut[i] = std::async(std::launch::async,
-          [buf, &out, &chunk_pos, i, len, mode, delim, quote]() {
-            return second_pass_chunk_with_errors(buf, chunk_pos[i], chunk_pos[i + 1],
-                                                  &out, i, len, mode, delim, quote);
-          });
-    }
-
-    // Collect results and merge errors
-    std::vector<ErrorCollector> thread_errors;
-    thread_errors.reserve(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-      auto result = second_pass_fut[i].get();
-      out.n_indexes[i] = result.n_indexes;
-      thread_errors.push_back(std::move(result.errors));
-    }
-
-    // Merge all thread-local errors, sorted by byte offset
-    errors.merge_sorted(thread_errors);
-
-    // Check field counts after parsing (single-threaded, scans file linearly)
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                                  const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with detailed error collection (single-threaded).
    *
-   * This method provides comprehensive error detection and collection while
-   * parsing. It runs single-threaded to ensure errors are reported in exact
-   * file order, making it ideal for validation and debugging.
-   *
-   * The method performs the following checks:
-   * - Empty header detection
-   * - Duplicate column name detection
-   * - Mixed line ending warnings
-   * - Quote errors (unclosed quotes, quotes in unquoted fields)
-   * - Inconsistent field counts across rows
-   * - Null byte detection
-   *
-   * @param buf Pointer to the CSV data buffer. Must remain valid during parsing.
-   * @param out The index structure to populate. Must be initialized via init().
-   * @param len Length of the CSV data in bytes.
-   * @param errors ErrorCollector to accumulate parsing errors. The collector's
-   *               mode (STRICT, PERMISSIVE, BEST_EFFORT) controls behavior.
-   *
-   * @return true if parsing completed without fatal errors, false if fatal
-   *         errors occurred or parsing was stopped early (STRICT mode).
-   *
-   * @note This method is single-threaded for precise error position tracking.
-   *       For large files where performance is critical, consider
-   *       parse_two_pass_with_errors() which uses multi-threading.
-   *
-   * @example
-   * @code
-   * libvroom::two_pass parser;
-   * libvroom::index idx = parser.init(length, 1);
-   * libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-   *
-   * bool success = parser.parse_with_errors(buffer, idx, length, errors);
-   *
-   * // Check for errors
-   * if (errors.error_count() > 0) {
-   *     std::cout << "Found " << errors.error_count() << " errors:\n";
-   *     for (const auto& err : errors.get_errors()) {
-   *         std::cout << "Line " << err.line << ", Col " << err.column
-   *                   << ": " << err.message << "\n";
-   *     }
-   * }
-   *
-   * if (!success) {
-   *     std::cerr << "Parsing failed due to fatal errors\n";
-   * }
-   * @endcode
-   *
-   * @deprecated Use Parser::parse() with error collection instead:
-   *             ```cpp
-   *             libvroom::Parser parser(1);  // single-threaded
-   *             libvroom::ErrorCollector errors(ErrorMode::PERMISSIVE);
-   *             auto result = parser.parse(buf, len, {
-   *                 .dialect = dialect,
-   *                 .errors = &errors
-   *             });
-   *             ```
-   *
-   * @see Parser For the recommended high-level API.
-   * @see ErrorCollector For error handling configuration and access.
-   * @see ErrorMode For different error handling strategies.
+   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors} instead.
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_with_errors(const uint8_t* buf, ParseIndex& out, size_t len, ErrorCollector& errors,
-                         const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // Check structural issues first
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    // Single-threaded parsing for accurate error position tracking
-    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-
-    // Check field counts after parsing
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                         const Dialect& dialect = Dialect::csv());
 
   // Check for empty header
-  static bool check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors) {
-    if (len == 0) return true;
-    if (buf[0] == '\n' || buf[0] == '\r') {
-      errors.add_error(ErrorCode::EMPTY_HEADER, ErrorSeverity::ERROR,
-                       1, 1, 0, "Header row is empty", "");
-      return false;
-    }
-    return true;
-  }
+  static bool check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors);
 
   /**
    * @brief Check for duplicate column names in header with dialect support.
    */
   static void check_duplicate_columns(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                      char delimiter = ',', char quote_char = '"') {
-    if (len == 0) return;
-
-    // Find end of first line
-    size_t header_end = 0;
-    bool in_quote = false;
-    while (header_end < len) {
-      if (buf[header_end] == static_cast<uint8_t>(quote_char)) in_quote = !in_quote;
-      else if (!in_quote && (buf[header_end] == '\n' || buf[header_end] == '\r')) break;
-      ++header_end;
-    }
-
-    // Parse header fields
-    std::vector<std::string> fields;
-    std::string current;
-    in_quote = false;
-    for (size_t i = 0; i < header_end; ++i) {
-      if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        in_quote = !in_quote;
-      } else if (!in_quote && buf[i] == static_cast<uint8_t>(delimiter)) {
-        fields.push_back(current);
-        current.clear();
-      } else if (buf[i] != '\r') {
-        current += static_cast<char>(buf[i]);
-      }
-    }
-    fields.push_back(current);
-
-    // Check for duplicates
-    std::unordered_set<std::string> seen;
-    for (size_t i = 0; i < fields.size(); ++i) {
-      if (seen.count(fields[i]) > 0) {
-        errors.add_error(ErrorCode::DUPLICATE_COLUMN_NAMES, ErrorSeverity::WARNING,
-                         1, i + 1, 0, "Duplicate column name: '" + fields[i] + "'", fields[i]);
-      }
-      seen.insert(fields[i]);
-    }
-  }
+                                      char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Check for inconsistent field counts with dialect support.
    */
   static void check_field_counts(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                 char delimiter = ',', char quote_char = '"') {
-    if (len == 0) return;
-
-    size_t expected_fields = 0;
-    size_t current_fields = 1;
-    size_t current_line = 1;
-    size_t line_start = 0;
-    bool in_quote = false;
-    bool header_done = false;
-
-    for (size_t i = 0; i < len; ++i) {
-      if (buf[i] == static_cast<uint8_t>(quote_char)) {
-        in_quote = !in_quote;
-      } else if (!in_quote) {
-        if (buf[i] == static_cast<uint8_t>(delimiter)) {
-          ++current_fields;
-        } else if (buf[i] == '\n') {
-          if (!header_done) {
-            expected_fields = current_fields;
-            header_done = true;
-          } else if (current_fields != expected_fields) {
-            std::ostringstream msg;
-            msg << "Expected " << expected_fields << " fields but found " << current_fields;
-            errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
-                             current_line, 1, line_start, msg.str(),
-                             get_context(buf, len, line_start, 40));
-            if (errors.should_stop()) return;
-          }
-          current_fields = 1;
-          ++current_line;
-          line_start = i + 1;
-        }
-      }
-    }
-
-    // Check last line if no trailing newline
-    if (header_done && current_fields != expected_fields && line_start < len) {
-      std::ostringstream msg;
-      msg << "Expected " << expected_fields << " fields but found " << current_fields;
-      errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
-                       current_line, 1, line_start, msg.str(),
-                       get_context(buf, len, line_start, 40));
-    }
-  }
+                                 char delimiter = ',', char quote_char = '"');
 
   // Check for mixed line endings
-  static void check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors) {
-    bool has_crlf = false;
-    bool has_lf = false;
-    bool has_cr = false;
-
-    for (size_t i = 0; i < len; ++i) {
-      if (buf[i] == '\r') {
-        if (i + 1 < len && buf[i + 1] == '\n') {
-          has_crlf = true;
-          ++i;
-        } else {
-          has_cr = true;
-        }
-      } else if (buf[i] == '\n') {
-        has_lf = true;
-      }
-    }
-
-    int types = (has_crlf ? 1 : 0) + (has_lf ? 1 : 0) + (has_cr ? 1 : 0);
-    if (types > 1) {
-      errors.add_error(ErrorCode::MIXED_LINE_ENDINGS, ErrorSeverity::WARNING,
-                       1, 1, 0, "Mixed line endings detected", "");
-    }
-  }
+  static void check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors);
 
   /**
    * @brief Perform full CSV validation with comprehensive error checking.
    *
-   * This method is functionally equivalent to parse_with_errors() but named
-   * to emphasize its validation purpose. Use this when your primary goal is
-   * to check a CSV file for errors rather than extract data.
-   *
-   * Validation checks performed:
-   * - Empty header row detection
-   * - Duplicate column name detection (warns on duplicates)
-   * - Mixed line endings detection (CRLF, LF, CR combinations)
-   * - Quote handling errors (unclosed quotes, quotes in unquoted fields)
-   * - Invalid characters after closing quotes
-   * - Inconsistent field counts across rows
-   * - Null byte detection
-   *
-   * @param buf Pointer to the CSV data buffer.
-   * @param out The index structure to populate (from init()).
-   * @param len Length of the CSV data in bytes.
-   * @param errors ErrorCollector to accumulate validation errors.
-   * @param dialect The dialect to use for validation (default: CSV with comma and double-quote).
-   *
-   * @return true if validation passed without fatal errors, false otherwise.
-   *
-   * @deprecated Use Parser::parse() with error collection instead (same functionality):
-   *             ```cpp
-   *             libvroom::Parser parser;
-   *             libvroom::ErrorCollector errors(ErrorMode::PERMISSIVE);
-   *             auto result = parser.parse(buf, len, {
-   *                 .dialect = dialect,
-   *                 .errors = &errors
-   *             });
-   *             ```
-   *
-   * @see Parser For the recommended high-level API.
-   * @see ErrorCollector For accessing validation results
+   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors} instead.
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_validate(const uint8_t* buf, ParseIndex& out, size_t len, ErrorCollector& errors,
-                      const Dialect& dialect = Dialect::csv()) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // Check structural issues first
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
-
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
-
-    // Parse with error collection
-    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-
-    // Check field counts after parsing
-    check_field_counts(buf, len, errors, delim, quote);
-
-    return !errors.has_fatal_errors();
-  }
+                      const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Initialize an index structure for parsing.
-   *
-   * Allocates memory for storing field separator positions. The index must be
-   * initialized before calling any parse method. The allocated size is based on
-   * the maximum possible number of fields (one per byte in worst case).
-   *
-   * @param len Length of the CSV buffer in bytes. Determines maximum index capacity.
-   * @param n_threads Number of threads to use for parsing. Use 1 for single-threaded
-   *                  parsing, or a higher value for multi-threaded parsing.
-   *                  Recommended: std::thread::hardware_concurrency() for large files.
-   *
-   * @return An initialized index structure ready for parsing.
-   *
-   * @note The returned index owns its memory and will free it on destruction.
-   *       Use move semantics to transfer ownership.
-   *
-   * @warning For very large files, this allocates len * sizeof(uint64_t) bytes
-   *          for the indexes array. Consider the memory implications.
-   *
-   * @example
-   * @code
-   * libvroom::two_pass parser;
-   *
-   * // Single-threaded parsing
-   * libvroom::index idx = parser.init(buffer_length, 1);
-   *
-   * // Multi-threaded parsing with 4 threads
-   * libvroom::index idx = parser.init(buffer_length, 4);
-   *
-   * // Use hardware concurrency
-   * libvroom::index idx = parser.init(buffer_length,
-   *                                   std::thread::hardware_concurrency());
-   * @endcode
    */
-  ParseIndex init(size_t len, size_t n_threads) {
-    ParseIndex out;
-    // Ensure at least 1 thread for valid memory allocation
-    if (n_threads == 0) n_threads = 1;
-    out.n_threads = n_threads;
-
-    // Allocate n_indexes array with RAII ownership
-    out.n_indexes_ptr_ = std::make_unique<uint64_t[]>(n_threads);
-    out.n_indexes = out.n_indexes_ptr_.get();
-
-    // Allocate space for interleaved index storage.
-    //
-    // With multi-threaded parsing, indexes are stored in an interleaved pattern:
-    // thread 0 writes to positions 0, n_threads, 2*n_threads, ...
-    // thread 1 writes to positions 1, n_threads+1, 2*n_threads+1, ...
-    //
-    // For a file with len bytes, the maximum number of separators is len (worst case:
-    // every byte is a separator). In multi-threaded mode, if one thread finds m
-    // separators, it writes to positions thread_id, thread_id + n_threads, ...,
-    // thread_id + (m-1) * n_threads.
-    //
-    // The maximum index accessed is: (n_threads - 1) + (len - 1) * n_threads + 7 * n_threads
-    // (the +7*n_threads is for speculative SIMD writes that always write 8 elements).
-    //
-    // This simplifies to approximately len * n_threads + 8 * n_threads.
-    //
-    // For single-threaded parsing (n_threads == 1), we only need len + 8 elements.
-    // For multi-threaded parsing, we need the full interleaved size.
-    //
-    // See GitHub issues #264 and #265 for details.
-    size_t allocation_size;
-    if (n_threads == 1) {
-      // Single-threaded: simple allocation with padding for speculative writes
-      allocation_size = len + 8;
-    } else {
-      // Multi-threaded: need space for interleaved storage
-      // Maximum index = (len - 1) * n_threads + (n_threads - 1) + 7 * n_threads
-      //               = len * n_threads - n_threads + n_threads - 1 + 7 * n_threads
-      //               = len * n_threads + 7 * n_threads - 1
-      //               < (len + 8) * n_threads
-      allocation_size = (len + 8) * n_threads;
-    }
-
-    // Allocate indexes array with RAII ownership
-    out.indexes_ptr_ = std::make_unique<uint64_t[]>(allocation_size);
-    out.indexes = out.indexes_ptr_.get();
-
-    return out;
-  }
+  ParseIndex init(size_t len, size_t n_threads);
 
   /**
    * @brief Initialize an index structure with overflow validation.
-   *
-   * This is the safe version of init() that validates all size calculations
-   * before memory allocation to prevent integer overflow vulnerabilities.
-   *
-   * @param len Length of the CSV buffer in bytes. Determines maximum index capacity.
-   * @param n_threads Number of threads to use for parsing. Use 1 for single-threaded
-   *                  parsing, or a higher value for multi-threaded parsing.
-   * @param errors Optional ErrorCollector for reporting size limit violations.
-   *               If nullptr and an overflow would occur, an exception is thrown.
-   *
-   * @return An initialized index structure ready for parsing, or an empty index
-   *         with nullptr indexes if allocation would overflow.
-   *
-   * @throws std::runtime_error if overflow detected and errors is nullptr.
-   *
-   * @note For most use cases, prefer using Parser::parse() which calls this
-   *       method internally with appropriate size limit validation.
-   *
-   * @see init() For the non-validating version (deprecated for untrusted input).
-   * @see SizeLimits For file size limits that should be checked before calling this.
    */
-  ParseIndex init_safe(size_t len, size_t n_threads, ErrorCollector* errors = nullptr) {
-    ParseIndex out;
-    // Ensure at least 1 thread for valid memory allocation
-    if (n_threads == 0) n_threads = 1;
-    out.n_threads = n_threads;
-
-    // Calculate allocation size with overflow checking
-    size_t allocation_size;
-    bool overflow = false;
-
-    if (n_threads == 1) {
-      // Single-threaded: simple allocation with padding for speculative writes
-      // allocation_size = len + 8
-      if (len > std::numeric_limits<size_t>::max() - 8) {
-        overflow = true;
-      } else {
-        allocation_size = len + 8;
-      }
-    } else {
-      // Multi-threaded: need space for interleaved storage
-      // allocation_size = (len + 8) * n_threads
-      size_t len_plus_8;
-      if (len > std::numeric_limits<size_t>::max() - 8) {
-        overflow = true;
-      } else {
-        len_plus_8 = len + 8;
-        // Check (len + 8) * n_threads for overflow
-        if (len_plus_8 > std::numeric_limits<size_t>::max() / n_threads) {
-          overflow = true;
-        } else {
-          allocation_size = len_plus_8 * n_threads;
-        }
-      }
-    }
-
-    // Check final allocation: allocation_size * sizeof(uint64_t)
-    if (!overflow && allocation_size > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
-      overflow = true;
-    }
-
-    if (overflow) {
-      std::string msg = "Index allocation would overflow: len=" + std::to_string(len) +
-                        ", n_threads=" + std::to_string(n_threads);
-      if (errors != nullptr) {
-        errors->add_error(ErrorCode::INDEX_ALLOCATION_OVERFLOW, ErrorSeverity::FATAL,
-                          1, 1, 0, msg);
-        // Return empty index to signal failure
-        return out;
-      } else {
-        throw std::runtime_error(msg);
-      }
-    }
-
-    // Safe to allocate
-    out.n_indexes = new uint64_t[n_threads];
-    out.indexes = new uint64_t[allocation_size];
-    return out;
-  }
+  ParseIndex init_safe(size_t len, size_t n_threads, ErrorCollector* errors = nullptr);
 };
 
 /// @brief Backward-compatible alias for TwoPass.

--- a/src/two_pass.cpp
+++ b/src/two_pass.cpp
@@ -1,0 +1,1147 @@
+/**
+ * @file two_pass.cpp
+ * @brief Implementation of TwoPass parser methods.
+ *
+ * This file contains non-performance-critical implementations from two_pass.h,
+ * including scalar parsing fallbacks, helper functions, and serialization.
+ * SIMD hot-path functions remain in the header for inlining.
+ */
+
+#include "two_pass.h"
+#include <algorithm>
+
+namespace libvroom {
+
+//-----------------------------------------------------------------------------
+// ParseIndex class implementations
+//-----------------------------------------------------------------------------
+
+void ParseIndex::write(const std::string& filename) {
+    std::FILE* fp = std::fopen(filename.c_str(), "wb");
+    if (!fp) {
+        throw std::runtime_error("error opening file for writing");
+    }
+    if (!((std::fwrite(&columns, sizeof(uint64_t), 1, fp) == 1) &&
+          (std::fwrite(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
+          (std::fwrite(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
+        std::fclose(fp);
+        throw std::runtime_error("error writing index");
+    }
+    size_t total_size = 0;
+    for (int i = 0; i < n_threads; ++i) {
+        total_size += n_indexes[i];
+    }
+    if (std::fwrite(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
+        std::fclose(fp);
+        throw std::runtime_error("error writing index2");
+    }
+
+    std::fclose(fp);
+}
+
+void ParseIndex::read(const std::string& filename) {
+    std::FILE* fp = std::fopen(filename.c_str(), "rb");
+    if (!fp) {
+        throw std::runtime_error("error opening file for reading");
+    }
+    if (!((std::fread(&columns, sizeof(uint64_t), 1, fp) == 1) &&
+          (std::fread(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
+          (std::fread(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
+        std::fclose(fp);
+        throw std::runtime_error("error reading index");
+    }
+    size_t total_size = 0;
+    for (int i = 0; i < n_threads; ++i) {
+        total_size += n_indexes[i];
+    }
+    if (std::fread(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
+        std::fclose(fp);
+        throw std::runtime_error("error reading index2");
+    }
+
+    std::fclose(fp);
+}
+
+//-----------------------------------------------------------------------------
+// TwoPass scalar first pass implementations
+//-----------------------------------------------------------------------------
+
+TwoPass::Stats TwoPass::first_pass_chunk(const uint8_t* buf, size_t start, size_t end,
+                                          char quote_char) {
+    Stats out;
+    uint64_t i = start;
+    bool needs_even = out.first_even_nl == null_pos;
+    bool needs_odd = out.first_odd_nl == null_pos;
+    while (i < end) {
+        // Support LF, CRLF, and CR-only line endings
+        // Check for line ending: \n, or \r not followed by \n
+        bool is_line_ending = false;
+        if (buf[i] == '\n') {
+            is_line_ending = true;
+        } else if (buf[i] == '\r') {
+            // CR is a line ending only if not followed by LF
+            if (i + 1 >= end || buf[i + 1] != '\n') {
+                is_line_ending = true;
+            }
+            // If followed by LF, skip this CR (the LF will be the line ending)
+        }
+
+        if (is_line_ending) {
+            bool is_even = (out.n_quotes % 2) == 0;
+            if (needs_even && is_even) {
+                out.first_even_nl = i;
+                needs_even = false;
+            } else if (needs_odd && !is_even) {
+                out.first_odd_nl = i;
+                needs_odd = false;
+            }
+        } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            ++out.n_quotes;
+        }
+        ++i;
+    }
+    return out;
+}
+
+TwoPass::Stats TwoPass::first_pass_naive(const uint8_t* buf, size_t start, size_t end) {
+    Stats out;
+    uint64_t i = start;
+    while (i < end) {
+        // Support LF, CRLF, and CR-only line endings
+        if (buf[i] == '\n') {
+            out.first_even_nl = i;
+            return out;
+        } else if (buf[i] == '\r') {
+            // CR is a line ending only if not followed by LF
+            if (i + 1 >= end || buf[i + 1] != '\n') {
+                out.first_even_nl = i;
+                return out;
+            }
+            // If followed by LF, continue - the LF will be the line ending
+        }
+        ++i;
+    }
+    return out;
+}
+
+TwoPass::quote_state TwoPass::get_quotation_state(const uint8_t* buf, size_t start,
+                                                   char delimiter, char quote_char) {
+    // 64kb
+    constexpr int SPECULATION_SIZE = 1 << 16;
+
+    if (start == 0) {
+        return UNQUOTED;
+    }
+
+    size_t end = start > SPECULATION_SIZE ? start - SPECULATION_SIZE : 0;
+    size_t i = start;
+    size_t num_quotes = 0;
+
+    // FIXED: Use i > end to avoid unsigned underflow when i reaches 0
+    while (i > end) {
+        if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            // q-o case
+            if (i + 1 < start && is_other(buf[i + 1], delimiter, quote_char)) {
+                return num_quotes % 2 == 0 ? QUOTED : UNQUOTED;
+            }
+
+            // o-q case
+            else if (i > end && is_other(buf[i - 1], delimiter, quote_char)) {
+                return num_quotes % 2 == 0 ? UNQUOTED : QUOTED;
+            }
+            ++num_quotes;
+        }
+        --i;
+    }
+    // Check the last position (i == end)
+    if (buf[end] == static_cast<uint8_t>(quote_char)) {
+        ++num_quotes;
+    }
+    return AMBIGUOUS;
+}
+
+TwoPass::Stats TwoPass::first_pass_speculate(const uint8_t* buf, size_t start, size_t end,
+                                              char delimiter, char quote_char) {
+    auto is_quoted = get_quotation_state(buf, start, delimiter, quote_char);
+
+    for (size_t i = start; i < end; ++i) {
+        // Support LF, CRLF, and CR-only line endings
+        bool is_line_ending = false;
+        if (buf[i] == '\n') {
+            is_line_ending = true;
+        } else if (buf[i] == '\r') {
+            // CR is a line ending only if not followed by LF
+            if (i + 1 >= end || buf[i + 1] != '\n') {
+                is_line_ending = true;
+            }
+        }
+
+        if (is_line_ending) {
+            if (is_quoted == UNQUOTED || is_quoted == AMBIGUOUS) {
+                return {0, i, null_pos};
+            } else {
+                return {1, null_pos, i};
+            }
+        } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            is_quoted = is_quoted == UNQUOTED ? QUOTED : UNQUOTED;
+        }
+    }
+    return {0, null_pos, null_pos};
+}
+
+//-----------------------------------------------------------------------------
+// TwoPass helper functions
+//-----------------------------------------------------------------------------
+
+std::string TwoPass::get_context(const uint8_t* buf, size_t len, size_t pos,
+                                  size_t context_size) {
+    // Handle empty buffer case
+    if (len == 0 || buf == nullptr) return "";
+
+    // Bounds check
+    size_t safe_pos = pos < len ? pos : len - 1;
+    size_t ctx_start = safe_pos > context_size ? safe_pos - context_size : 0;
+    size_t ctx_end = std::min(safe_pos + context_size, len);
+
+    std::string ctx;
+    // Reserve space to avoid reallocations (worst case: every char becomes 2 chars like \n)
+    ctx.reserve((ctx_end - ctx_start) * 2);
+
+    for (size_t i = ctx_start; i < ctx_end; ++i) {
+        char c = static_cast<char>(buf[i]);
+        if (c == '\n') ctx += "\\n";
+        else if (c == '\r') ctx += "\\r";
+        else if (c == '\0') ctx += "\\0";
+        else if (c >= 32 && c < 127) ctx += c;
+        else ctx += "?";
+    }
+    return ctx;
+}
+
+void TwoPass::get_line_column(const uint8_t* buf, size_t buf_len, size_t offset,
+                               size_t& line, size_t& column) {
+    line = 1;
+    column = 1;
+    // Ensure we don't read past buffer bounds
+    size_t safe_offset = offset < buf_len ? offset : buf_len;
+    for (size_t i = 0; i < safe_offset; ++i) {
+        if (buf[i] == '\n') {
+            ++line;
+            column = 1;
+        } else if (buf[i] != '\r') {
+            ++column;
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------
+// TwoPass scalar second pass implementations
+//-----------------------------------------------------------------------------
+
+uint64_t TwoPass::second_pass_chunk(const uint8_t* buf, size_t start, size_t end,
+                                     ParseIndex* out, size_t thread_id,
+                                     ErrorCollector* errors,
+                                     size_t total_len,
+                                     char delimiter, char quote_char) {
+    uint64_t pos = start;
+    size_t n_indexes = 0;
+    size_t i = thread_id;
+    csv_state s = RECORD_START;
+
+    while (pos < end) {
+        uint8_t value = buf[pos];
+
+        // Use effective buffer length for bounds checking
+        size_t buf_len = total_len > 0 ? total_len : end;
+
+        // Check for null bytes
+        if (value == '\0' && errors) {
+            size_t line, col;
+            get_line_column(buf, buf_len, pos, line, col);
+            errors->add_error(ErrorCode::NULL_BYTE, ErrorSeverity::ERROR,
+                              line, col, pos, "Null byte in data",
+                              get_context(buf, buf_len, pos));
+            if (errors->should_stop()) return n_indexes;
+            ++pos;
+            continue;
+        }
+
+        StateResult result;
+        if (value == static_cast<uint8_t>(quote_char)) {
+            result = quoted_state(s);
+            if (result.error != ErrorCode::NONE && errors) {
+                size_t line, col;
+                get_line_column(buf, buf_len, pos, line, col);
+                std::string msg = "Quote character '";
+                msg += quote_char;
+                msg += "' in unquoted field";
+                errors->add_error(result.error, ErrorSeverity::ERROR,
+                                  line, col, pos, msg,
+                                  get_context(buf, buf_len, pos));
+                if (errors->should_stop()) return n_indexes;
+            }
+            s = result.state;
+        } else if (value == static_cast<uint8_t>(delimiter)) {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            result = comma_state(s);
+            s = result.state;
+        } else if (value == '\n') {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            result = newline_state(s);
+            s = result.state;
+        } else if (value == '\r') {
+            // Support CR-only line endings: CR is a line ending if not followed by LF
+            bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
+            if (is_line_ending && s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+                result = newline_state(s);
+                s = result.state;
+            }
+            // If CR is followed by LF (CRLF), treat CR as regular character
+            // The LF will be the line ending; CR will be stripped during value extraction
+        } else {
+            result = other_state(s);
+            if (result.error != ErrorCode::NONE && errors) {
+                size_t line, col;
+                get_line_column(buf, buf_len, pos, line, col);
+                std::string msg = "Invalid character after closing quote '";
+                msg += quote_char;
+                msg += "'";
+                errors->add_error(result.error, ErrorSeverity::ERROR,
+                                  line, col, pos, msg,
+                                  get_context(buf, buf_len, pos));
+                if (errors->should_stop()) return n_indexes;
+            }
+            s = result.state;
+        }
+        ++pos;
+    }
+
+    // Use effective buffer length for bounds checking
+    size_t buf_len = total_len > 0 ? total_len : end;
+
+    // Check for unclosed quote at end of chunk
+    if (s == QUOTED_FIELD && errors && end == buf_len) {
+        size_t line, col;
+        get_line_column(buf, buf_len, pos > 0 ? pos - 1 : 0, line, col);
+        std::string msg = "Unclosed quote '";
+        msg += quote_char;
+        msg += "' at end of file";
+        errors->add_error(ErrorCode::UNCLOSED_QUOTE, ErrorSeverity::FATAL,
+                          line, col, pos, msg,
+                          get_context(buf, buf_len, pos > 20 ? pos - 20 : 0));
+    }
+
+    return n_indexes;
+}
+
+uint64_t TwoPass::second_pass_chunk_throwing(const uint8_t* buf, size_t start, size_t end,
+                                              ParseIndex* out, size_t thread_id,
+                                              char delimiter, char quote_char) {
+    uint64_t pos = start;
+    size_t n_indexes = 0;
+    size_t i = thread_id;
+    csv_state s = RECORD_START;
+
+    while (pos < end) {
+        uint8_t value = buf[pos];
+        StateResult result;
+        if (value == static_cast<uint8_t>(quote_char)) {
+            result = quoted_state(s);
+            if (result.error != ErrorCode::NONE) {
+                std::string msg = "Quote character '";
+                msg += quote_char;
+                msg += "' in unquoted field";
+                throw std::runtime_error(msg);
+            }
+            s = result.state;
+        } else if (value == static_cast<uint8_t>(delimiter)) {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            s = comma_state(s).state;
+        } else if (value == '\n') {
+            if (s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+            }
+            s = newline_state(s).state;
+        } else if (value == '\r') {
+            // Support CR-only line endings: CR is a line ending if not followed by LF
+            bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
+            if (is_line_ending && s != QUOTED_FIELD) {
+                i = add_position(out, i, pos);
+                ++n_indexes;
+                s = newline_state(s).state;
+            }
+            // If CR is followed by LF (CRLF), treat CR as regular character
+        } else {
+            result = other_state(s);
+            if (result.error != ErrorCode::NONE) {
+                std::string msg = "Invalid character after closing quote '";
+                msg += quote_char;
+                msg += "'";
+                throw std::runtime_error(msg);
+            }
+            s = result.state;
+        }
+        ++pos;
+    }
+    return n_indexes;
+}
+
+//-----------------------------------------------------------------------------
+// TwoPass orchestration methods
+//-----------------------------------------------------------------------------
+
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
+bool TwoPass::parse_speculate(const uint8_t* buf, ParseIndex& out, size_t len,
+                               const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+    uint8_t n_threads = out.n_threads;
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    size_t chunk_size = len / n_threads;
+    // If chunk size is too small, small chunks may not contain any newlines,
+    // causing first_pass_speculate to return null_pos. Fall back to single-threaded.
+    if (chunk_size < 64) {
+        // CRITICAL: Must update n_threads to 1 for correct stride in write()
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<Stats>> first_pass_fut(n_threads);
+    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, delim, quote]() {
+                return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+        chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            // CRITICAL: Must update n_threads to 1 for correct stride in write()
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+            return true;
+        }
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [buf, &out, &chunk_pos, i, delim, quote]() {
+                return second_pass_simd(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
+            });
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        out.n_indexes[i] = second_pass_fut[i].get();
+    }
+
+    return true;
+}
+
+bool TwoPass::parse_two_pass(const uint8_t* buf, ParseIndex& out, size_t len,
+                              const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+    uint8_t n_threads = out.n_threads;
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    size_t chunk_size = len / n_threads;
+    // If chunk size is too small, small chunks may not contain any newlines,
+    // causing first_pass_chunk to return null_pos. Fall back to single-threaded.
+    if (chunk_size < 64) {
+        // CRITICAL: Must update n_threads to 1 for correct stride in write()
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+        return true;
+    }
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<Stats>> first_pass_fut(n_threads);
+    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, quote]() {
+                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    size_t n_quotes = st.n_quotes;
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+        n_quotes += st.n_quotes;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            // CRITICAL: Must update n_threads to 1 for correct stride in write()
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+            return true;
+        }
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [buf, &out, &chunk_pos, i, delim, quote]() {
+                return second_pass_chunk_throwing(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
+            });
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        out.n_indexes[i] = second_pass_fut[i].get();
+    }
+
+    return true;
+}
+
+bool TwoPass::parse(const uint8_t* buf, ParseIndex& out, size_t len,
+                     const Dialect& dialect) {
+    return parse_speculate(buf, out, len, dialect);
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_END
+
+TwoPass::branchless_chunk_result TwoPass::second_pass_branchless_chunk_with_errors(
+    const BranchlessStateMachine& sm,
+    const uint8_t* buf, size_t start, size_t end,
+    ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode) {
+    branchless_chunk_result result;
+    result.errors.set_mode(mode);
+    result.n_indexes = second_pass_branchless_with_errors(
+        sm, buf, start, end, out->indexes, thread_id, out->n_threads,
+        &result.errors, total_len);
+    return result;
+}
+
+bool TwoPass::parse_branchless_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
+                                            ErrorCollector& errors,
+                                            const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+    char escape = dialect.escape_char;
+    bool double_quote = dialect.double_quote;
+
+    // Handle empty input
+    if (len == 0) return true;
+
+    // Check structural issues first (single-threaded, fast)
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    BranchlessStateMachine sm(delim, quote, escape, double_quote);
+    uint8_t n_threads = out.n_threads;
+
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+
+    // For single-threaded, use the simpler path
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_branchless_with_errors(
+            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+        check_field_counts(buf, len, errors, delim, quote);
+        return !errors.has_fatal_errors();
+    }
+
+    size_t chunk_size = len / n_threads;
+
+    // If chunk size is too small, fall back to single-threaded
+    if (chunk_size < 64) {
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_branchless_with_errors(
+            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+        check_field_counts(buf, len, errors, delim, quote);
+        return !errors.has_fatal_errors();
+    }
+
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<Stats>> first_pass_fut(n_threads);
+    std::vector<std::future<branchless_chunk_result>> second_pass_fut(n_threads);
+
+    // First pass: find chunk boundaries
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, quote]() {
+                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    size_t n_quotes = st.n_quotes;
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+        n_quotes += st.n_quotes;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_branchless_with_errors(
+                sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+            check_field_counts(buf, len, errors, delim, quote);
+            return !errors.has_fatal_errors();
+        }
+    }
+
+    // Second pass: parse with thread-local error collectors using branchless
+    ErrorMode mode = errors.mode();
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [sm, buf, &out, &chunk_pos, i, len, mode]() {
+                return second_pass_branchless_chunk_with_errors(
+                    sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i, len, mode);
+            });
+    }
+
+    // Collect results and merge errors
+    std::vector<ErrorCollector> thread_errors;
+    thread_errors.reserve(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        auto result = second_pass_fut[i].get();
+        out.n_indexes[i] = result.n_indexes;
+        thread_errors.push_back(std::move(result.errors));
+    }
+
+    // Merge all thread-local errors, sorted by byte offset
+    errors.merge_sorted(thread_errors);
+
+    // Check field counts after parsing (single-threaded, scans file linearly)
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
+bool TwoPass::parse_branchless(const uint8_t* buf, ParseIndex& out, size_t len,
+                                const Dialect& dialect) {
+    BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char,
+                               dialect.escape_char, dialect.double_quote);
+    uint8_t n_threads = out.n_threads;
+
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+        return true;
+    }
+
+    // Multi-threaded parsing with branchless second pass
+    size_t chunk_size = len / n_threads;
+
+    // If chunk size is too small, fall back to single-threaded
+    if (chunk_size < 64) {
+        out.n_threads = 1;
+        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+        return true;
+    }
+
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<Stats>> first_pass_fut(n_threads);
+    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // First pass: find chunk boundaries (reuse existing implementation)
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, delim, quote]() {
+                return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+        chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+            return true;
+        }
+    }
+
+    // Second pass: branchless parsing of each chunk
+    // Capture sm by value since it's small (~300 bytes) and we need thread safety
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [sm, buf, &out, &chunk_pos, i]() {
+                return second_pass_simd_branchless(sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i);
+            });
+    }
+
+    for (int i = 0; i < n_threads; ++i) {
+        out.n_indexes[i] = second_pass_fut[i].get();
+    }
+
+    return true;
+}
+
+bool TwoPass::parse_auto(const uint8_t* buf, ParseIndex& out, size_t len,
+                          ErrorCollector& errors, DetectionResult* detected,
+                          const DetectionOptions& detection_options) {
+    // Perform dialect detection
+    DialectDetector detector(detection_options);
+    DetectionResult result = detector.detect(buf, len);
+
+    // Store detection result if requested
+    if (detected != nullptr) {
+        *detected = result;
+    }
+
+    // Use detected dialect if successful, otherwise fall back to standard CSV
+    Dialect dialect = result.success() ? result.dialect : Dialect::csv();
+
+    // Add info message about detected dialect
+    if (result.success()) {
+        Dialect csv = Dialect::csv();
+        if (result.dialect.delimiter != csv.delimiter ||
+            result.dialect.quote_char != csv.quote_char) {
+            std::string msg = "Auto-detected dialect: " + result.dialect.to_string();
+            errors.add_error(ErrorCode::NONE, ErrorSeverity::WARNING,
+                             1, 1, 0, msg, "");
+        }
+    }
+
+    // Parse with detected dialect
+    return parse_two_pass_with_errors(buf, out, len, errors, dialect);
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_END
+
+DetectionResult TwoPass::detect_dialect(const uint8_t* buf, size_t len,
+                                         const DetectionOptions& options) {
+    DialectDetector detector(options);
+    return detector.detect(buf, len);
+}
+
+TwoPass::chunk_result TwoPass::second_pass_chunk_with_errors(
+    const uint8_t* buf, size_t start, size_t end,
+    ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode,
+    char delimiter, char quote_char) {
+    chunk_result result;
+    result.errors.set_mode(mode);
+    result.n_indexes = second_pass_chunk(buf, start, end, out, thread_id,
+                                         &result.errors, total_len, delimiter, quote_char);
+    return result;
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_START
+
+bool TwoPass::parse_two_pass_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
+                                          ErrorCollector& errors,
+                                          const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // Handle empty input
+    if (len == 0) return true;
+
+    // Check structural issues first (single-threaded, fast)
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    uint8_t n_threads = out.n_threads;
+
+    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+    if (n_threads == 0) n_threads = 1;
+
+    // For single-threaded, use the simpler path
+    if (n_threads == 1) {
+        out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+        check_field_counts(buf, len, errors, delim, quote);
+        return !errors.has_fatal_errors();
+    }
+
+    size_t chunk_size = len / n_threads;
+    std::vector<uint64_t> chunk_pos(n_threads + 1);
+    std::vector<std::future<Stats>> first_pass_fut(n_threads);
+    std::vector<std::future<chunk_result>> second_pass_fut(n_threads);
+
+    // First pass: find chunk boundaries
+    for (int i = 0; i < n_threads; ++i) {
+        first_pass_fut[i] = std::async(std::launch::async,
+            [buf, chunk_size, i, quote]() {
+                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+            });
+    }
+
+    auto st = first_pass_fut[0].get();
+    size_t n_quotes = st.n_quotes;
+    chunk_pos[0] = 0;
+    for (int i = 1; i < n_threads; ++i) {
+        auto st = first_pass_fut[i].get();
+        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+        n_quotes += st.n_quotes;
+    }
+    chunk_pos[n_threads] = len;
+
+    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+    for (int i = 1; i < n_threads; ++i) {
+        if (chunk_pos[i] == null_pos) {
+            out.n_threads = 1;
+            out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+            check_field_counts(buf, len, errors, delim, quote);
+            return !errors.has_fatal_errors();
+        }
+    }
+
+    // Second pass: parse with thread-local error collectors
+    ErrorMode mode = errors.mode();
+    for (int i = 0; i < n_threads; ++i) {
+        second_pass_fut[i] = std::async(std::launch::async,
+            [buf, &out, &chunk_pos, i, len, mode, delim, quote]() {
+                return second_pass_chunk_with_errors(buf, chunk_pos[i], chunk_pos[i + 1],
+                                                      &out, i, len, mode, delim, quote);
+            });
+    }
+
+    // Collect results and merge errors
+    std::vector<ErrorCollector> thread_errors;
+    thread_errors.reserve(n_threads);
+
+    for (int i = 0; i < n_threads; ++i) {
+        auto result = second_pass_fut[i].get();
+        out.n_indexes[i] = result.n_indexes;
+        thread_errors.push_back(std::move(result.errors));
+    }
+
+    // Merge all thread-local errors, sorted by byte offset
+    errors.merge_sorted(thread_errors);
+
+    // Check field counts after parsing (single-threaded, scans file linearly)
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+bool TwoPass::parse_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
+                                 ErrorCollector& errors,
+                                 const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // Check structural issues first
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    // Single-threaded parsing for accurate error position tracking
+    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+
+    // Check field counts after parsing
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+bool TwoPass::parse_validate(const uint8_t* buf, ParseIndex& out, size_t len,
+                              ErrorCollector& errors,
+                              const Dialect& dialect) {
+    char delim = dialect.delimiter;
+    char quote = dialect.quote_char;
+
+    // Check structural issues first
+    check_empty_header(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    check_duplicate_columns(buf, len, errors, delim, quote);
+    if (errors.should_stop()) return false;
+
+    check_line_endings(buf, len, errors);
+    if (errors.should_stop()) return false;
+
+    // Parse with error collection
+    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+
+    // Check field counts after parsing
+    check_field_counts(buf, len, errors, delim, quote);
+
+    return !errors.has_fatal_errors();
+}
+
+LIBVROOM_SUPPRESS_DEPRECATION_END
+
+//-----------------------------------------------------------------------------
+// TwoPass validation functions
+//-----------------------------------------------------------------------------
+
+bool TwoPass::check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors) {
+    if (len == 0) return true;
+    if (buf[0] == '\n' || buf[0] == '\r') {
+        errors.add_error(ErrorCode::EMPTY_HEADER, ErrorSeverity::ERROR,
+                         1, 1, 0, "Header row is empty", "");
+        return false;
+    }
+    return true;
+}
+
+void TwoPass::check_duplicate_columns(const uint8_t* buf, size_t len, ErrorCollector& errors,
+                                       char delimiter, char quote_char) {
+    if (len == 0) return;
+
+    // Find end of first line
+    size_t header_end = 0;
+    bool in_quote = false;
+    while (header_end < len) {
+        if (buf[header_end] == static_cast<uint8_t>(quote_char)) in_quote = !in_quote;
+        else if (!in_quote && (buf[header_end] == '\n' || buf[header_end] == '\r')) break;
+        ++header_end;
+    }
+
+    // Parse header fields
+    std::vector<std::string> fields;
+    std::string current;
+    in_quote = false;
+    for (size_t i = 0; i < header_end; ++i) {
+        if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            in_quote = !in_quote;
+        } else if (!in_quote && buf[i] == static_cast<uint8_t>(delimiter)) {
+            fields.push_back(current);
+            current.clear();
+        } else if (buf[i] != '\r') {
+            current += static_cast<char>(buf[i]);
+        }
+    }
+    fields.push_back(current);
+
+    // Check for duplicates
+    std::unordered_set<std::string> seen;
+    for (size_t i = 0; i < fields.size(); ++i) {
+        if (seen.count(fields[i]) > 0) {
+            errors.add_error(ErrorCode::DUPLICATE_COLUMN_NAMES, ErrorSeverity::WARNING,
+                             1, i + 1, 0, "Duplicate column name: '" + fields[i] + "'", fields[i]);
+        }
+        seen.insert(fields[i]);
+    }
+}
+
+void TwoPass::check_field_counts(const uint8_t* buf, size_t len, ErrorCollector& errors,
+                                  char delimiter, char quote_char) {
+    if (len == 0) return;
+
+    size_t expected_fields = 0;
+    size_t current_fields = 1;
+    size_t current_line = 1;
+    size_t line_start = 0;
+    bool in_quote = false;
+    bool header_done = false;
+
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] == static_cast<uint8_t>(quote_char)) {
+            in_quote = !in_quote;
+        } else if (!in_quote) {
+            if (buf[i] == static_cast<uint8_t>(delimiter)) {
+                ++current_fields;
+            } else if (buf[i] == '\n') {
+                if (!header_done) {
+                    expected_fields = current_fields;
+                    header_done = true;
+                } else if (current_fields != expected_fields) {
+                    std::ostringstream msg;
+                    msg << "Expected " << expected_fields << " fields but found " << current_fields;
+                    errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
+                                     current_line, 1, line_start, msg.str(),
+                                     get_context(buf, len, line_start, 40));
+                    if (errors.should_stop()) return;
+                }
+                current_fields = 1;
+                ++current_line;
+                line_start = i + 1;
+            }
+        }
+    }
+
+    // Check last line if no trailing newline
+    if (header_done && current_fields != expected_fields && line_start < len) {
+        std::ostringstream msg;
+        msg << "Expected " << expected_fields << " fields but found " << current_fields;
+        errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
+                         current_line, 1, line_start, msg.str(),
+                         get_context(buf, len, line_start, 40));
+    }
+}
+
+void TwoPass::check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors) {
+    bool has_crlf = false;
+    bool has_lf = false;
+    bool has_cr = false;
+
+    for (size_t i = 0; i < len; ++i) {
+        if (buf[i] == '\r') {
+            if (i + 1 < len && buf[i + 1] == '\n') {
+                has_crlf = true;
+                ++i;
+            } else {
+                has_cr = true;
+            }
+        } else if (buf[i] == '\n') {
+            has_lf = true;
+        }
+    }
+
+    int types = (has_crlf ? 1 : 0) + (has_lf ? 1 : 0) + (has_cr ? 1 : 0);
+    if (types > 1) {
+        errors.add_error(ErrorCode::MIXED_LINE_ENDINGS, ErrorSeverity::WARNING,
+                         1, 1, 0, "Mixed line endings detected", "");
+    }
+}
+
+//-----------------------------------------------------------------------------
+// TwoPass initialization functions
+//-----------------------------------------------------------------------------
+
+ParseIndex TwoPass::init(size_t len, size_t n_threads) {
+    ParseIndex out;
+    // Ensure at least 1 thread for valid memory allocation
+    if (n_threads == 0) n_threads = 1;
+    out.n_threads = n_threads;
+
+    // Allocate n_indexes array with RAII ownership
+    out.n_indexes_ptr_ = std::make_unique<uint64_t[]>(n_threads);
+    out.n_indexes = out.n_indexes_ptr_.get();
+
+    // Allocate space for interleaved index storage.
+    size_t allocation_size;
+    if (n_threads == 1) {
+        // Single-threaded: simple allocation with padding for speculative writes
+        allocation_size = len + 8;
+    } else {
+        // Multi-threaded: need space for interleaved storage
+        allocation_size = (len + 8) * n_threads;
+    }
+
+    // Allocate indexes array with RAII ownership
+    out.indexes_ptr_ = std::make_unique<uint64_t[]>(allocation_size);
+    out.indexes = out.indexes_ptr_.get();
+
+    return out;
+}
+
+ParseIndex TwoPass::init_safe(size_t len, size_t n_threads, ErrorCollector* errors) {
+    ParseIndex out;
+    // Ensure at least 1 thread for valid memory allocation
+    if (n_threads == 0) n_threads = 1;
+    out.n_threads = n_threads;
+
+    // Calculate allocation size with overflow checking
+    size_t allocation_size;
+    bool overflow = false;
+
+    if (n_threads == 1) {
+        // Single-threaded: simple allocation with padding for speculative writes
+        // allocation_size = len + 8
+        if (len > std::numeric_limits<size_t>::max() - 8) {
+            overflow = true;
+        } else {
+            allocation_size = len + 8;
+        }
+    } else {
+        // Multi-threaded: need space for interleaved storage
+        // allocation_size = (len + 8) * n_threads
+        size_t len_plus_8;
+        if (len > std::numeric_limits<size_t>::max() - 8) {
+            overflow = true;
+        } else {
+            len_plus_8 = len + 8;
+            // Check (len + 8) * n_threads for overflow
+            if (len_plus_8 > std::numeric_limits<size_t>::max() / n_threads) {
+                overflow = true;
+            } else {
+                allocation_size = len_plus_8 * n_threads;
+            }
+        }
+    }
+
+    // Check final allocation: allocation_size * sizeof(uint64_t)
+    if (!overflow && allocation_size > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
+        overflow = true;
+    }
+
+    if (overflow) {
+        std::string msg = "Index allocation would overflow: len=" + std::to_string(len) +
+                          ", n_threads=" + std::to_string(n_threads);
+        if (errors != nullptr) {
+            errors->add_error(ErrorCode::INDEX_ALLOCATION_OVERFLOW, ErrorSeverity::FATAL,
+                              1, 1, 0, msg);
+            // Return empty index to signal failure
+            return out;
+        } else {
+            throw std::runtime_error(msg);
+        }
+    }
+
+    // Safe to allocate - Note: init_safe uses raw new[] for backward compatibility
+    out.n_indexes = new uint64_t[n_threads];
+    out.indexes = new uint64_t[allocation_size];
+    return out;
+}
+
+}  // namespace libvroom


### PR DESCRIPTION
## Summary

- Move non-performance-critical function implementations from `two_pass.h` to `src/two_pass.cpp`
- Reduces header from ~2100 lines to ~700 lines
- Improves compilation times and reduces header dependencies

### Functions moved to two_pass.cpp:
- `ParseIndex::write()` and `read()` - file I/O operations
- `first_pass_chunk()`, `first_pass_naive()` - scalar first pass implementations
- `get_quotation_state()`, `first_pass_speculate()` - speculative parsing setup
- `get_context()`, `get_line_column()` - error reporting helpers
- `second_pass_chunk()`, `second_pass_chunk_throwing()` - scalar second pass
- All `parse_*()` orchestration methods
- Validation functions (`check_empty_header`, `check_duplicate_columns`, etc.)
- Initialization functions (`init()`, `init_safe()`)

### Functions kept inline in header for performance:
- `first_pass_simd()` - SIMD line boundary detection
- `second_pass_simd()` - SIMD field indexing
- `second_pass_simd_branchless()` - SIMD branchless state machine
- State machine helpers (`quoted_state`, `comma_state`, `newline_state`, etc.)

## Test plan

- [x] All existing tests pass (1660/1660)
- [x] Benchmarks run successfully with no performance regression
- [x] Build completes with no duplicate symbol errors

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)