### PR TITLE
fix: Validate file path is regular file before reading (fixes #344)

### DIFF
--- a/src/io_util.cpp
+++ b/src/io_util.cpp
@@ -5,6 +5,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <vector>
+#include <sys/stat.h>
 
 uint8_t * allocate_padded_buffer(size_t length, size_t padding) {
     // Check for integer overflow before addition
@@ -56,6 +57,12 @@ std::basic_string_view<uint8_t> get_corpus_stdin(size_t padding) {
 }
 
 std::basic_string_view<uint8_t> get_corpus(const std::string& filename, size_t padding) {
+  // Check if the path is a regular file (not a directory or special file)
+  struct stat path_stat;
+  if (stat(filename.c_str(), &path_stat) != 0 || !S_ISREG(path_stat.st_mode)) {
+    throw std::runtime_error("could not load corpus");
+  }
+
   std::FILE *fp = std::fopen(filename.c_str(), "rb");
   if (fp != nullptr) {
     std::fseek(fp, 0, SEEK_END);
@@ -127,6 +134,12 @@ static LoadResult process_with_encoding(uint8_t* raw_buf, size_t raw_len, size_t
 }
 
 LoadResult get_corpus_with_encoding(const std::string& filename, size_t padding) {
+    // Check if the path is a regular file (not a directory or special file)
+    struct stat path_stat;
+    if (stat(filename.c_str(), &path_stat) != 0 || !S_ISREG(path_stat.st_mode)) {
+        throw std::runtime_error("could not load corpus");
+    }
+
     std::FILE *fp = std::fopen(filename.c_str(), "rb");
     if (fp == nullptr) {
         throw std::runtime_error("could not load corpus");


### PR DESCRIPTION
## Summary

`get_corpus()` crashes with an invalid allocation size when given a directory path instead of a file path. This triggers AddressSanitizer with:

> "ERROR: AddressSanitizer: requested allocation size 0x800000000000003f exceeds maximum supported size"

## Root Cause

On Linux, `fopen()` on a directory often succeeds (it opens the directory descriptor), but `ftell()` returns garbage/undefined values. This causes `allocate_padded_buffer()` to attempt an absurdly large memory allocation.

## Fix

Added a `stat()` check before `fopen()` to validate that the path refers to a regular file (not a directory or special file). The same fix is applied to both `get_corpus()` and `get_corpus_with_encoding()`.

## Changes

- `src/io_util.cpp`: Added `#include <sys/stat.h>` and `S_ISREG()` validation before file operations

## Test plan

- [x] `IOUtilTest.GetCorpus_DirectoryPath` - now passes instead of crashing
- [x] All 51 io_util tests pass

## Note

The related issues #306, #307, and #331 were already fixed by PR #336 ("Add SIMD padding to test buffers and C API for ASAN safety").

🤖 Generated with [Claude Code](https://claude.com/claude-code)