### PR TITLE
feat: increase MAX_THREADS from 255 to 1024 via uint16_t n_threads

### DIFF
--- a/benchmark/external_parser_benchmarks.cpp
+++ b/benchmark/external_parser_benchmarks.cpp
@@ -1,5 +1,6 @@
 // External CSV Parser Benchmarks
-// Compares libvroom against best-in-class CSV parsers: DuckDB, zsv, and Apache Arrow
+// Compares libvroom against best-in-class CSV parsers: DuckDB, zsv, and Apache
+// Arrow
 //
 // =============================================================================
 // HOW TO ENABLE AND RUN EXTERNAL PARSER BENCHMARKS
@@ -19,7 +20,8 @@
 //   cmake -B build -DENABLE_ARROW_BENCHMARK=ON
 //
 //   # Enable all parsers
-//   cmake -B build -DENABLE_ZSV_BENCHMARK=ON -DENABLE_DUCKDB_BENCHMARK=ON -DENABLE_ARROW_BENCHMARK=ON
+//   cmake -B build -DENABLE_ZSV_BENCHMARK=ON -DENABLE_DUCKDB_BENCHMARK=ON
+//   -DENABLE_ARROW_BENCHMARK=ON
 //
 // Build and run:
 //   cmake --build build
@@ -38,20 +40,21 @@
 //
 // =============================================================================
 
-// Benchmarks intentionally test deprecated two_pass methods for performance comparison
+// Benchmarks intentionally test deprecated two_pass methods for performance
+// comparison
 #include "two_pass.h"
 LIBVROOM_SUPPRESS_DEPRECATION_START
 
-#include <benchmark/benchmark.h>
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
+#include <benchmark/benchmark.h>
+#include <cstring>
 #include <fstream>
+#include <random>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <cstring>
-#include <random>
 
 #ifdef HAVE_ZSV
 // zsv uses C99 restrict keyword which is not valid in C++
@@ -67,119 +70,126 @@ extern "C" {
 #endif
 
 #ifdef HAVE_DUCKDB
+#include <atomic>
 #include <duckdb.hpp>
 #include <duckdb/common/file_system.hpp>
-#include <atomic>
 #include <mutex>
 
 // ============================================================================
 // In-Memory FileSystem for DuckDB
 // ============================================================================
-// Custom FileSystem that serves CSV data from memory buffers, avoiding file I/O.
+// Custom FileSystem that serves CSV data from memory buffers, avoiding file
+// I/O.
 
 class MemoryFileHandle : public duckdb::FileHandle {
 public:
-    MemoryFileHandle(duckdb::FileSystem &fs, duckdb::string path,
-                     const uint8_t* data, size_t len)
-        : FileHandle(fs, std::move(path)),
-          data_(data), len_(len), pos_(0) {}
+  MemoryFileHandle(duckdb::FileSystem &fs, duckdb::string path,
+                   const uint8_t *data, size_t len)
+      : FileHandle(fs, std::move(path)), data_(data), len_(len), pos_(0) {}
 
-    void Close() override {}
+  void Close() override {}
 
-    const uint8_t* data_;
-    size_t len_;
-    size_t pos_;
+  const uint8_t *data_;
+  size_t len_;
+  size_t pos_;
 };
 
 class MemoryFileSystem : public duckdb::FileSystem {
 public:
-    static constexpr const char* PROTOCOL = "memory://";
+  static constexpr const char *PROTOCOL = "memory://";
 
-    // Register a memory buffer with a name
-    void RegisterBuffer(const std::string& name, const uint8_t* data, size_t len) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        buffers_[PROTOCOL + name] = {data, len};
-    }
+  // Register a memory buffer with a name
+  void RegisterBuffer(const std::string &name, const uint8_t *data,
+                      size_t len) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffers_[PROTOCOL + name] = {data, len};
+  }
 
-    void ClearBuffers() {
-        std::lock_guard<std::mutex> lock(mutex_);
-        buffers_.clear();
-    }
+  void ClearBuffers() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffers_.clear();
+  }
 
-    // FileSystem interface
-    std::string GetName() const override { return "MemoryFileSystem"; }
+  // FileSystem interface
+  std::string GetName() const override { return "MemoryFileSystem"; }
 
-    bool CanHandleFile(const std::string &path) override {
-        return path.rfind(PROTOCOL, 0) == 0;  // starts with memory://
-    }
+  bool CanHandleFile(const std::string &path) override {
+    return path.rfind(PROTOCOL, 0) == 0; // starts with memory://
+  }
 
-    duckdb::unique_ptr<duckdb::FileHandle> OpenFile(const duckdb::string &path,
-                                                     duckdb::FileOpenFlags flags,
-                                                     duckdb::optional_ptr<duckdb::FileOpener>) override {
-        std::lock_guard<std::mutex> lock(mutex_);
-        auto it = buffers_.find(path);
-        if (it == buffers_.end()) {
-            throw duckdb::IOException("Memory buffer not found: " + path);
-        }
-        return duckdb::make_uniq<MemoryFileHandle>(*this, path, it->second.data, it->second.len);
+  duckdb::unique_ptr<duckdb::FileHandle>
+  OpenFile(const duckdb::string &path, duckdb::FileOpenFlags flags,
+           duckdb::optional_ptr<duckdb::FileOpener>) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = buffers_.find(path);
+    if (it == buffers_.end()) {
+      throw duckdb::IOException("Memory buffer not found: " + path);
     }
+    return duckdb::make_uniq<MemoryFileHandle>(*this, path, it->second.data,
+                                               it->second.len);
+  }
 
-    int64_t Read(duckdb::FileHandle &handle, void *buffer, int64_t nr_bytes) override {
-        auto &mem_handle = handle.Cast<MemoryFileHandle>();
-        int64_t bytes_available = static_cast<int64_t>(mem_handle.len_ - mem_handle.pos_);
-        int64_t bytes_to_read = std::min(nr_bytes, bytes_available);
-        if (bytes_to_read > 0) {
-            memcpy(buffer, mem_handle.data_ + mem_handle.pos_, bytes_to_read);
-            mem_handle.pos_ += bytes_to_read;
-        }
-        return bytes_to_read;
+  int64_t Read(duckdb::FileHandle &handle, void *buffer,
+               int64_t nr_bytes) override {
+    auto &mem_handle = handle.Cast<MemoryFileHandle>();
+    int64_t bytes_available =
+        static_cast<int64_t>(mem_handle.len_ - mem_handle.pos_);
+    int64_t bytes_to_read = std::min(nr_bytes, bytes_available);
+    if (bytes_to_read > 0) {
+      memcpy(buffer, mem_handle.data_ + mem_handle.pos_, bytes_to_read);
+      mem_handle.pos_ += bytes_to_read;
     }
+    return bytes_to_read;
+  }
 
-    int64_t GetFileSize(duckdb::FileHandle &handle) override {
-        auto &mem_handle = handle.Cast<MemoryFileHandle>();
-        return static_cast<int64_t>(mem_handle.len_);
-    }
+  int64_t GetFileSize(duckdb::FileHandle &handle) override {
+    auto &mem_handle = handle.Cast<MemoryFileHandle>();
+    return static_cast<int64_t>(mem_handle.len_);
+  }
 
-    void Seek(duckdb::FileHandle &handle, duckdb::idx_t location) override {
-        auto &mem_handle = handle.Cast<MemoryFileHandle>();
-        mem_handle.pos_ = std::min(location, static_cast<duckdb::idx_t>(mem_handle.len_));
-    }
+  void Seek(duckdb::FileHandle &handle, duckdb::idx_t location) override {
+    auto &mem_handle = handle.Cast<MemoryFileHandle>();
+    mem_handle.pos_ =
+        std::min(location, static_cast<duckdb::idx_t>(mem_handle.len_));
+  }
 
-    void Reset(duckdb::FileHandle &handle) override {
-        auto &mem_handle = handle.Cast<MemoryFileHandle>();
-        mem_handle.pos_ = 0;
-    }
+  void Reset(duckdb::FileHandle &handle) override {
+    auto &mem_handle = handle.Cast<MemoryFileHandle>();
+    mem_handle.pos_ = 0;
+  }
 
-    duckdb::idx_t SeekPosition(duckdb::FileHandle &handle) override {
-        auto &mem_handle = handle.Cast<MemoryFileHandle>();
-        return mem_handle.pos_;
-    }
+  duckdb::idx_t SeekPosition(duckdb::FileHandle &handle) override {
+    auto &mem_handle = handle.Cast<MemoryFileHandle>();
+    return mem_handle.pos_;
+  }
 
-    bool CanSeek() override { return true; }
-    bool OnDiskFile(duckdb::FileHandle &) override { return false; }
-    bool IsPipe(const std::string &, duckdb::optional_ptr<duckdb::FileOpener>) override { return false; }
+  bool CanSeek() override { return true; }
+  bool OnDiskFile(duckdb::FileHandle &) override { return false; }
+  bool IsPipe(const std::string &,
+              duckdb::optional_ptr<duckdb::FileOpener>) override {
+    return false;
+  }
 
-    // Required but unused for read-only access
-    int64_t Write(duckdb::FileHandle &, void *, int64_t) override {
-        throw duckdb::IOException("MemoryFileSystem is read-only");
-    }
-    void FileSync(duckdb::FileHandle &) override {}
-    void Truncate(duckdb::FileHandle &, int64_t) override {}
-    time_t GetLastModifiedTime(duckdb::FileHandle &) override {
-        return 0;
-    }
-    bool FileExists(const std::string &filename, duckdb::optional_ptr<duckdb::FileOpener>) override {
-        std::lock_guard<std::mutex> lock(mutex_);
-        return buffers_.find(filename) != buffers_.end();
-    }
+  // Required but unused for read-only access
+  int64_t Write(duckdb::FileHandle &, void *, int64_t) override {
+    throw duckdb::IOException("MemoryFileSystem is read-only");
+  }
+  void FileSync(duckdb::FileHandle &) override {}
+  void Truncate(duckdb::FileHandle &, int64_t) override {}
+  time_t GetLastModifiedTime(duckdb::FileHandle &) override { return 0; }
+  bool FileExists(const std::string &filename,
+                  duckdb::optional_ptr<duckdb::FileOpener>) override {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return buffers_.find(filename) != buffers_.end();
+  }
 
 private:
-    struct BufferInfo {
-        const uint8_t* data;
-        size_t len;
-    };
-    std::mutex mutex_;
-    std::map<std::string, BufferInfo> buffers_;
+  struct BufferInfo {
+    const uint8_t *data;
+    size_t len;
+  };
+  std::mutex mutex_;
+  std::map<std::string, BufferInfo> buffers_;
 };
 
 #endif
@@ -192,7 +202,7 @@ private:
 #endif
 
 extern std::map<std::string, std::basic_string_view<uint8_t>> test_data;
-extern libvroom::two_pass* global_parser;
+extern libvroom::two_pass *global_parser;
 
 // ============================================================================
 // Test Data Generation
@@ -200,116 +210,123 @@ extern libvroom::two_pass* global_parser;
 
 // Generate synthetic CSV data for benchmarking
 static std::string generate_csv_data(size_t target_size, int num_columns = 10) {
-    std::string result;
-    result.reserve(target_size + 1024);
+  std::string result;
+  result.reserve(target_size + 1024);
 
-    // Header row
+  // Header row
+  for (int i = 0; i < num_columns; ++i) {
+    if (i > 0)
+      result += ',';
+    result += "col" + std::to_string(i);
+  }
+  result += '\n';
+
+  // Data rows
+  std::mt19937 rng(42); // Fixed seed for reproducibility
+  std::uniform_int_distribution<int> int_dist(0, 1000000);
+  std::uniform_real_distribution<double> real_dist(0.0, 10000.0);
+
+  int row = 0;
+  while (result.size() < target_size) {
     for (int i = 0; i < num_columns; ++i) {
-        if (i > 0) result += ',';
-        result += "col" + std::to_string(i);
+      if (i > 0)
+        result += ',';
+      if (i % 3 == 0) {
+        // Integer column
+        result += std::to_string(int_dist(rng));
+      } else if (i % 3 == 1) {
+        // Float column
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%.2f", real_dist(rng));
+        result += buf;
+      } else {
+        // String column
+        result += "str" + std::to_string(row) + "_" + std::to_string(i);
+      }
     }
     result += '\n';
+    row++;
+  }
 
-    // Data rows
-    std::mt19937 rng(42); // Fixed seed for reproducibility
-    std::uniform_int_distribution<int> int_dist(0, 1000000);
-    std::uniform_real_distribution<double> real_dist(0.0, 10000.0);
-
-    int row = 0;
-    while (result.size() < target_size) {
-        for (int i = 0; i < num_columns; ++i) {
-            if (i > 0) result += ',';
-            if (i % 3 == 0) {
-                // Integer column
-                result += std::to_string(int_dist(rng));
-            } else if (i % 3 == 1) {
-                // Float column
-                char buf[32];
-                snprintf(buf, sizeof(buf), "%.2f", real_dist(rng));
-                result += buf;
-            } else {
-                // String column
-                result += "str" + std::to_string(row) + "_" + std::to_string(i);
-            }
-        }
-        result += '\n';
-        row++;
-    }
-
-    return result;
+  return result;
 }
 
 // Generate quoted CSV data (more challenging for parsers)
-static std::string generate_quoted_csv_data(size_t target_size, int num_columns = 10) {
-    std::string result;
-    result.reserve(target_size + 1024);
+static std::string generate_quoted_csv_data(size_t target_size,
+                                            int num_columns = 10) {
+  std::string result;
+  result.reserve(target_size + 1024);
 
-    // Header row
+  // Header row
+  for (int i = 0; i < num_columns; ++i) {
+    if (i > 0)
+      result += ',';
+    result += "\"column_" + std::to_string(i) + "\"";
+  }
+  result += '\n';
+
+  // Data rows with quoted fields
+  std::mt19937 rng(42);
+  std::uniform_int_distribution<int> int_dist(0, 1000000);
+
+  int row = 0;
+  while (result.size() < target_size) {
     for (int i = 0; i < num_columns; ++i) {
-        if (i > 0) result += ',';
-        result += "\"column_" + std::to_string(i) + "\"";
+      if (i > 0)
+        result += ',';
+      if (i % 2 == 0) {
+        // Quoted string with potential special characters
+        result += "\"value_" + std::to_string(row) + "_" +
+                  std::to_string(int_dist(rng)) + "\"";
+      } else {
+        // Unquoted number
+        result += std::to_string(int_dist(rng));
+      }
     }
     result += '\n';
+    row++;
+  }
 
-    // Data rows with quoted fields
-    std::mt19937 rng(42);
-    std::uniform_int_distribution<int> int_dist(0, 1000000);
-
-    int row = 0;
-    while (result.size() < target_size) {
-        for (int i = 0; i < num_columns; ++i) {
-            if (i > 0) result += ',';
-            if (i % 2 == 0) {
-                // Quoted string with potential special characters
-                result += "\"value_" + std::to_string(row) + "_" + std::to_string(int_dist(rng)) + "\"";
-            } else {
-                // Unquoted number
-                result += std::to_string(int_dist(rng));
-            }
-        }
-        result += '\n';
-        row++;
-    }
-
-    return result;
+  return result;
 }
 
 // Cache for generated test data
 static std::map<size_t, std::string> generated_data_cache;
 static std::map<size_t, std::string> generated_quoted_data_cache;
 
-static const std::string& get_or_generate_data(size_t size) {
-    if (generated_data_cache.find(size) == generated_data_cache.end()) {
-        generated_data_cache[size] = generate_csv_data(size);
-    }
-    return generated_data_cache[size];
+static const std::string &get_or_generate_data(size_t size) {
+  if (generated_data_cache.find(size) == generated_data_cache.end()) {
+    generated_data_cache[size] = generate_csv_data(size);
+  }
+  return generated_data_cache[size];
 }
 
-static const std::string& get_or_generate_quoted_data(size_t size) {
-    if (generated_quoted_data_cache.find(size) == generated_quoted_data_cache.end()) {
-        generated_quoted_data_cache[size] = generate_quoted_csv_data(size);
-    }
-    return generated_quoted_data_cache[size];
+static const std::string &get_or_generate_quoted_data(size_t size) {
+  if (generated_quoted_data_cache.find(size) ==
+      generated_quoted_data_cache.end()) {
+    generated_quoted_data_cache[size] = generate_quoted_csv_data(size);
+  }
+  return generated_quoted_data_cache[size];
 }
 
 // ============================================================================
 // libvroom Parser (baseline)
 // ============================================================================
 
-static size_t parse_libvroom(const uint8_t* data, size_t len) {
-    if (!global_parser) {
-        global_parser = new libvroom::two_pass();
-    }
+static size_t parse_libvroom(const uint8_t *data, size_t len) {
+  if (!global_parser) {
+    global_parser = new libvroom::two_pass();
+  }
 
-    libvroom::index result = global_parser->init(len, 1);
-    global_parser->parse(data, result, len);
+  libvroom::index result = global_parser->init(len, 1);
+  global_parser->parse(data, result, len);
 
-    // Return total field count as work indicator
-    size_t total_fields = 0;
-    for (uint8_t i = 0; i < result.n_threads; ++i) {
-        total_fields += result.n_indexes[i];
-    }
-    return total_fields;
+  // Return total field count as work indicator
+  size_t total_fields = 0;
+  for (uint16_t i = 0; i < result.n_threads; ++i) {
+    total_fields += result.n_indexes[i];
+  }
+  return total_fields;
 }
 
 // ============================================================================
@@ -319,110 +336,112 @@ static size_t parse_libvroom(const uint8_t* data, size_t len) {
 #ifdef HAVE_ZSV
 
 struct ZsvMemoryStream {
-    const uint8_t* data;
-    size_t len;
-    size_t pos;
+  const uint8_t *data;
+  size_t len;
+  size_t pos;
 };
 
 struct ZsvParseContext {
-    zsv_parser parser;  // Need parser reference to access cells
-    const uint8_t* base_ptr;  // Base pointer to calculate offsets
-    size_t row_count = 0;
-    size_t cell_count = 0;
-    // Index vector to store cell positions - similar to libvroom's index
-    std::vector<uint64_t>* index_storage;
+  zsv_parser parser;       // Need parser reference to access cells
+  const uint8_t *base_ptr; // Base pointer to calculate offsets
+  size_t row_count = 0;
+  size_t cell_count = 0;
+  // Index vector to store cell positions - similar to libvroom's index
+  std::vector<uint64_t> *index_storage;
 };
 
 // Row handler that builds an index of all cell positions (like libvroom)
-static void zsv_row_handler_with_index(void* ctx) {
-    auto* context = static_cast<ZsvParseContext*>(ctx);
-    context->row_count++;
+static void zsv_row_handler_with_index(void *ctx) {
+  auto *context = static_cast<ZsvParseContext *>(ctx);
+  context->row_count++;
 
-    // Get and iterate through all cells - this is the work libvroom does
-    // when it builds its field index
-    size_t cell_count = zsv_cell_count(context->parser);
-    size_t write_pos = context->cell_count;
-    context->cell_count += cell_count;
+  // Get and iterate through all cells - this is the work libvroom does
+  // when it builds its field index
+  size_t cell_count = zsv_cell_count(context->parser);
+  size_t write_pos = context->cell_count;
+  context->cell_count += cell_count;
 
-    // Ensure capacity (should rarely need to grow due to pre-allocation)
-    if (write_pos + cell_count > context->index_storage->size()) {
-        context->index_storage->resize((write_pos + cell_count) * 2);
-    }
+  // Ensure capacity (should rarely need to grow due to pre-allocation)
+  if (write_pos + cell_count > context->index_storage->size()) {
+    context->index_storage->resize((write_pos + cell_count) * 2);
+  }
 
-    // Write to index array (like libvroom does)
-    uint64_t* positions = context->index_storage->data();
-    for (size_t i = 0; i < cell_count; i++, write_pos++) {
-        struct zsv_cell cell = zsv_get_cell(context->parser, i);
-        // Calculate byte offset from start of data - this is what libvroom stores
-        uint64_t offset = static_cast<uint64_t>(cell.str - context->base_ptr);
-        // Write to index array - this is the key work that libvroom does
-        positions[write_pos] = offset;
-    }
+  // Write to index array (like libvroom does)
+  uint64_t *positions = context->index_storage->data();
+  for (size_t i = 0; i < cell_count; i++, write_pos++) {
+    struct zsv_cell cell = zsv_get_cell(context->parser, i);
+    // Calculate byte offset from start of data - this is what libvroom stores
+    uint64_t offset = static_cast<uint64_t>(cell.str - context->base_ptr);
+    // Write to index array - this is the key work that libvroom does
+    positions[write_pos] = offset;
+  }
 }
 
 // Custom read function for memory buffer (mimics fread signature)
-static size_t zsv_memory_read(void* buffer, size_t n, size_t size, void* stream) {
-    auto* mem_stream = static_cast<ZsvMemoryStream*>(stream);
-    size_t bytes_to_read = n * size;
-    size_t bytes_available = mem_stream->len - mem_stream->pos;
-    size_t bytes_read = std::min(bytes_to_read, bytes_available);
+static size_t zsv_memory_read(void *buffer, size_t n, size_t size,
+                              void *stream) {
+  auto *mem_stream = static_cast<ZsvMemoryStream *>(stream);
+  size_t bytes_to_read = n * size;
+  size_t bytes_available = mem_stream->len - mem_stream->pos;
+  size_t bytes_read = std::min(bytes_to_read, bytes_available);
 
-    if (bytes_read > 0) {
-        memcpy(buffer, mem_stream->data + mem_stream->pos, bytes_read);
-        mem_stream->pos += bytes_read;
-    }
+  if (bytes_read > 0) {
+    memcpy(buffer, mem_stream->data + mem_stream->pos, bytes_read);
+    mem_stream->pos += bytes_read;
+  }
 
-    return bytes_read / size; // Return number of elements read
+  return bytes_read / size; // Return number of elements read
 }
 
 // Thread-local storage for zsv index to avoid allocation in hot path
 static thread_local std::vector<uint64_t> zsv_index_storage;
 
-static size_t parse_zsv(const uint8_t* data, size_t len) {
-    ZsvParseContext ctx;
-    ctx.parser = nullptr;
-    ctx.base_ptr = data;
-    ctx.index_storage = &zsv_index_storage;
-    ZsvMemoryStream mem_stream = {data, len, 0};
+static size_t parse_zsv(const uint8_t *data, size_t len) {
+  ZsvParseContext ctx;
+  ctx.parser = nullptr;
+  ctx.base_ptr = data;
+  ctx.index_storage = &zsv_index_storage;
+  ZsvMemoryStream mem_stream = {data, len, 0};
 
-    // Pre-allocate index array - estimate ~1 cell per 8 bytes (similar to libvroom)
-    size_t estimated_cells = len / 8;
-    if (zsv_index_storage.size() < estimated_cells) {
-        zsv_index_storage.resize(estimated_cells);
-    }
+  // Pre-allocate index array - estimate ~1 cell per 8 bytes (similar to
+  // libvroom)
+  size_t estimated_cells = len / 8;
+  if (zsv_index_storage.size() < estimated_cells) {
+    zsv_index_storage.resize(estimated_cells);
+  }
 
-    // Configure zsv parser options
-    struct zsv_opts opts;
-    memset(&opts, 0, sizeof(opts));
-    opts.row_handler = zsv_row_handler_with_index;
-    opts.ctx = &ctx;
-    opts.stream = &mem_stream;
-    opts.read = zsv_memory_read;
+  // Configure zsv parser options
+  struct zsv_opts opts;
+  memset(&opts, 0, sizeof(opts));
+  opts.row_handler = zsv_row_handler_with_index;
+  opts.ctx = &ctx;
+  opts.stream = &mem_stream;
+  opts.read = zsv_memory_read;
 
-    // Create parser
-    zsv_parser parser = zsv_new(&opts);
-    if (!parser) {
-        return 0;
-    }
+  // Create parser
+  zsv_parser parser = zsv_new(&opts);
+  if (!parser) {
+    return 0;
+  }
 
-    // Store parser in context so row handler can access cells
-    ctx.parser = parser;
+  // Store parser in context so row handler can access cells
+  ctx.parser = parser;
 
-    // Parse data - zsv_parse_more reads from the stream internally
-    enum zsv_status status;
-    while ((status = zsv_parse_more(parser)) == zsv_status_ok) {
-        // Continue parsing
-    }
+  // Parse data - zsv_parse_more reads from the stream internally
+  enum zsv_status status;
+  while ((status = zsv_parse_more(parser)) == zsv_status_ok) {
+    // Continue parsing
+  }
 
-    zsv_finish(parser);
-    zsv_delete(parser);
+  zsv_finish(parser);
+  zsv_delete(parser);
 
-    // Prevent optimizer from eliminating the index array
-    benchmark::DoNotOptimize(zsv_index_storage.data());
-    benchmark::ClobberMemory();
+  // Prevent optimizer from eliminating the index array
+  benchmark::DoNotOptimize(zsv_index_storage.data());
+  benchmark::ClobberMemory();
 
-    // Return cell count as work indicator (similar to libvroom field count)
-    return ctx.cell_count;
+  // Return cell count as work indicator (similar to libvroom field count)
+  return ctx.cell_count;
 }
 
 #endif // HAVE_ZSV
@@ -436,32 +455,33 @@ static size_t parse_zsv(const uint8_t* data, size_t len) {
 
 #ifdef HAVE_DUCKDB
 
-static size_t parse_duckdb(const uint8_t* data, size_t len) {
-    // Create fresh DuckDB instance each time to avoid any caching effects
-    // This ensures fair comparison with other parsers that don't cache
-    duckdb::DuckDB db(nullptr);
+static size_t parse_duckdb(const uint8_t *data, size_t len) {
+  // Create fresh DuckDB instance each time to avoid any caching effects
+  // This ensures fair comparison with other parsers that don't cache
+  duckdb::DuckDB db(nullptr);
 
-    // Create and register memory filesystem
-    auto mem_fs = duckdb::make_uniq<MemoryFileSystem>();
-    auto* mem_fs_ptr = mem_fs.get();
-    db.GetFileSystem().RegisterSubSystem(std::move(mem_fs));
+  // Create and register memory filesystem
+  auto mem_fs = duckdb::make_uniq<MemoryFileSystem>();
+  auto *mem_fs_ptr = mem_fs.get();
+  db.GetFileSystem().RegisterSubSystem(std::move(mem_fs));
 
-    // Register the buffer
-    mem_fs_ptr->RegisterBuffer("data.csv", data, len);
+  // Register the buffer
+  mem_fs_ptr->RegisterBuffer("data.csv", data, len);
 
-    duckdb::Connection conn(db);
+  duckdb::Connection conn(db);
 
-    try {
-        auto result = conn.Query("SELECT COUNT(*) FROM read_csv_auto('memory://data.csv')");
-        if (result->HasError()) {
-            return 0;
-        }
-
-        auto count = result->GetValue(0, 0).GetValue<int64_t>();
-        return static_cast<size_t>(count);
-    } catch (...) {
-        return 0;
+  try {
+    auto result =
+        conn.Query("SELECT COUNT(*) FROM read_csv_auto('memory://data.csv')");
+    if (result->HasError()) {
+      return 0;
     }
+
+    auto count = result->GetValue(0, 0).GetValue<int64_t>();
+    return static_cast<size_t>(count);
+  } catch (...) {
+    return 0;
+  }
 }
 
 #endif // HAVE_DUCKDB
@@ -472,46 +492,43 @@ static size_t parse_duckdb(const uint8_t* data, size_t len) {
 
 #ifdef HAVE_ARROW
 
-static size_t parse_arrow(const uint8_t* data, size_t len) {
-    // Create a buffer from the data
-    auto buffer = std::make_shared<arrow::Buffer>(data, static_cast<int64_t>(len));
-    auto buffer_reader = std::make_shared<arrow::io::BufferReader>(buffer);
+static size_t parse_arrow(const uint8_t *data, size_t len) {
+  // Create a buffer from the data
+  auto buffer =
+      std::make_shared<arrow::Buffer>(data, static_cast<int64_t>(len));
+  auto buffer_reader = std::make_shared<arrow::io::BufferReader>(buffer);
 
-    // Configure CSV reader options
-    auto read_options = arrow::csv::ReadOptions::Defaults();
-    auto parse_options = arrow::csv::ParseOptions::Defaults();
-    auto convert_options = arrow::csv::ConvertOptions::Defaults();
+  // Configure CSV reader options
+  auto read_options = arrow::csv::ReadOptions::Defaults();
+  auto parse_options = arrow::csv::ParseOptions::Defaults();
+  auto convert_options = arrow::csv::ConvertOptions::Defaults();
 
-    // Disable type inference for fair comparison (just parse, don't convert)
-    // Arrow will still parse but treat everything as strings
+  // Disable type inference for fair comparison (just parse, don't convert)
+  // Arrow will still parse but treat everything as strings
 
-    // Create streaming reader for memory efficiency
-    auto maybe_reader = arrow::csv::StreamingReader::Make(
-        arrow::io::default_io_context(),
-        buffer_reader,
-        read_options,
-        parse_options,
-        convert_options
-    );
+  // Create streaming reader for memory efficiency
+  auto maybe_reader = arrow::csv::StreamingReader::Make(
+      arrow::io::default_io_context(), buffer_reader, read_options,
+      parse_options, convert_options);
 
-    if (!maybe_reader.ok()) {
-        return 0;
+  if (!maybe_reader.ok()) {
+    return 0;
+  }
+
+  auto reader = *maybe_reader;
+
+  // Read all batches and count rows
+  size_t total_rows = 0;
+  std::shared_ptr<arrow::RecordBatch> batch;
+  while (true) {
+    auto status = reader->ReadNext(&batch);
+    if (!status.ok() || !batch) {
+      break;
     }
+    total_rows += batch->num_rows();
+  }
 
-    auto reader = *maybe_reader;
-
-    // Read all batches and count rows
-    size_t total_rows = 0;
-    std::shared_ptr<arrow::RecordBatch> batch;
-    while (true) {
-        auto status = reader->ReadNext(&batch);
-        if (!status.ok() || !batch) {
-            break;
-        }
-        total_rows += batch->num_rows();
-    }
-
-    return total_rows;
+  return total_rows;
 }
 
 #endif // HAVE_ARROW
@@ -521,73 +538,84 @@ static size_t parse_arrow(const uint8_t* data, size_t len) {
 // ============================================================================
 
 // Benchmark libvroom with generated data
-static void BM_libvroom_generated(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    const std::string& csv_data = get_or_generate_data(data_size);
+static void BM_libvroom_generated(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  const std::string &csv_data = get_or_generate_data(data_size);
 
-    // Allocate padded buffer for libvroom
-    size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
-    auto* buffer = static_cast<uint8_t*>(aligned_malloc(64, padded_size));
-    memcpy(buffer, csv_data.data(), csv_data.size());
-    memset(buffer + csv_data.size(), 0, LIBVROOM_PADDING);
+  // Allocate padded buffer for libvroom
+  size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
+  auto *buffer = static_cast<uint8_t *>(aligned_malloc(64, padded_size));
+  memcpy(buffer, csv_data.data(), csv_data.size());
+  memset(buffer + csv_data.size(), 0, LIBVROOM_PADDING);
 
-    for (auto _ : state) {
-        size_t result = parse_libvroom(buffer, csv_data.size());
-        benchmark::DoNotOptimize(result);
-    }
+  for (auto _ : state) {
+    size_t result = parse_libvroom(buffer, csv_data.size());
+    benchmark::DoNotOptimize(result);
+  }
 
-    aligned_free(buffer);
+  aligned_free(buffer);
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["Parser"] = 0; // libvroom = 0
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["Parser"] = 0; // libvroom = 0
 }
 
 #ifdef HAVE_ZSV
-static void BM_zsv_generated(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    const std::string& csv_data = get_or_generate_data(data_size);
+static void BM_zsv_generated(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  const std::string &csv_data = get_or_generate_data(data_size);
 
-    for (auto _ : state) {
-        size_t result = parse_zsv(reinterpret_cast<const uint8_t*>(csv_data.data()), csv_data.size());
-        benchmark::DoNotOptimize(result);
-    }
+  for (auto _ : state) {
+    size_t result = parse_zsv(
+        reinterpret_cast<const uint8_t *>(csv_data.data()), csv_data.size());
+    benchmark::DoNotOptimize(result);
+  }
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["Parser"] = 1; // zsv = 1
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["Parser"] = 1; // zsv = 1
 }
 #endif
 
 #ifdef HAVE_DUCKDB
-static void BM_duckdb_generated(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    const std::string& csv_data = get_or_generate_data(data_size);
+static void BM_duckdb_generated(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  const std::string &csv_data = get_or_generate_data(data_size);
 
-    for (auto _ : state) {
-        size_t result = parse_duckdb(reinterpret_cast<const uint8_t*>(csv_data.data()), csv_data.size());
-        benchmark::DoNotOptimize(result);
-    }
+  for (auto _ : state) {
+    size_t result = parse_duckdb(
+        reinterpret_cast<const uint8_t *>(csv_data.data()), csv_data.size());
+    benchmark::DoNotOptimize(result);
+  }
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["Parser"] = 2; // duckdb = 2
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["Parser"] = 2; // duckdb = 2
 }
 #endif
 
 #ifdef HAVE_ARROW
-static void BM_arrow_generated(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    const std::string& csv_data = get_or_generate_data(data_size);
+static void BM_arrow_generated(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  const std::string &csv_data = get_or_generate_data(data_size);
 
-    for (auto _ : state) {
-        size_t result = parse_arrow(reinterpret_cast<const uint8_t*>(csv_data.data()), csv_data.size());
-        benchmark::DoNotOptimize(result);
-    }
+  for (auto _ : state) {
+    size_t result = parse_arrow(
+        reinterpret_cast<const uint8_t *>(csv_data.data()), csv_data.size());
+    benchmark::DoNotOptimize(result);
+  }
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["Parser"] = 3; // arrow = 3
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["Parser"] = 3; // arrow = 3
 }
 #endif
 
@@ -595,56 +623,64 @@ static void BM_arrow_generated(benchmark::State& state) {
 // Quoted CSV Benchmarks
 // ============================================================================
 
-static void BM_libvroom_quoted(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    const std::string& csv_data = get_or_generate_quoted_data(data_size);
+static void BM_libvroom_quoted(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  const std::string &csv_data = get_or_generate_quoted_data(data_size);
 
-    size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
-    auto* buffer = static_cast<uint8_t*>(aligned_malloc(64, padded_size));
-    memcpy(buffer, csv_data.data(), csv_data.size());
-    memset(buffer + csv_data.size(), 0, LIBVROOM_PADDING);
+  size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
+  auto *buffer = static_cast<uint8_t *>(aligned_malloc(64, padded_size));
+  memcpy(buffer, csv_data.data(), csv_data.size());
+  memset(buffer + csv_data.size(), 0, LIBVROOM_PADDING);
 
-    for (auto _ : state) {
-        size_t result = parse_libvroom(buffer, csv_data.size());
-        benchmark::DoNotOptimize(result);
-    }
+  for (auto _ : state) {
+    size_t result = parse_libvroom(buffer, csv_data.size());
+    benchmark::DoNotOptimize(result);
+  }
 
-    aligned_free(buffer);
+  aligned_free(buffer);
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["QuotedData"] = 1;
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["QuotedData"] = 1;
 }
 
 #ifdef HAVE_ZSV
-static void BM_zsv_quoted(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    const std::string& csv_data = get_or_generate_quoted_data(data_size);
+static void BM_zsv_quoted(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  const std::string &csv_data = get_or_generate_quoted_data(data_size);
 
-    for (auto _ : state) {
-        size_t result = parse_zsv(reinterpret_cast<const uint8_t*>(csv_data.data()), csv_data.size());
-        benchmark::DoNotOptimize(result);
-    }
+  for (auto _ : state) {
+    size_t result = parse_zsv(
+        reinterpret_cast<const uint8_t *>(csv_data.data()), csv_data.size());
+    benchmark::DoNotOptimize(result);
+  }
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["QuotedData"] = 1;
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["QuotedData"] = 1;
 }
 #endif
 
 #ifdef HAVE_ARROW
-static void BM_arrow_quoted(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    const std::string& csv_data = get_or_generate_quoted_data(data_size);
+static void BM_arrow_quoted(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  const std::string &csv_data = get_or_generate_quoted_data(data_size);
 
-    for (auto _ : state) {
-        size_t result = parse_arrow(reinterpret_cast<const uint8_t*>(csv_data.data()), csv_data.size());
-        benchmark::DoNotOptimize(result);
-    }
+  for (auto _ : state) {
+    size_t result = parse_arrow(
+        reinterpret_cast<const uint8_t *>(csv_data.data()), csv_data.size());
+    benchmark::DoNotOptimize(result);
+  }
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["QuotedData"] = 1;
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["QuotedData"] = 1;
 }
 #endif
 
@@ -652,83 +688,85 @@ static void BM_arrow_quoted(benchmark::State& state) {
 // Fair Comparison Benchmark (all parsers, same data)
 // ============================================================================
 
-enum class ParserType {
-    LIBVROOM = 0,
-    ZSV = 1,
-    DUCKDB = 2,
-    ARROW = 3
-};
+enum class ParserType { LIBVROOM = 0, ZSV = 1, DUCKDB = 2, ARROW = 3 };
 
-static void BM_fair_comparison(benchmark::State& state) {
-    size_t data_size = static_cast<size_t>(state.range(0));
-    ParserType parser_type = static_cast<ParserType>(state.range(1));
+static void BM_fair_comparison(benchmark::State &state) {
+  size_t data_size = static_cast<size_t>(state.range(0));
+  ParserType parser_type = static_cast<ParserType>(state.range(1));
 
-    const std::string& csv_data = get_or_generate_data(data_size);
+  const std::string &csv_data = get_or_generate_data(data_size);
 
-    // Prepare libvroom buffer (with padding)
-    size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
-    auto* padded_buffer = static_cast<uint8_t*>(aligned_malloc(64, padded_size));
-    memcpy(padded_buffer, csv_data.data(), csv_data.size());
-    memset(padded_buffer + csv_data.size(), 0, LIBVROOM_PADDING);
+  // Prepare libvroom buffer (with padding)
+  size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
+  auto *padded_buffer = static_cast<uint8_t *>(aligned_malloc(64, padded_size));
+  memcpy(padded_buffer, csv_data.data(), csv_data.size());
+  memset(padded_buffer + csv_data.size(), 0, LIBVROOM_PADDING);
 
-    const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(csv_data.data());
+  const uint8_t *data_ptr = reinterpret_cast<const uint8_t *>(csv_data.data());
 
-    switch (parser_type) {
-        case ParserType::LIBVROOM: {
-            for (auto _ : state) {
-                size_t result = parse_libvroom(padded_buffer, csv_data.size());
-                benchmark::DoNotOptimize(result);
-            }
-            break;
-        }
+  switch (parser_type) {
+  case ParserType::LIBVROOM: {
+    for (auto _ : state) {
+      size_t result = parse_libvroom(padded_buffer, csv_data.size());
+      benchmark::DoNotOptimize(result);
+    }
+    break;
+  }
 #ifdef HAVE_ZSV
-        case ParserType::ZSV: {
-            for (auto _ : state) {
-                size_t result = parse_zsv(data_ptr, csv_data.size());
-                benchmark::DoNotOptimize(result);
-            }
-            break;
-        }
+  case ParserType::ZSV: {
+    for (auto _ : state) {
+      size_t result = parse_zsv(data_ptr, csv_data.size());
+      benchmark::DoNotOptimize(result);
+    }
+    break;
+  }
 #endif
 #ifdef HAVE_DUCKDB
-        case ParserType::DUCKDB: {
-            for (auto _ : state) {
-                size_t result = parse_duckdb(data_ptr, csv_data.size());
-                benchmark::DoNotOptimize(result);
-            }
-            break;
-        }
+  case ParserType::DUCKDB: {
+    for (auto _ : state) {
+      size_t result = parse_duckdb(data_ptr, csv_data.size());
+      benchmark::DoNotOptimize(result);
+    }
+    break;
+  }
 #endif
 #ifdef HAVE_ARROW
-        case ParserType::ARROW: {
-            for (auto _ : state) {
-                size_t result = parse_arrow(data_ptr, csv_data.size());
-                benchmark::DoNotOptimize(result);
-            }
-            break;
-        }
-#endif
-        default:
-            state.SkipWithError("Unknown parser type");
-            break;
+  case ParserType::ARROW: {
+    for (auto _ : state) {
+      size_t result = parse_arrow(data_ptr, csv_data.size());
+      benchmark::DoNotOptimize(result);
     }
+    break;
+  }
+#endif
+  default:
+    state.SkipWithError("Unknown parser type");
+    break;
+  }
 
-    aligned_free(padded_buffer);
+  aligned_free(padded_buffer);
 
-    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-    state.counters["Parser"] = static_cast<double>(parser_type);
+  state.SetBytesProcessed(
+      static_cast<int64_t>(csv_data.size() * state.iterations()));
+  state.counters["FileSize_MB"] =
+      static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+  state.counters["Parser"] = static_cast<double>(parser_type);
 }
 
 // Helper to get parser name for labels
 static std::string GetParserName(int parser_id) {
-    switch (static_cast<ParserType>(parser_id)) {
-        case ParserType::LIBVROOM: return "libvroom";
-        case ParserType::ZSV: return "zsv";
-        case ParserType::DUCKDB: return "duckdb";
-        case ParserType::ARROW: return "arrow";
-        default: return "unknown";
-    }
+  switch (static_cast<ParserType>(parser_id)) {
+  case ParserType::LIBVROOM:
+    return "libvroom";
+  case ParserType::ZSV:
+    return "zsv";
+  case ParserType::DUCKDB:
+    return "duckdb";
+  case ParserType::ARROW:
+    return "arrow";
+  default:
+    return "unknown";
+  }
 }
 
 // ============================================================================
@@ -736,142 +774,141 @@ static std::string GetParserName(int parser_id) {
 // ============================================================================
 
 // Benchmark data sizes: 1KB, 10KB, 100KB, 1MB, 10MB, 100MB (powers of 10)
-#define BENCHMARK_CSV_SIZES_1KB_TO_100MB Range(1024, 100 * 1024 * 1024)->RangeMultiplier(10)
+#define BENCHMARK_CSV_SIZES_1KB_TO_100MB                                       \
+  Range(1024, 100 * 1024 * 1024)->RangeMultiplier(10)
 
 // Register libvroom benchmarks (always available)
 BENCHMARK(BM_libvroom_generated)
-    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB
-    ->Unit(benchmark::kMillisecond)
+    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB->Unit(benchmark::kMillisecond)
     ->Name("BM_external/libvroom/generated");
 
 BENCHMARK(BM_libvroom_quoted)
-    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB
-    ->Unit(benchmark::kMillisecond)
+    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB->Unit(benchmark::kMillisecond)
     ->Name("BM_external/libvroom/quoted");
 
 // Register zsv benchmarks
 #ifdef HAVE_ZSV
 BENCHMARK(BM_zsv_generated)
-    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB
-    ->Unit(benchmark::kMillisecond)
+    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB->Unit(benchmark::kMillisecond)
     ->Name("BM_external/zsv/generated");
 
 BENCHMARK(BM_zsv_quoted)
-    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB
-    ->Unit(benchmark::kMillisecond)
+    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB->Unit(benchmark::kMillisecond)
     ->Name("BM_external/zsv/quoted");
 #endif
 
 // Register DuckDB benchmarks
 #ifdef HAVE_DUCKDB
 BENCHMARK(BM_duckdb_generated)
-    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB
-    ->Unit(benchmark::kMillisecond)
+    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB->Unit(benchmark::kMillisecond)
     ->Name("BM_external/duckdb/generated");
 #endif
 
 // Register Arrow benchmarks
 #ifdef HAVE_ARROW
 BENCHMARK(BM_arrow_generated)
-    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB
-    ->Unit(benchmark::kMillisecond)
+    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB->Unit(benchmark::kMillisecond)
     ->Name("BM_external/arrow/generated");
 
 BENCHMARK(BM_arrow_quoted)
-    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB
-    ->Unit(benchmark::kMillisecond)
+    ->BENCHMARK_CSV_SIZES_1KB_TO_100MB->Unit(benchmark::kMillisecond)
     ->Name("BM_external/arrow/quoted");
 #endif
 
 // Fair comparison benchmark - tests all available parsers with same data sizes
 static void RegisterFairComparisonBenchmarks() {
-    std::vector<int64_t> sizes = {
-        1024,           // 1KB
-        10 * 1024,      // 10KB
-        100 * 1024,     // 100KB
-        1024 * 1024,    // 1MB
-        10 * 1024 * 1024,   // 10MB
-        100 * 1024 * 1024   // 100MB
-    };
+  std::vector<int64_t> sizes = {
+      1024,             // 1KB
+      10 * 1024,        // 10KB
+      100 * 1024,       // 100KB
+      1024 * 1024,      // 1MB
+      10 * 1024 * 1024, // 10MB
+      100 * 1024 * 1024 // 100MB
+  };
 
-    std::vector<int> parsers = {0}; // libvroom always available
+  std::vector<int> parsers = {0}; // libvroom always available
 #ifdef HAVE_ZSV
-    parsers.push_back(1);
+  parsers.push_back(1);
 #endif
 #ifdef HAVE_DUCKDB
-    parsers.push_back(2);
+  parsers.push_back(2);
 #endif
 #ifdef HAVE_ARROW
-    parsers.push_back(3);
+  parsers.push_back(3);
 #endif
 
-    for (int64_t size : sizes) {
-        for (int parser : parsers) {
-            benchmark::RegisterBenchmark(
-                ("BM_fair_comparison/" + GetParserName(parser) + "/" +
-                 std::to_string(size / 1024) + "KB").c_str(),
-                [size, parser](benchmark::State& state) {
-                    const std::string& csv_data = get_or_generate_data(size);
+  for (int64_t size : sizes) {
+    for (int parser : parsers) {
+      benchmark::RegisterBenchmark(
+          ("BM_fair_comparison/" + GetParserName(parser) + "/" +
+           std::to_string(size / 1024) + "KB")
+              .c_str(),
+          [size, parser](benchmark::State &state) {
+            const std::string &csv_data = get_or_generate_data(size);
 
-                    size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
-                    auto* padded_buffer = static_cast<uint8_t*>(aligned_malloc(64, padded_size));
-                    memcpy(padded_buffer, csv_data.data(), csv_data.size());
-                    memset(padded_buffer + csv_data.size(), 0, LIBVROOM_PADDING);
+            size_t padded_size = csv_data.size() + LIBVROOM_PADDING;
+            auto *padded_buffer =
+                static_cast<uint8_t *>(aligned_malloc(64, padded_size));
+            memcpy(padded_buffer, csv_data.data(), csv_data.size());
+            memset(padded_buffer + csv_data.size(), 0, LIBVROOM_PADDING);
 
-                    const uint8_t* data_ptr = reinterpret_cast<const uint8_t*>(csv_data.data());
+            const uint8_t *data_ptr =
+                reinterpret_cast<const uint8_t *>(csv_data.data());
 
-                    switch (static_cast<ParserType>(parser)) {
-                        case ParserType::LIBVROOM: {
-                            for (auto _ : state) {
-                                size_t result = parse_libvroom(padded_buffer, csv_data.size());
-                                benchmark::DoNotOptimize(result);
-                            }
-                            break;
-                        }
+            switch (static_cast<ParserType>(parser)) {
+            case ParserType::LIBVROOM: {
+              for (auto _ : state) {
+                size_t result = parse_libvroom(padded_buffer, csv_data.size());
+                benchmark::DoNotOptimize(result);
+              }
+              break;
+            }
 #ifdef HAVE_ZSV
-                        case ParserType::ZSV: {
-                            for (auto _ : state) {
-                                size_t result = parse_zsv(data_ptr, csv_data.size());
-                                benchmark::DoNotOptimize(result);
-                            }
-                            break;
-                        }
+            case ParserType::ZSV: {
+              for (auto _ : state) {
+                size_t result = parse_zsv(data_ptr, csv_data.size());
+                benchmark::DoNotOptimize(result);
+              }
+              break;
+            }
 #endif
 #ifdef HAVE_DUCKDB
-                        case ParserType::DUCKDB: {
-                            for (auto _ : state) {
-                                size_t result = parse_duckdb(data_ptr, csv_data.size());
-                                benchmark::DoNotOptimize(result);
-                            }
-                            break;
-                        }
+            case ParserType::DUCKDB: {
+              for (auto _ : state) {
+                size_t result = parse_duckdb(data_ptr, csv_data.size());
+                benchmark::DoNotOptimize(result);
+              }
+              break;
+            }
 #endif
 #ifdef HAVE_ARROW
-                        case ParserType::ARROW: {
-                            for (auto _ : state) {
-                                size_t result = parse_arrow(data_ptr, csv_data.size());
-                                benchmark::DoNotOptimize(result);
-                            }
-                            break;
-                        }
+            case ParserType::ARROW: {
+              for (auto _ : state) {
+                size_t result = parse_arrow(data_ptr, csv_data.size());
+                benchmark::DoNotOptimize(result);
+              }
+              break;
+            }
 #endif
-                        default:
-                            break;
-                    }
+            default:
+              break;
+            }
 
-                    aligned_free(padded_buffer);
+            aligned_free(padded_buffer);
 
-                    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
-                    state.counters["FileSize_MB"] = static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
-                    state.counters["Parser"] = static_cast<double>(parser);
-                }
-            )->Unit(benchmark::kMillisecond);
-        }
+            state.SetBytesProcessed(
+                static_cast<int64_t>(csv_data.size() * state.iterations()));
+            state.counters["FileSize_MB"] =
+                static_cast<double>(csv_data.size()) / (1024.0 * 1024.0);
+            state.counters["Parser"] = static_cast<double>(parser);
+          })
+          ->Unit(benchmark::kMillisecond);
     }
+  }
 }
 
 // Static initialization to register fair comparison benchmarks
 static int dummy = []() {
-    RegisterFairComparisonBenchmarks();
-    return 0;
+  RegisterFairComparisonBenchmarks();
+  return 0;
 }();

--- a/include/debug_parser.h
+++ b/include/debug_parser.h
@@ -6,130 +6,135 @@
 #ifndef LIBVROOM_DEBUG_PARSER_H
 #define LIBVROOM_DEBUG_PARSER_H
 
-#include "two_pass.h"
 #include "debug.h"
+#include "two_pass.h"
 #include <string>
 
 namespace libvroom {
 
-inline const char* get_simd_path_name() {
+inline const char *get_simd_path_name() {
 #if defined(__AVX512F__)
-    return "AVX512";
+  return "AVX512";
 #elif defined(__AVX2__)
-    return "AVX2";
+  return "AVX2";
 #elif defined(__SSE4_2__)
-    return "SSE4.2";
+  return "SSE4.2";
 #elif defined(__ARM_NEON)
-    return "NEON";
+  return "NEON";
 #else
-    return "Scalar";
+  return "Scalar";
 #endif
 }
 
 inline size_t get_simd_vector_bytes() {
-    namespace hn = hwy::HWY_NAMESPACE;
-    const hn::ScalableTag<uint8_t> d;
-    return hn::Lanes(d);
+  namespace hn = hwy::HWY_NAMESPACE;
+  const hn::ScalableTag<uint8_t> d;
+  return hn::Lanes(d);
 }
 
 inline std::string get_simd_info() {
-    std::string info = get_simd_path_name();
-    info += " (";
-    info += std::to_string(get_simd_vector_bytes());
-    info += "-byte vectors)";
-    return info;
+  std::string info = get_simd_path_name();
+  info += " (";
+  info += std::to_string(get_simd_vector_bytes());
+  info += "-byte vectors)";
+  return info;
 }
 
 class debug_parser {
 public:
-    debug_parser() = default;
+  debug_parser() = default;
 
-    ParseIndex init(size_t len, size_t n_threads) {
-        return parser_.init(len, n_threads);
+  ParseIndex init(size_t len, size_t n_threads) {
+    return parser_.init(len, n_threads);
+  }
+
+  bool parse_debug(const uint8_t *buf, ParseIndex &out, size_t len,
+                   DebugTrace &trace, const Dialect &dialect = Dialect::csv()) {
+    trace.log("Starting parse: %zu bytes, %u threads", len, out.n_threads);
+    trace.log_threading(out.n_threads,
+                        len / (out.n_threads > 0 ? out.n_threads : 1));
+    trace.log_dialect(dialect.delimiter, dialect.quote_char, 1.0);
+    trace.log_simd_path(get_simd_path_name(), get_simd_vector_bytes());
+
+    if (trace.dump_masks()) {
+      trace.dump_buffer("input (start)", buf, len < 64 ? len : 64, 0);
     }
 
-    bool parse_debug(const uint8_t* buf, ParseIndex& out, size_t len,
-                     DebugTrace& trace, const Dialect& dialect = Dialect::csv()) {
-        trace.log("Starting parse: %zu bytes, %u threads", len, out.n_threads);
-        trace.log_threading(out.n_threads, len / (out.n_threads > 0 ? out.n_threads : 1));
-        trace.log_dialect(dialect.delimiter, dialect.quote_char, 1.0);
-        trace.log_simd_path(get_simd_path_name(), get_simd_vector_bytes());
+    trace.start_phase("parse");
+    bool result = parser_.parse(buf, out, len, dialect);
+    trace.end_phase(len);
 
-        if (trace.dump_masks()) {
-            trace.dump_buffer("input (start)", buf, len < 64 ? len : 64, 0);
+    if (trace.dump_masks() && result) {
+      // Calculate safe total_size: max index accessed + 1
+      // For strided layout: max_idx = thread_id + (count-1) * stride
+      size_t max_count = 0;
+      for (uint16_t t = 0; t < out.n_threads; ++t) {
+        if (out.n_indexes[t] > max_count)
+          max_count = out.n_indexes[t];
+      }
+      size_t total_size = max_count * out.n_threads;
+      for (uint16_t t = 0; t < out.n_threads; ++t) {
+        if (out.n_indexes[t] > 0) {
+          trace.dump_indexes(out.indexes, out.n_indexes[t], t, out.n_threads,
+                             total_size);
         }
-
-        trace.start_phase("parse");
-        bool result = parser_.parse(buf, out, len, dialect);
-        trace.end_phase(len);
-
-        if (trace.dump_masks() && result) {
-            // Calculate safe total_size: max index accessed + 1
-            // For strided layout: max_idx = thread_id + (count-1) * stride
-            size_t max_count = 0;
-            for (uint8_t t = 0; t < out.n_threads; ++t) {
-                if (out.n_indexes[t] > max_count) max_count = out.n_indexes[t];
-            }
-            size_t total_size = max_count * out.n_threads;
-            for (uint8_t t = 0; t < out.n_threads; ++t) {
-                if (out.n_indexes[t] > 0) {
-                    trace.dump_indexes(out.indexes, out.n_indexes[t], t, out.n_threads, total_size);
-                }
-            }
-        }
-
-        trace.print_timing_summary();
-        return result;
+      }
     }
 
-    bool parse_with_errors_debug(const uint8_t* buf, ParseIndex& out, size_t len,
-                                 ErrorCollector& errors, DebugTrace& trace,
-                                 const Dialect& dialect = Dialect::csv()) {
-        trace.log("Starting parse_with_errors: %zu bytes", len);
-        trace.log_dialect(dialect.delimiter, dialect.quote_char, 1.0);
-        trace.log_simd_path(get_simd_path_name(), get_simd_vector_bytes());
+    trace.print_timing_summary();
+    return result;
+  }
 
-        if (trace.dump_masks()) {
-            trace.dump_buffer("input (start)", buf, len < 64 ? len : 64, 0);
-        }
+  bool parse_with_errors_debug(const uint8_t *buf, ParseIndex &out, size_t len,
+                               ErrorCollector &errors, DebugTrace &trace,
+                               const Dialect &dialect = Dialect::csv()) {
+    trace.log("Starting parse_with_errors: %zu bytes", len);
+    trace.log_dialect(dialect.delimiter, dialect.quote_char, 1.0);
+    trace.log_simd_path(get_simd_path_name(), get_simd_vector_bytes());
 
-        trace.start_phase("parse_with_errors");
-        bool result = parser_.parse_with_errors(buf, out, len, errors, dialect);
-        trace.end_phase(len);
-
-        if (trace.dump_masks()) {
-            // Calculate safe total_size for strided layout
-            size_t max_count = 0;
-            for (uint8_t t = 0; t < out.n_threads; ++t) {
-                if (out.n_indexes[t] > max_count) max_count = out.n_indexes[t];
-            }
-            size_t total_size = max_count * out.n_threads;
-            trace.dump_indexes(out.indexes, out.n_indexes[0], 0, out.n_threads, total_size);
-        }
-
-        trace.log("Parse complete: %zu errors, %s",
-                  errors.error_count(),
-                  errors.has_fatal_errors() ? "has fatal errors" : "no fatal errors");
-
-        trace.print_timing_summary();
-        return result;
+    if (trace.dump_masks()) {
+      trace.dump_buffer("input (start)", buf, len < 64 ? len : 64, 0);
     }
 
-    bool parse(const uint8_t* buf, ParseIndex& out, size_t len,
-               const Dialect& dialect = Dialect::csv()) {
-        return parser_.parse(buf, out, len, dialect);
+    trace.start_phase("parse_with_errors");
+    bool result = parser_.parse_with_errors(buf, out, len, errors, dialect);
+    trace.end_phase(len);
+
+    if (trace.dump_masks()) {
+      // Calculate safe total_size for strided layout
+      size_t max_count = 0;
+      for (uint16_t t = 0; t < out.n_threads; ++t) {
+        if (out.n_indexes[t] > max_count)
+          max_count = out.n_indexes[t];
+      }
+      size_t total_size = max_count * out.n_threads;
+      trace.dump_indexes(out.indexes, out.n_indexes[0], 0, out.n_threads,
+                         total_size);
     }
 
-    bool parse_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
-                           ErrorCollector& errors,
-                           const Dialect& dialect = Dialect::csv()) {
-        return parser_.parse_with_errors(buf, out, len, errors, dialect);
-    }
+    trace.log("Parse complete: %zu errors, %s", errors.error_count(),
+              errors.has_fatal_errors() ? "has fatal errors"
+                                        : "no fatal errors");
+
+    trace.print_timing_summary();
+    return result;
+  }
+
+  bool parse(const uint8_t *buf, ParseIndex &out, size_t len,
+             const Dialect &dialect = Dialect::csv()) {
+    return parser_.parse(buf, out, len, dialect);
+  }
+
+  bool parse_with_errors(const uint8_t *buf, ParseIndex &out, size_t len,
+                         ErrorCollector &errors,
+                         const Dialect &dialect = Dialect::csv()) {
+    return parser_.parse_with_errors(buf, out, len, errors, dialect);
+  }
 
 private:
-    TwoPass parser_;
+  TwoPass parser_;
 };
 
-}  // namespace libvroom
+} // namespace libvroom
 
-#endif  // LIBVROOM_DEBUG_PARSER_H
+#endif // LIBVROOM_DEBUG_PARSER_H

--- a/include/libvroom.h
+++ b/include/libvroom.h
@@ -1250,7 +1250,7 @@ public:
       if (!idx.n_indexes)
         return 0;
       size_t total = 0;
-      for (uint8_t t = 0; t < idx.n_threads; ++t) {
+      for (uint16_t t = 0; t < idx.n_threads; ++t) {
         total += idx.n_indexes[t];
       }
       return total;

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -35,59 +35,57 @@
  * ## Algorithm Overview
  *
  * 1. **First Pass**: Scans for line boundaries while tracking quote parity.
- *    Finds safe split points where the file can be divided for parallel processing.
+ *    Finds safe split points where the file can be divided for parallel
+ * processing.
  *
  * 2. **Speculative Chunking**: The file is divided into chunks based on quote
  *    parity analysis. Multiple threads can speculatively parse chunks.
  *
- * 3. **Second Pass**: SIMD-based field indexing using a state machine. Processes
- *    64 bytes at a time using Google Highway portable SIMD intrinsics.
+ * 3. **Second Pass**: SIMD-based field indexing using a state machine.
+ * Processes 64 bytes at a time using Google Highway portable SIMD intrinsics.
  *
  * @see libvroom::Parser for the unified public API
  * @see libvroom::ParseOptions for configuration options
  * @see libvroom::index for the result structure containing field positions
  */
 
-#include <unistd.h>  // for getopt
+#include "branchless_state_machine.h"
+#include "dialect.h"
+#include "error.h"
+#include "simd_highway.h"
 #include <cassert>
 #include <cstdint>
+#include <cstring> // for memcpy
 #include <future>
 #include <limits>
-#include <vector>
-#include <cstring>  // for memcpy
-#include <unordered_set>
 #include <sstream>
-#include "simd_highway.h"
-#include "error.h"
-#include "dialect.h"
-#include "branchless_state_machine.h"
+#include <unistd.h> // for getopt
+#include <unordered_set>
+#include <vector>
 
 // Deprecation macro for cross-compiler support
 #if defined(__GNUC__) || defined(__clang__)
-    #define LIBVROOM_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#define LIBVROOM_DEPRECATED(msg) __attribute__((deprecated(msg)))
 #elif defined(_MSC_VER)
-    #define LIBVROOM_DEPRECATED(msg) __declspec(deprecated(msg))
+#define LIBVROOM_DEPRECATED(msg) __declspec(deprecated(msg))
 #else
-    #define LIBVROOM_DEPRECATED(msg)
+#define LIBVROOM_DEPRECATED(msg)
 #endif
 
 // Macro to suppress deprecation warnings for internal use
 // (Parser class needs to call deprecated methods)
 #ifdef __GNUC__
-    #define LIBVROOM_SUPPRESS_DEPRECATION_START \
-        _Pragma("GCC diagnostic push") \
-        _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-    #define LIBVROOM_SUPPRESS_DEPRECATION_END \
-        _Pragma("GCC diagnostic pop")
+#define LIBVROOM_SUPPRESS_DEPRECATION_START                                    \
+  _Pragma("GCC diagnostic push")                                               \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define LIBVROOM_SUPPRESS_DEPRECATION_END _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)
-    #define LIBVROOM_SUPPRESS_DEPRECATION_START \
-        __pragma(warning(push)) \
-        __pragma(warning(disable: 4996))
-    #define LIBVROOM_SUPPRESS_DEPRECATION_END \
-        __pragma(warning(pop))
+#define LIBVROOM_SUPPRESS_DEPRECATION_START                                    \
+  __pragma(warning(push)) __pragma(warning(disable : 4996))
+#define LIBVROOM_SUPPRESS_DEPRECATION_END __pragma(warning(pop))
 #else
-    #define LIBVROOM_SUPPRESS_DEPRECATION_START
-    #define LIBVROOM_SUPPRESS_DEPRECATION_END
+#define LIBVROOM_SUPPRESS_DEPRECATION_START
+#define LIBVROOM_SUPPRESS_DEPRECATION_END
 #endif
 
 namespace libvroom {
@@ -98,23 +96,25 @@ constexpr static uint64_t null_pos = std::numeric_limits<uint64_t>::max();
 /**
  * @brief Result structure containing parsed CSV field positions.
  *
- * The ParseIndex class stores the byte offsets of field separators (commas and newlines)
- * found during CSV parsing. These positions enable efficient random access to
- * individual fields without re-parsing the entire file.
+ * The ParseIndex class stores the byte offsets of field separators (commas and
+ * newlines) found during CSV parsing. These positions enable efficient random
+ * access to individual fields without re-parsing the entire file.
  *
- * When using multi-threaded parsing, field positions are interleaved across threads.
- * For example, with 4 threads: thread 0 stores positions at indices 0, 4, 8, ...;
- * thread 1 stores at indices 1, 5, 9, ...; and so on.
+ * When using multi-threaded parsing, field positions are interleaved across
+ * threads. For example, with 4 threads: thread 0 stores positions at indices 0,
+ * 4, 8, ...; thread 1 stores at indices 1, 5, 9, ...; and so on.
  *
- * @note This class is move-only. Copy operations are deleted to prevent accidental
- *       expensive copies of large index arrays.
+ * @note This class is move-only. Copy operations are deleted to prevent
+ * accidental expensive copies of large index arrays.
  *
  * @note Memory management uses std::unique_ptr for automatic RAII cleanup. The
- *       raw pointer accessors (n_indexes, indexes) are provided for compatibility
- *       with existing parsing code but ownership remains with the unique_ptr members.
+ *       raw pointer accessors (n_indexes, indexes) are provided for
+ * compatibility with existing parsing code but ownership remains with the
+ * unique_ptr members.
  *
  * @warning The caller must ensure the index remains valid while accessing the
- *          underlying buffer data. The index stores byte offsets, not the data itself.
+ *          underlying buffer data. The index stores byte offsets, not the data
+ * itself.
  *
  * @example
  * @code
@@ -123,25 +123,30 @@ constexpr static uint64_t null_pos = std::numeric_limits<uint64_t>::max();
  * auto result = parser.parse(buffer, length);
  *
  * // Access field positions from result.idx
- * // For single-threaded: positions are at result.idx.indexes[0], result.idx.indexes[1], ...
+ * // For single-threaded: positions are at result.idx.indexes[0],
+ * result.idx.indexes[1], ...
  * // For multi-threaded: use stride of result.idx.n_threads
  * @endcode
  */
 class ParseIndex {
- public:
+public:
   /// Number of columns detected in the CSV (set after parsing header).
   uint64_t columns{0};
 
   /// Number of threads used for parsing. Determines the interleave stride.
-  uint8_t n_threads{0};
+  /// Changed from uint8_t to uint16_t to support systems with >255 cores.
+  uint16_t n_threads{0};
 
-  /// Array of size n_threads containing the count of indexes found by each thread.
-  /// @note This is a raw pointer accessor for compatibility; memory is managed by n_indexes_ptr_.
-  uint64_t* n_indexes{nullptr};
+  /// Array of size n_threads containing the count of indexes found by each
+  /// thread.
+  /// @note This is a raw pointer accessor for compatibility; memory is managed
+  /// by n_indexes_ptr_.
+  uint64_t *n_indexes{nullptr};
 
   /// Array of field separator positions (byte offsets). Interleaved by thread.
-  /// @note This is a raw pointer accessor for compatibility; memory is managed by indexes_ptr_.
-  uint64_t* indexes{nullptr};
+  /// @note This is a raw pointer accessor for compatibility; memory is managed
+  /// by indexes_ptr_.
+  uint64_t *indexes{nullptr};
 
   /// Default constructor. Creates an empty, uninitialized index.
   ParseIndex() = default;
@@ -151,13 +156,12 @@ class ParseIndex {
    *
    * Transfers ownership of index arrays from another ParseIndex object.
    *
-   * @param other The ParseIndex to move from. Will be left in a valid but empty state.
+   * @param other The ParseIndex to move from. Will be left in a valid but empty
+   * state.
    */
-  ParseIndex(ParseIndex&& other) noexcept
-      : columns(other.columns),
-        n_threads(other.n_threads),
-        n_indexes(other.n_indexes),
-        indexes(other.indexes),
+  ParseIndex(ParseIndex &&other) noexcept
+      : columns(other.columns), n_threads(other.n_threads),
+        n_indexes(other.n_indexes), indexes(other.indexes),
         n_indexes_ptr_(std::move(other.n_indexes_ptr_)),
         indexes_ptr_(std::move(other.indexes_ptr_)) {
     other.n_indexes = nullptr;
@@ -169,10 +173,11 @@ class ParseIndex {
    *
    * Releases current resources and takes ownership from another ParseIndex.
    *
-   * @param other The ParseIndex to move from. Will be left in a valid but empty state.
+   * @param other The ParseIndex to move from. Will be left in a valid but empty
+   * state.
    * @return Reference to this ParseIndex.
    */
-  ParseIndex& operator=(ParseIndex&& other) noexcept {
+  ParseIndex &operator=(ParseIndex &&other) noexcept {
     if (this != &other) {
       columns = other.columns;
       n_threads = other.n_threads;
@@ -187,8 +192,8 @@ class ParseIndex {
   }
 
   // Delete copy operations to prevent accidental copies
-  ParseIndex(const ParseIndex&) = delete;
-  ParseIndex& operator=(const ParseIndex&) = delete;
+  ParseIndex(const ParseIndex &) = delete;
+  ParseIndex &operator=(const ParseIndex &) = delete;
 
   /**
    * @brief Serialize the index to a binary file.
@@ -199,7 +204,7 @@ class ParseIndex {
    * @param filename Path to the output file.
    * @throws std::runtime_error If writing fails.
    */
-  void write(const std::string& filename);
+  void write(const std::string &filename);
 
   /**
    * @brief Deserialize the index from a binary file.
@@ -209,9 +214,10 @@ class ParseIndex {
    * @param filename Path to the input file.
    * @throws std::runtime_error If reading fails.
    *
-   * @warning The n_indexes and indexes arrays must be pre-allocated before calling.
+   * @warning The n_indexes and indexes arrays must be pre-allocated before
+   * calling.
    */
-  void read(const std::string& filename);
+  void read(const std::string &filename);
 
   /**
    * @brief Destructor. Releases allocated index arrays via RAII.
@@ -220,9 +226,9 @@ class ParseIndex {
    */
   ~ParseIndex() = default;
 
-  void fill_double_array(ParseIndex* idx, uint64_t column, double* out) {}
+  void fill_double_array(ParseIndex *idx, uint64_t column, double *out) {}
 
- private:
+private:
   /// RAII owner for n_indexes array. Memory freed automatically on destruction.
   std::unique_ptr<uint64_t[]> n_indexes_ptr_;
 
@@ -234,7 +240,8 @@ class ParseIndex {
 };
 
 /// @brief Backward-compatible alias for ParseIndex.
-/// @deprecated Use ParseIndex instead. This alias will be removed in a future version.
+/// @deprecated Use ParseIndex instead. This alias will be removed in a future
+/// version.
 using index [[deprecated("Use ParseIndex instead")]] = ParseIndex;
 
 /**
@@ -290,7 +297,7 @@ using index [[deprecated("Use ParseIndex instead")]] = ParseIndex;
  * @see ErrorCollector For error handling during parsing
  */
 class TwoPass {
- public:
+public:
   /**
    * @brief Statistics from the first pass of parsing.
    *
@@ -304,18 +311,18 @@ class TwoPass {
     /// Total number of quote characters found in the chunk.
     uint64_t n_quotes{0};
 
-    /// Position of first newline at even quote count (safe split point if unquoted).
-    /// Set to null_pos if no such newline exists.
+    /// Position of first newline at even quote count (safe split point if
+    /// unquoted). Set to null_pos if no such newline exists.
     uint64_t first_even_nl{null_pos};
 
-    /// Position of first newline at odd quote count (safe split point if quoted).
-    /// Set to null_pos if no such newline exists.
+    /// Position of first newline at odd quote count (safe split point if
+    /// quoted). Set to null_pos if no such newline exists.
     uint64_t first_odd_nl{null_pos};
   };
   /**
    * @brief First pass SIMD scan with dialect-aware quote character.
    */
-  static Stats first_pass_simd(const uint8_t* buf, size_t start, size_t end,
+  static Stats first_pass_simd(const uint8_t *buf, size_t start, size_t end,
                                char quote_char = '"') {
     Stats out;
     assert(end >= start && "Invalid range: end must be >= start");
@@ -335,7 +342,8 @@ class TwoPass {
         mask = blsmsk_u64(1ULL << (len - idx));
       }
 
-      uint64_t quotes = cmp_mask_against_input(in, static_cast<uint8_t>(quote_char)) & mask;
+      uint64_t quotes =
+          cmp_mask_against_input(in, static_cast<uint8_t>(quote_char)) & mask;
 
       if (needs_even || needs_odd) {
         // Support LF, CRLF, and CR-only line endings
@@ -369,16 +377,17 @@ class TwoPass {
   /**
    * @brief First pass scalar scan with dialect-aware quote character.
    */
-  static Stats first_pass_chunk(const uint8_t* buf, size_t start, size_t end,
+  static Stats first_pass_chunk(const uint8_t *buf, size_t start, size_t end,
                                 char quote_char = '"');
 
-  static Stats first_pass_naive(const uint8_t* buf, size_t start, size_t end);
+  static Stats first_pass_naive(const uint8_t *buf, size_t start, size_t end);
 
   /**
    * @brief Check if character is not a delimiter, newline (LF or CR), or quote.
    */
   static bool is_other(uint8_t c, char delimiter = ',', char quote_char = '"') {
-    return c != static_cast<uint8_t>(delimiter) && c != '\n' && c != '\r' && c != static_cast<uint8_t>(quote_char);
+    return c != static_cast<uint8_t>(delimiter) && c != '\n' && c != '\r' &&
+           c != static_cast<uint8_t>(quote_char);
   }
 
   enum quote_state { AMBIGUOUS, QUOTED, UNQUOTED };
@@ -386,28 +395,32 @@ class TwoPass {
   /**
    * @brief Determine quote state at a position using backward scanning.
    */
-  static quote_state get_quotation_state(const uint8_t* buf, size_t start,
-                                         char delimiter = ',', char quote_char = '"');
+  static quote_state get_quotation_state(const uint8_t *buf, size_t start,
+                                         char delimiter = ',',
+                                         char quote_char = '"');
 
   /**
    * @brief Speculative first pass with dialect-aware quote character.
    */
-  static Stats first_pass_speculate(const uint8_t* buf, size_t start, size_t end,
-                                    char delimiter = ',', char quote_char = '"');
+  static Stats first_pass_speculate(const uint8_t *buf, size_t start,
+                                    size_t end, char delimiter = ',',
+                                    char quote_char = '"');
 
   /**
-   * @brief Second pass SIMD scan with dialect-aware delimiter and quote character.
+   * @brief Second pass SIMD scan with dialect-aware delimiter and quote
+   * character.
    */
-  static uint64_t second_pass_simd(const uint8_t* buf, size_t start, size_t end,
-                                   ParseIndex* out, size_t thread_id,
-                                   char delimiter = ',', char quote_char = '"') {
+  static uint64_t second_pass_simd(const uint8_t *buf, size_t start, size_t end,
+                                   ParseIndex *out, size_t thread_id,
+                                   char delimiter = ',',
+                                   char quote_char = '"') {
     bool is_quoted = false;
     assert(end >= start && "Invalid range: end must be >= start");
     size_t len = end - start;
     uint64_t idx = 0;
     size_t n_indexes = 0;
     size_t i = thread_id;
-    uint64_t prev_iter_inside_quote = 0ULL;  // either all zeros or all ones
+    uint64_t prev_iter_inside_quote = 0ULL; // either all zeros or all ones
     uint64_t base = 0;
     buf += start;
 
@@ -421,15 +434,17 @@ class TwoPass {
         mask = blsmsk_u64(1ULL << (len - idx));
       }
 
-      uint64_t quotes = cmp_mask_against_input(in, static_cast<uint8_t>(quote_char)) & mask;
+      uint64_t quotes =
+          cmp_mask_against_input(in, static_cast<uint8_t>(quote_char)) & mask;
 
       uint64_t quote_mask = find_quote_mask2(quotes, prev_iter_inside_quote);
-      uint64_t sep = cmp_mask_against_input(in, static_cast<uint8_t>(delimiter)) & mask;
+      uint64_t sep =
+          cmp_mask_against_input(in, static_cast<uint8_t>(delimiter)) & mask;
       // Support LF, CRLF, and CR-only line endings
       uint64_t end_mask = compute_line_ending_mask_simple(in, mask);
       uint64_t field_sep = (end_mask | sep) & ~quote_mask;
-      n_indexes +=
-          write(out->indexes + thread_id, base, start + idx, out->n_threads, field_sep);
+      n_indexes += write(out->indexes + thread_id, base, start + idx,
+                         out->n_threads, field_sep);
     }
     return n_indexes;
   }
@@ -437,9 +452,9 @@ class TwoPass {
   /**
    * @brief Branchless SIMD second pass using lookup table state machine.
    *
-   * This method uses the branchless state machine implementation which eliminates
-   * branch mispredictions by using precomputed lookup tables for character
-   * classification and state transitions.
+   * This method uses the branchless state machine implementation which
+   * eliminates branch mispredictions by using precomputed lookup tables for
+   * character classification and state transitions.
    *
    * Performance characteristics:
    * - Eliminates 90%+ of branches in the parsing hot path
@@ -455,9 +470,10 @@ class TwoPass {
    * @param thread_id Thread ID for interleaved storage
    * @return Number of field separators found
    */
-  static uint64_t second_pass_simd_branchless(const BranchlessStateMachine& sm,
-                                               const uint8_t* buf, size_t start, size_t end,
-                                               ParseIndex* out, size_t thread_id) {
+  static uint64_t second_pass_simd_branchless(const BranchlessStateMachine &sm,
+                                              const uint8_t *buf, size_t start,
+                                              size_t end, ParseIndex *out,
+                                              size_t thread_id) {
     return libvroom::second_pass_simd_branchless(
         sm, buf, start, end, out->indexes, thread_id, out->n_threads);
   }
@@ -480,11 +496,12 @@ class TwoPass {
    * - QUOTED_END + '\n' -> RECORD_START (record ended)
    */
   enum csv_state {
-    RECORD_START,    ///< At the beginning of a new record (row).
-    FIELD_START,     ///< At the beginning of a new field (after comma).
-    UNQUOTED_FIELD,  ///< Inside an unquoted field.
-    QUOTED_FIELD,    ///< Inside a quoted field.
-    QUOTED_END       ///< Just saw a quote inside a quoted field (might be closing or escape).
+    RECORD_START,   ///< At the beginning of a new record (row).
+    FIELD_START,    ///< At the beginning of a new field (after comma).
+    UNQUOTED_FIELD, ///< Inside an unquoted field.
+    QUOTED_FIELD,   ///< Inside a quoted field.
+    QUOTED_END ///< Just saw a quote inside a quoted field (might be closing or
+               ///< escape).
   };
 
   // Error result from state transitions
@@ -494,142 +511,159 @@ class TwoPass {
   };
 
   really_inline static StateResult quoted_state(csv_state in) {
-    // LCOV_EXCL_BR_START - State machine branches are covered by integration tests
+    // LCOV_EXCL_BR_START - State machine branches are covered by integration
+    // tests
     switch (in) {
-      case RECORD_START:
-        return {QUOTED_FIELD, ErrorCode::NONE};
-      case FIELD_START:
-        return {QUOTED_FIELD, ErrorCode::NONE};
-      case UNQUOTED_FIELD:
-        // Quote in middle of unquoted field
-        return {UNQUOTED_FIELD, ErrorCode::QUOTE_IN_UNQUOTED_FIELD};
-      case QUOTED_FIELD:
-        return {QUOTED_END, ErrorCode::NONE};
-      case QUOTED_END:
-        return {QUOTED_FIELD, ErrorCode::NONE};
+    case RECORD_START:
+      return {QUOTED_FIELD, ErrorCode::NONE};
+    case FIELD_START:
+      return {QUOTED_FIELD, ErrorCode::NONE};
+    case UNQUOTED_FIELD:
+      // Quote in middle of unquoted field
+      return {UNQUOTED_FIELD, ErrorCode::QUOTE_IN_UNQUOTED_FIELD};
+    case QUOTED_FIELD:
+      return {QUOTED_END, ErrorCode::NONE};
+    case QUOTED_END:
+      return {QUOTED_FIELD, ErrorCode::NONE};
     }
     // LCOV_EXCL_BR_STOP
-    return {in, ErrorCode::INTERNAL_ERROR};  // LCOV_EXCL_LINE - unreachable
+    return {in, ErrorCode::INTERNAL_ERROR}; // LCOV_EXCL_LINE - unreachable
   }
 
   really_inline static StateResult comma_state(csv_state in) {
-    // LCOV_EXCL_BR_START - State machine branches are covered by integration tests
+    // LCOV_EXCL_BR_START - State machine branches are covered by integration
+    // tests
     switch (in) {
-      case RECORD_START:
-        return {FIELD_START, ErrorCode::NONE};
-      case FIELD_START:
-        return {FIELD_START, ErrorCode::NONE};
-      case UNQUOTED_FIELD:
-        return {FIELD_START, ErrorCode::NONE};
-      case QUOTED_FIELD:
-        return {QUOTED_FIELD, ErrorCode::NONE};
-      case QUOTED_END:
-        return {FIELD_START, ErrorCode::NONE};
+    case RECORD_START:
+      return {FIELD_START, ErrorCode::NONE};
+    case FIELD_START:
+      return {FIELD_START, ErrorCode::NONE};
+    case UNQUOTED_FIELD:
+      return {FIELD_START, ErrorCode::NONE};
+    case QUOTED_FIELD:
+      return {QUOTED_FIELD, ErrorCode::NONE};
+    case QUOTED_END:
+      return {FIELD_START, ErrorCode::NONE};
     }
     // LCOV_EXCL_BR_STOP
-    return {in, ErrorCode::INTERNAL_ERROR};  // LCOV_EXCL_LINE - unreachable
+    return {in, ErrorCode::INTERNAL_ERROR}; // LCOV_EXCL_LINE - unreachable
   }
 
   really_inline static StateResult newline_state(csv_state in) {
-    // LCOV_EXCL_BR_START - State machine branches are covered by integration tests
+    // LCOV_EXCL_BR_START - State machine branches are covered by integration
+    // tests
     switch (in) {
-      case RECORD_START:
-        return {RECORD_START, ErrorCode::NONE};
-      case FIELD_START:
-        return {RECORD_START, ErrorCode::NONE};
-      case UNQUOTED_FIELD:
-        return {RECORD_START, ErrorCode::NONE};
-      case QUOTED_FIELD:
-        return {QUOTED_FIELD, ErrorCode::NONE};
-      case QUOTED_END:
-        return {RECORD_START, ErrorCode::NONE};
+    case RECORD_START:
+      return {RECORD_START, ErrorCode::NONE};
+    case FIELD_START:
+      return {RECORD_START, ErrorCode::NONE};
+    case UNQUOTED_FIELD:
+      return {RECORD_START, ErrorCode::NONE};
+    case QUOTED_FIELD:
+      return {QUOTED_FIELD, ErrorCode::NONE};
+    case QUOTED_END:
+      return {RECORD_START, ErrorCode::NONE};
     }
     // LCOV_EXCL_BR_STOP
-    return {in, ErrorCode::INTERNAL_ERROR};  // LCOV_EXCL_LINE - unreachable
+    return {in, ErrorCode::INTERNAL_ERROR}; // LCOV_EXCL_LINE - unreachable
   }
 
   really_inline static StateResult other_state(csv_state in) {
-    // LCOV_EXCL_BR_START - State machine branches are covered by integration tests
+    // LCOV_EXCL_BR_START - State machine branches are covered by integration
+    // tests
     switch (in) {
-      case RECORD_START:
-        return {UNQUOTED_FIELD, ErrorCode::NONE};
-      case FIELD_START:
-        return {UNQUOTED_FIELD, ErrorCode::NONE};
-      case UNQUOTED_FIELD:
-        return {UNQUOTED_FIELD, ErrorCode::NONE};
-      case QUOTED_FIELD:
-        return {QUOTED_FIELD, ErrorCode::NONE};
-      case QUOTED_END:
-        // Invalid character after closing quote
-        return {UNQUOTED_FIELD, ErrorCode::INVALID_QUOTE_ESCAPE};
+    case RECORD_START:
+      return {UNQUOTED_FIELD, ErrorCode::NONE};
+    case FIELD_START:
+      return {UNQUOTED_FIELD, ErrorCode::NONE};
+    case UNQUOTED_FIELD:
+      return {UNQUOTED_FIELD, ErrorCode::NONE};
+    case QUOTED_FIELD:
+      return {QUOTED_FIELD, ErrorCode::NONE};
+    case QUOTED_END:
+      // Invalid character after closing quote
+      return {UNQUOTED_FIELD, ErrorCode::INVALID_QUOTE_ESCAPE};
     }
     // LCOV_EXCL_BR_STOP
-    return {in, ErrorCode::INTERNAL_ERROR};  // LCOV_EXCL_LINE - unreachable
+    return {in, ErrorCode::INTERNAL_ERROR}; // LCOV_EXCL_LINE - unreachable
   }
 
-  really_inline static size_t add_position(ParseIndex* out, size_t i, size_t pos) {
+  really_inline static size_t add_position(ParseIndex *out, size_t i,
+                                           size_t pos) {
     out->indexes[i] = pos;
     return i + out->n_threads;
   }
 
-  // Default context size for error messages (characters before/after error position)
+  // Default context size for error messages (characters before/after error
+  // position)
   static constexpr size_t DEFAULT_ERROR_CONTEXT_SIZE = 20;
 
   // Helper to get context around an error position
-  // Returns a string representation of the buffer content near the given position
-  static std::string get_context(const uint8_t* buf, size_t len, size_t pos,
-                                 size_t context_size = DEFAULT_ERROR_CONTEXT_SIZE);
+  // Returns a string representation of the buffer content near the given
+  // position
+  static std::string
+  get_context(const uint8_t *buf, size_t len, size_t pos,
+              size_t context_size = DEFAULT_ERROR_CONTEXT_SIZE);
 
   // Helper to calculate line and column from byte offset
   // SECURITY: buf_len parameter ensures we never read past buffer bounds
-  static void get_line_column(const uint8_t* buf, size_t buf_len, size_t offset,
-                               size_t& line, size_t& column);
+  static void get_line_column(const uint8_t *buf, size_t buf_len, size_t offset,
+                              size_t &line, size_t &column);
 
   /**
    * @brief Second pass with error collection and dialect support.
    */
-  static uint64_t second_pass_chunk(const uint8_t* buf, size_t start, size_t end,
-                                    ParseIndex* out, size_t thread_id,
-                                    ErrorCollector* errors = nullptr,
-                                    size_t total_len = 0,
-                                    char delimiter = ',', char quote_char = '"');
+  static uint64_t second_pass_chunk(const uint8_t *buf, size_t start,
+                                    size_t end, ParseIndex *out,
+                                    size_t thread_id,
+                                    ErrorCollector *errors = nullptr,
+                                    size_t total_len = 0, char delimiter = ',',
+                                    char quote_char = '"');
 
   /**
-   * @brief Second pass that throws on error (backward compatible), with dialect support.
+   * @brief Second pass that throws on error (backward compatible), with dialect
+   * support.
    */
-  static uint64_t second_pass_chunk_throwing(const uint8_t* buf, size_t start, size_t end,
-                                             ParseIndex* out, size_t thread_id,
-                                             char delimiter = ',', char quote_char = '"');
+  static uint64_t second_pass_chunk_throwing(const uint8_t *buf, size_t start,
+                                             size_t end, ParseIndex *out,
+                                             size_t thread_id,
+                                             char delimiter = ',',
+                                             char quote_char = '"');
 
   /**
    * @brief Parse using speculative multi-threading with dialect support.
    *
-   * @deprecated Use Parser::parse() with ParseOptions{.algorithm = ParseAlgorithm::SPECULATIVE}
-   *             instead. This method will be made private in a future version.
+   * @deprecated Use Parser::parse() with ParseOptions{.algorithm =
+   * ParseAlgorithm::SPECULATIVE} instead. This method will be made private in a
+   * future version.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::SPECULATIVE instead")
-  bool parse_speculate(const uint8_t* buf, ParseIndex& out, size_t len,
-                       const Dialect& dialect = Dialect::csv());
+  LIBVROOM_DEPRECATED(
+      "Use Parser::parse() with ParseAlgorithm::SPECULATIVE instead")
+  bool parse_speculate(const uint8_t *buf, ParseIndex &out, size_t len,
+                       const Dialect &dialect = Dialect::csv());
 
   /**
    * @brief Parse using two-pass algorithm with dialect support.
    *
-   * @deprecated Use Parser::parse() with ParseOptions{.algorithm = ParseAlgorithm::TWO_PASS}
-   *             instead. This method will be made private in a future version.
+   * @deprecated Use Parser::parse() with ParseOptions{.algorithm =
+   * ParseAlgorithm::TWO_PASS} instead. This method will be made private in a
+   * future version.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::TWO_PASS instead")
-  bool parse_two_pass(const uint8_t* buf, ParseIndex& out, size_t len,
-                      const Dialect& dialect = Dialect::csv());
+  LIBVROOM_DEPRECATED(
+      "Use Parser::parse() with ParseAlgorithm::TWO_PASS instead")
+  bool parse_two_pass(const uint8_t *buf, ParseIndex &out, size_t len,
+                      const Dialect &dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer and build the field index.
    *
    * @deprecated Use Parser::parse() from libvroom.h instead. The Parser class
-   *             provides a simpler, unified API with automatic index management.
+   *             provides a simpler, unified API with automatic index
+   * management.
    */
   LIBVROOM_DEPRECATED("Use Parser::parse() from libvroom.h instead")
-  bool parse(const uint8_t* buf, ParseIndex& out, size_t len,
-             const Dialect& dialect = Dialect::csv());
+  bool parse(const uint8_t *buf, ParseIndex &out, size_t len,
+             const Dialect &dialect = Dialect::csv());
 
   // Result from multi-threaded branchless parsing with error collection
   struct branchless_chunk_result {
@@ -640,44 +674,51 @@ class TwoPass {
   };
 
   /**
-   * @brief Static wrapper for thread-safe branchless parsing with error collection.
+   * @brief Static wrapper for thread-safe branchless parsing with error
+   * collection.
    */
   static branchless_chunk_result second_pass_branchless_chunk_with_errors(
-      const BranchlessStateMachine& sm,
-      const uint8_t* buf, size_t start, size_t end,
-      ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode);
+      const BranchlessStateMachine &sm, const uint8_t *buf, size_t start,
+      size_t end, ParseIndex *out, size_t thread_id, size_t total_len,
+      ErrorMode mode);
 
   /**
-   * @brief Parse a CSV buffer using branchless state machine with error collection.
+   * @brief Parse a CSV buffer using branchless state machine with error
+   * collection.
    */
-  bool parse_branchless_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
-                                    ErrorCollector& errors,
-                                    const Dialect& dialect = Dialect::csv());
+  bool parse_branchless_with_errors(const uint8_t *buf, ParseIndex &out,
+                                    size_t len, ErrorCollector &errors,
+                                    const Dialect &dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer using branchless state machine (optimized).
    *
    * @deprecated Use Parser::parse() with ParseOptions::branchless() instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with ParseOptions::branchless() instead")
-  bool parse_branchless(const uint8_t* buf, ParseIndex& out, size_t len,
-                        const Dialect& dialect = Dialect::csv());
+  LIBVROOM_DEPRECATED(
+      "Use Parser::parse() with ParseOptions::branchless() instead")
+  bool parse_branchless(const uint8_t *buf, ParseIndex &out, size_t len,
+                        const Dialect &dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with automatic dialect detection.
    *
-   * @deprecated Use Parser::parse() with default ParseOptions (auto-detects dialect).
+   * @deprecated Use Parser::parse() with default ParseOptions (auto-detects
+   * dialect).
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.errors = &errors} instead (auto-detects dialect)")
-  bool parse_auto(const uint8_t* buf, ParseIndex& out, size_t len,
-                  ErrorCollector& errors, DetectionResult* detected = nullptr,
-                  const DetectionOptions& detection_options = DetectionOptions());
+  LIBVROOM_DEPRECATED("Use Parser::parse() with {.errors = &errors} instead "
+                      "(auto-detects dialect)")
+  bool
+  parse_auto(const uint8_t *buf, ParseIndex &out, size_t len,
+             ErrorCollector &errors, DetectionResult *detected = nullptr,
+             const DetectionOptions &detection_options = DetectionOptions());
 
   /**
    * @brief Detect the dialect of a CSV buffer without parsing.
    */
-  static DetectionResult detect_dialect(const uint8_t* buf, size_t len,
-                                         const DetectionOptions& options = DetectionOptions());
+  static DetectionResult
+  detect_dialect(const uint8_t *buf, size_t len,
+                 const DetectionOptions &options = DetectionOptions());
 
   // Result from multi-threaded parsing with error collection
   struct chunk_result {
@@ -688,58 +729,73 @@ class TwoPass {
   };
 
   /**
-   * @brief Static wrapper for thread-safe parsing with error collection and dialect.
+   * @brief Static wrapper for thread-safe parsing with error collection and
+   * dialect.
    */
-  static chunk_result second_pass_chunk_with_errors(
-      const uint8_t* buf, size_t start, size_t end,
-      ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode,
-      char delimiter = ',', char quote_char = '"');
+  static chunk_result
+  second_pass_chunk_with_errors(const uint8_t *buf, size_t start, size_t end,
+                                ParseIndex *out, size_t thread_id,
+                                size_t total_len, ErrorMode mode,
+                                char delimiter = ',', char quote_char = '"');
 
   /**
    * @brief Parse a CSV buffer with error collection using multi-threading.
    *
-   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors} instead.
+   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors}
+   * instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
-  bool parse_two_pass_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
-                                  ErrorCollector& errors,
-                                  const Dialect& dialect = Dialect::csv());
+  LIBVROOM_DEPRECATED(
+      "Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
+  bool parse_two_pass_with_errors(const uint8_t *buf, ParseIndex &out,
+                                  size_t len, ErrorCollector &errors,
+                                  const Dialect &dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with detailed error collection (single-threaded).
    *
-   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors} instead.
+   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors}
+   * instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
-  bool parse_with_errors(const uint8_t* buf, ParseIndex& out, size_t len, ErrorCollector& errors,
-                         const Dialect& dialect = Dialect::csv());
+  LIBVROOM_DEPRECATED(
+      "Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
+  bool parse_with_errors(const uint8_t *buf, ParseIndex &out, size_t len,
+                         ErrorCollector &errors,
+                         const Dialect &dialect = Dialect::csv());
 
   // Check for empty header
-  static bool check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors);
+  static bool check_empty_header(const uint8_t *buf, size_t len,
+                                 ErrorCollector &errors);
 
   /**
    * @brief Check for duplicate column names in header with dialect support.
    */
-  static void check_duplicate_columns(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                      char delimiter = ',', char quote_char = '"');
+  static void check_duplicate_columns(const uint8_t *buf, size_t len,
+                                      ErrorCollector &errors,
+                                      char delimiter = ',',
+                                      char quote_char = '"');
 
   /**
    * @brief Check for inconsistent field counts with dialect support.
    */
-  static void check_field_counts(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                 char delimiter = ',', char quote_char = '"');
+  static void check_field_counts(const uint8_t *buf, size_t len,
+                                 ErrorCollector &errors, char delimiter = ',',
+                                 char quote_char = '"');
 
   // Check for mixed line endings
-  static void check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors);
+  static void check_line_endings(const uint8_t *buf, size_t len,
+                                 ErrorCollector &errors);
 
   /**
    * @brief Perform full CSV validation with comprehensive error checking.
    *
-   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors} instead.
+   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors}
+   * instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
-  bool parse_validate(const uint8_t* buf, ParseIndex& out, size_t len, ErrorCollector& errors,
-                      const Dialect& dialect = Dialect::csv());
+  LIBVROOM_DEPRECATED(
+      "Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
+  bool parse_validate(const uint8_t *buf, ParseIndex &out, size_t len,
+                      ErrorCollector &errors,
+                      const Dialect &dialect = Dialect::csv());
 
   /**
    * @brief Initialize an index structure for parsing.
@@ -749,13 +805,15 @@ class TwoPass {
   /**
    * @brief Initialize an index structure with overflow validation.
    */
-  ParseIndex init_safe(size_t len, size_t n_threads, ErrorCollector* errors = nullptr);
+  ParseIndex init_safe(size_t len, size_t n_threads,
+                       ErrorCollector *errors = nullptr);
 };
 
 /// @brief Backward-compatible alias for TwoPass.
-/// @deprecated Use TwoPass instead. This alias will be removed in a future version.
+/// @deprecated Use TwoPass instead. This alias will be removed in a future
+/// version.
 using two_pass [[deprecated("Use TwoPass instead")]] = TwoPass;
 
-}  // namespace libvroom
+} // namespace libvroom
 
-#endif  // TWO_PASS_H
+#endif // TWO_PASS_H

--- a/src/arrow_output.cpp
+++ b/src/arrow_output.cpp
@@ -3,13 +3,13 @@
 #include "arrow_output.h"
 #include "io_util.h"
 #include "mem_util.h"
+#include <algorithm>
 #include <arrow/builder.h>
 #include <arrow/table.h>
-#include <algorithm>
 #include <cassert>
-#include <charconv>
 #include <cctype>
 #include <cerrno>
+#include <charconv>
 #include <cmath>
 #include <cstring>
 #include <memory>
@@ -18,406 +18,550 @@
 namespace libvroom {
 
 // RAII wrapper for aligned memory to ensure proper cleanup on all code paths
-// This prevents memory leaks when exceptions are thrown during parsing or conversion
+// This prevents memory leaks when exceptions are thrown during parsing or
+// conversion
 struct AlignedDeleter {
-    void operator()(uint8_t* ptr) const noexcept {
-        if (ptr) aligned_free(ptr);
-    }
+  void operator()(uint8_t *ptr) const noexcept {
+    if (ptr)
+      aligned_free(ptr);
+  }
 };
 using AlignedBufferPtr = std::unique_ptr<uint8_t, AlignedDeleter>;
 
 std::shared_ptr<arrow::DataType> column_type_to_arrow(ColumnType type) {
-    switch (type) {
-        case ColumnType::STRING: return arrow::utf8();
-        case ColumnType::INT64: return arrow::int64();
-        case ColumnType::DOUBLE: return arrow::float64();
-        case ColumnType::BOOLEAN: return arrow::boolean();
-        case ColumnType::DATE: return arrow::date32();
-        case ColumnType::TIMESTAMP: return arrow::timestamp(arrow::TimeUnit::MICRO);
-        case ColumnType::NULL_TYPE: return arrow::null();
-        default: return arrow::utf8();
-    }
+  switch (type) {
+  case ColumnType::STRING:
+    return arrow::utf8();
+  case ColumnType::INT64:
+    return arrow::int64();
+  case ColumnType::DOUBLE:
+    return arrow::float64();
+  case ColumnType::BOOLEAN:
+    return arrow::boolean();
+  case ColumnType::DATE:
+    return arrow::date32();
+  case ColumnType::TIMESTAMP:
+    return arrow::timestamp(arrow::TimeUnit::MICRO);
+  case ColumnType::NULL_TYPE:
+    return arrow::null();
+  default:
+    return arrow::utf8();
+  }
 }
 
-const char* column_type_to_string(ColumnType type) {
-    switch (type) {
-        case ColumnType::STRING: return "STRING";
-        case ColumnType::INT64: return "INT64";
-        case ColumnType::DOUBLE: return "DOUBLE";
-        case ColumnType::BOOLEAN: return "BOOLEAN";
-        case ColumnType::DATE: return "DATE";
-        case ColumnType::TIMESTAMP: return "TIMESTAMP";
-        case ColumnType::NULL_TYPE: return "NULL";
-        case ColumnType::AUTO: return "AUTO";
-        default: return "UNKNOWN";
-    }
+const char *column_type_to_string(ColumnType type) {
+  switch (type) {
+  case ColumnType::STRING:
+    return "STRING";
+  case ColumnType::INT64:
+    return "INT64";
+  case ColumnType::DOUBLE:
+    return "DOUBLE";
+  case ColumnType::BOOLEAN:
+    return "BOOLEAN";
+  case ColumnType::DATE:
+    return "DATE";
+  case ColumnType::TIMESTAMP:
+    return "TIMESTAMP";
+  case ColumnType::NULL_TYPE:
+    return "NULL";
+  case ColumnType::AUTO:
+    return "AUTO";
+  default:
+    return "UNKNOWN";
+  }
 }
 
 namespace {
 // Case-insensitive string comparison for ASCII
 bool iequals(std::string_view a, std::string_view b) {
-    if (a.size() != b.size()) return false;
-    for (size_t i = 0; i < a.size(); ++i) {
-        if (std::tolower(static_cast<unsigned char>(a[i])) !=
-            std::tolower(static_cast<unsigned char>(b[i]))) return false;
-    }
-    return true;
+  if (a.size() != b.size())
+    return false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(a[i])) !=
+        std::tolower(static_cast<unsigned char>(b[i])))
+      return false;
+  }
+  return true;
 }
-}  // anonymous namespace
+} // anonymous namespace
 
 ArrowConverter::ArrowConverter() : options_(), has_user_schema_(false) {}
-ArrowConverter::ArrowConverter(const ArrowConvertOptions& options) : options_(options), has_user_schema_(false) {
-    // Validate type_inference_rows does not exceed the maximum allowed value
-    if (options_.type_inference_rows > ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) {
-        throw std::invalid_argument(
-            "type_inference_rows (" + std::to_string(options_.type_inference_rows) +
-            ") exceeds maximum allowed (" + std::to_string(ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) + ")");
-    }
+ArrowConverter::ArrowConverter(const ArrowConvertOptions &options)
+    : options_(options), has_user_schema_(false) {
+  // Validate type_inference_rows does not exceed the maximum allowed value
+  if (options_.type_inference_rows >
+      ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) {
+    throw std::invalid_argument(
+        "type_inference_rows (" + std::to_string(options_.type_inference_rows) +
+        ") exceeds maximum allowed (" +
+        std::to_string(ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) + ")");
+  }
 }
-ArrowConverter::ArrowConverter(const std::vector<ColumnSpec>& columns, const ArrowConvertOptions& options)
+ArrowConverter::ArrowConverter(const std::vector<ColumnSpec> &columns,
+                               const ArrowConvertOptions &options)
     : options_(options), columns_(columns), has_user_schema_(true) {
-    // Validate type_inference_rows does not exceed the maximum allowed value
-    if (options_.type_inference_rows > ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) {
-        throw std::invalid_argument(
-            "type_inference_rows (" + std::to_string(options_.type_inference_rows) +
-            ") exceeds maximum allowed (" + std::to_string(ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) + ")");
-    }
+  // Validate type_inference_rows does not exceed the maximum allowed value
+  if (options_.type_inference_rows >
+      ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) {
+    throw std::invalid_argument(
+        "type_inference_rows (" + std::to_string(options_.type_inference_rows) +
+        ") exceeds maximum allowed (" +
+        std::to_string(ArrowConvertOptions::MAX_TYPE_INFERENCE_ROWS) + ")");
+  }
 }
 
 bool ArrowConverter::is_null_value(std::string_view value) {
-    for (const auto& null_str : options_.null_values) {
-        if (value == null_str) return true;
-    }
-    return false;
+  for (const auto &null_str : options_.null_values) {
+    if (value == null_str)
+      return true;
+  }
+  return false;
 }
 
 std::optional<bool> ArrowConverter::parse_boolean(std::string_view value) {
-    // Use case-insensitive comparison without allocating temporary strings
-    for (const auto& v : options_.true_values) {
-        if (iequals(value, v)) return true;
-    }
-    for (const auto& v : options_.false_values) {
-        if (iequals(value, v)) return false;
-    }
-    return std::nullopt;
+  // Use case-insensitive comparison without allocating temporary strings
+  for (const auto &v : options_.true_values) {
+    if (iequals(value, v))
+      return true;
+  }
+  for (const auto &v : options_.false_values) {
+    if (iequals(value, v))
+      return false;
+  }
+  return std::nullopt;
 }
 
 std::optional<int64_t> ArrowConverter::parse_int64(std::string_view value) {
-    if (value.empty()) return std::nullopt;
-    size_t start = 0, end = value.size();
-    while (start < end && std::isspace(static_cast<unsigned char>(value[start]))) ++start;
-    while (end > start && std::isspace(static_cast<unsigned char>(value[end-1]))) --end;
-    if (start >= end) return std::nullopt;
-    int64_t result;
-    auto [ptr, ec] = std::from_chars(value.data()+start, value.data()+end, result);
-    if (ec == std::errc() && ptr == value.data()+end) return result;
+  if (value.empty())
     return std::nullopt;
+  size_t start = 0, end = value.size();
+  while (start < end && std::isspace(static_cast<unsigned char>(value[start])))
+    ++start;
+  while (end > start &&
+         std::isspace(static_cast<unsigned char>(value[end - 1])))
+    --end;
+  if (start >= end)
+    return std::nullopt;
+  int64_t result;
+  auto [ptr, ec] =
+      std::from_chars(value.data() + start, value.data() + end, result);
+  if (ec == std::errc() && ptr == value.data() + end)
+    return result;
+  return std::nullopt;
 }
 
 std::optional<double> ArrowConverter::parse_double(std::string_view value) {
-    if (value.empty()) return std::nullopt;
-    size_t start = 0, end = value.size();
-    while (start < end && std::isspace(static_cast<unsigned char>(value[start]))) ++start;
-    while (end > start && std::isspace(static_cast<unsigned char>(value[end-1]))) --end;
-    if (start >= end) return std::nullopt;
-    std::string_view trimmed = value.substr(start, end-start);
-    if (trimmed == "inf" || trimmed == "Inf") return std::numeric_limits<double>::infinity();
-    if (trimmed == "-inf" || trimmed == "-Inf") return -std::numeric_limits<double>::infinity();
-    if (trimmed == "nan" || trimmed == "NaN") return std::numeric_limits<double>::quiet_NaN();
-    char* endptr;
-    std::string temp(trimmed);
-    errno = 0;  // Reset errno before call
-    double result = std::strtod(temp.c_str(), &endptr);
-    // Check for parsing success and overflow/underflow (ERANGE)
-    if (endptr == temp.c_str() + temp.size() && errno != ERANGE) return result;
+  if (value.empty())
     return std::nullopt;
+  size_t start = 0, end = value.size();
+  while (start < end && std::isspace(static_cast<unsigned char>(value[start])))
+    ++start;
+  while (end > start &&
+         std::isspace(static_cast<unsigned char>(value[end - 1])))
+    --end;
+  if (start >= end)
+    return std::nullopt;
+  std::string_view trimmed = value.substr(start, end - start);
+  if (trimmed == "inf" || trimmed == "Inf")
+    return std::numeric_limits<double>::infinity();
+  if (trimmed == "-inf" || trimmed == "-Inf")
+    return -std::numeric_limits<double>::infinity();
+  if (trimmed == "nan" || trimmed == "NaN")
+    return std::numeric_limits<double>::quiet_NaN();
+  char *endptr;
+  std::string temp(trimmed);
+  errno = 0; // Reset errno before call
+  double result = std::strtod(temp.c_str(), &endptr);
+  // Check for parsing success and overflow/underflow (ERANGE)
+  if (endptr == temp.c_str() + temp.size() && errno != ERANGE)
+    return result;
+  return std::nullopt;
 }
 
 ColumnType ArrowConverter::infer_cell_type(std::string_view cell) {
-    if (cell.empty() || is_null_value(cell)) return ColumnType::NULL_TYPE;
-    if (parse_boolean(cell).has_value()) return ColumnType::BOOLEAN;
-    if (parse_int64(cell).has_value()) return ColumnType::INT64;
-    if (parse_double(cell).has_value()) return ColumnType::DOUBLE;
-    return ColumnType::STRING;
+  if (cell.empty() || is_null_value(cell))
+    return ColumnType::NULL_TYPE;
+  if (parse_boolean(cell).has_value())
+    return ColumnType::BOOLEAN;
+  if (parse_int64(cell).has_value())
+    return ColumnType::INT64;
+  if (parse_double(cell).has_value())
+    return ColumnType::DOUBLE;
+  return ColumnType::STRING;
 }
 
-std::string_view ArrowConverter::extract_field(const uint8_t* buf, size_t start, size_t end, const Dialect& dialect) {
-    // Validate bounds to catch corrupted index data early in debug builds.
-    // If end < start with unsigned types, subtraction would underflow causing
-    // buffer over-reads and undefined behavior.
-    assert(end >= start && "Invalid field range: end must be >= start");
-    // Return an empty string_view with a valid data pointer (not nullptr).
-    // Using std::string_view() returns a view with data()==nullptr, which causes
-    // undefined behavior when constructing std::string from it on some platforms
-    // (notably macOS). By using buf+start, we ensure data() is always valid.
-    if (start >= end) return std::string_view(reinterpret_cast<const char*>(buf + start), 0);
-    const char* field_start = reinterpret_cast<const char*>(buf + start);
-    size_t len = end - start;
-    if (len >= 2 && field_start[0] == dialect.quote_char && field_start[len-1] == dialect.quote_char) {
-        field_start++; len -= 2;
-    }
-    return std::string_view(field_start, len);
+std::string_view ArrowConverter::extract_field(const uint8_t *buf, size_t start,
+                                               size_t end,
+                                               const Dialect &dialect) {
+  // Validate bounds to catch corrupted index data early in debug builds.
+  // If end < start with unsigned types, subtraction would underflow causing
+  // buffer over-reads and undefined behavior.
+  assert(end >= start && "Invalid field range: end must be >= start");
+  // Return an empty string_view with a valid data pointer (not nullptr).
+  // Using std::string_view() returns a view with data()==nullptr, which causes
+  // undefined behavior when constructing std::string from it on some platforms
+  // (notably macOS). By using buf+start, we ensure data() is always valid.
+  if (start >= end)
+    return std::string_view(reinterpret_cast<const char *>(buf + start), 0);
+  const char *field_start = reinterpret_cast<const char *>(buf + start);
+  size_t len = end - start;
+  if (len >= 2 && field_start[0] == dialect.quote_char &&
+      field_start[len - 1] == dialect.quote_char) {
+    field_start++;
+    len -= 2;
+  }
+  return std::string_view(field_start, len);
 }
 
-std::vector<std::vector<ArrowConverter::FieldRange>> ArrowConverter::extract_field_ranges(
-    const uint8_t* buf, size_t len, const ParseIndex& idx, const Dialect& dialect) {
-    std::vector<std::vector<FieldRange>> columns;
-    if (idx.n_threads == 0) return columns;
-    size_t total_seps = 0;
-    for (uint8_t t = 0; t < idx.n_threads; ++t) total_seps += idx.n_indexes[t];
-    if (total_seps == 0) return columns;
-    std::vector<uint64_t> all_positions;
-    all_positions.reserve(total_seps);
-    for (uint8_t t = 0; t < idx.n_threads; ++t)
-        for (size_t i = 0; i < idx.n_indexes[t]; ++i) {
-            uint64_t pos = idx.indexes[t + i * idx.n_threads];
-            if (pos < len) all_positions.push_back(pos);  // Bounds check to prevent buffer overrun
-        }
-    std::sort(all_positions.begin(), all_positions.end());
-    if (all_positions.empty()) return columns;  // No valid positions after bounds filtering
-    size_t num_columns = 0;
-    for (size_t i = 0; i < all_positions.size(); ++i) {
-        num_columns++;
-        if (buf[all_positions[i]] == '\n') break;
-    }
-    if (num_columns == 0) return columns;
-    columns.resize(num_columns);
-    size_t field_start = 0, current_col = 0;
-    bool skip_header = true;
-    for (size_t i = 0; i < all_positions.size(); ++i) {
-        size_t field_end = all_positions[i];
-        char sep_char = static_cast<char>(buf[field_end]);
-        if (!skip_header && current_col < num_columns)
-            columns[current_col].push_back({field_start, field_end});
-        if (sep_char == '\n') { if (skip_header) skip_header = false; current_col = 0; }
-        else current_col++;
-        field_start = field_end + 1;
-    }
+std::vector<std::vector<ArrowConverter::FieldRange>>
+ArrowConverter::extract_field_ranges(const uint8_t *buf, size_t len,
+                                     const ParseIndex &idx,
+                                     const Dialect &dialect) {
+  std::vector<std::vector<FieldRange>> columns;
+  if (idx.n_threads == 0)
     return columns;
+  size_t total_seps = 0;
+  for (uint16_t t = 0; t < idx.n_threads; ++t)
+    total_seps += idx.n_indexes[t];
+  if (total_seps == 0)
+    return columns;
+  std::vector<uint64_t> all_positions;
+  all_positions.reserve(total_seps);
+  for (uint16_t t = 0; t < idx.n_threads; ++t)
+    for (size_t i = 0; i < idx.n_indexes[t]; ++i) {
+      uint64_t pos = idx.indexes[t + i * idx.n_threads];
+      if (pos < len)
+        all_positions.push_back(pos); // Bounds check to prevent buffer overrun
+    }
+  std::sort(all_positions.begin(), all_positions.end());
+  if (all_positions.empty())
+    return columns; // No valid positions after bounds filtering
+  size_t num_columns = 0;
+  for (size_t i = 0; i < all_positions.size(); ++i) {
+    num_columns++;
+    if (buf[all_positions[i]] == '\n')
+      break;
+  }
+  if (num_columns == 0)
+    return columns;
+  columns.resize(num_columns);
+  size_t field_start = 0, current_col = 0;
+  bool skip_header = true;
+  for (size_t i = 0; i < all_positions.size(); ++i) {
+    size_t field_end = all_positions[i];
+    char sep_char = static_cast<char>(buf[field_end]);
+    if (!skip_header && current_col < num_columns)
+      columns[current_col].push_back({field_start, field_end});
+    if (sep_char == '\n') {
+      if (skip_header)
+        skip_header = false;
+      current_col = 0;
+    } else
+      current_col++;
+    field_start = field_end + 1;
+  }
+  return columns;
 }
 
-std::vector<ColumnType> ArrowConverter::infer_types(const uint8_t* buf, size_t len, const ParseIndex& idx, const Dialect& dialect) {
-    auto field_ranges = extract_field_ranges(buf, len, idx, dialect);
-    std::vector<ColumnType> types(field_ranges.size(), ColumnType::NULL_TYPE);
-    for (size_t col = 0; col < field_ranges.size(); ++col) {
-        const auto& ranges = field_ranges[col];
-        size_t samples = options_.type_inference_rows > 0 ? std::min(options_.type_inference_rows, ranges.size()) : ranges.size();
-        ColumnType strongest = ColumnType::NULL_TYPE;
-        for (size_t row = 0; row < samples; ++row) {
-            ColumnType ct = infer_cell_type(extract_field(buf, ranges[row].start, ranges[row].end, dialect));
-            if (ct == ColumnType::NULL_TYPE) continue;
-            if (strongest == ColumnType::NULL_TYPE) strongest = ct;
-            else if (strongest != ct) {
-                // Type promotion rules:
-                // - INT64 + DOUBLE -> DOUBLE (standard numeric promotion)
-                // - BOOLEAN + INT64 -> INT64 (boolean values 0/1 are valid ints)
-                // - BOOLEAN + DOUBLE -> DOUBLE (boolean values 0/1 are valid doubles)
-                // - Any other mismatch -> STRING
-                if ((strongest == ColumnType::INT64 && ct == ColumnType::DOUBLE) ||
-                    (strongest == ColumnType::DOUBLE && ct == ColumnType::INT64)) {
-                    strongest = ColumnType::DOUBLE;
-                } else if ((strongest == ColumnType::BOOLEAN && ct == ColumnType::INT64) ||
-                           (strongest == ColumnType::INT64 && ct == ColumnType::BOOLEAN)) {
-                    strongest = ColumnType::INT64;
-                } else if ((strongest == ColumnType::BOOLEAN && ct == ColumnType::DOUBLE) ||
-                           (strongest == ColumnType::DOUBLE && ct == ColumnType::BOOLEAN)) {
-                    strongest = ColumnType::DOUBLE;
-                } else {
-                    strongest = ColumnType::STRING;
-                    break;
-                }
-            }
+std::vector<ColumnType> ArrowConverter::infer_types(const uint8_t *buf,
+                                                    size_t len,
+                                                    const ParseIndex &idx,
+                                                    const Dialect &dialect) {
+  auto field_ranges = extract_field_ranges(buf, len, idx, dialect);
+  std::vector<ColumnType> types(field_ranges.size(), ColumnType::NULL_TYPE);
+  for (size_t col = 0; col < field_ranges.size(); ++col) {
+    const auto &ranges = field_ranges[col];
+    size_t samples = options_.type_inference_rows > 0
+                         ? std::min(options_.type_inference_rows, ranges.size())
+                         : ranges.size();
+    ColumnType strongest = ColumnType::NULL_TYPE;
+    for (size_t row = 0; row < samples; ++row) {
+      ColumnType ct = infer_cell_type(
+          extract_field(buf, ranges[row].start, ranges[row].end, dialect));
+      if (ct == ColumnType::NULL_TYPE)
+        continue;
+      if (strongest == ColumnType::NULL_TYPE)
+        strongest = ct;
+      else if (strongest != ct) {
+        // Type promotion rules:
+        // - INT64 + DOUBLE -> DOUBLE (standard numeric promotion)
+        // - BOOLEAN + INT64 -> INT64 (boolean values 0/1 are valid ints)
+        // - BOOLEAN + DOUBLE -> DOUBLE (boolean values 0/1 are valid doubles)
+        // - Any other mismatch -> STRING
+        if ((strongest == ColumnType::INT64 && ct == ColumnType::DOUBLE) ||
+            (strongest == ColumnType::DOUBLE && ct == ColumnType::INT64)) {
+          strongest = ColumnType::DOUBLE;
+        } else if ((strongest == ColumnType::BOOLEAN &&
+                    ct == ColumnType::INT64) ||
+                   (strongest == ColumnType::INT64 &&
+                    ct == ColumnType::BOOLEAN)) {
+          strongest = ColumnType::INT64;
+        } else if ((strongest == ColumnType::BOOLEAN &&
+                    ct == ColumnType::DOUBLE) ||
+                   (strongest == ColumnType::DOUBLE &&
+                    ct == ColumnType::BOOLEAN)) {
+          strongest = ColumnType::DOUBLE;
+        } else {
+          strongest = ColumnType::STRING;
+          break;
         }
-        types[col] = (strongest == ColumnType::NULL_TYPE) ? ColumnType::STRING : strongest;
+      }
     }
-    return types;
+    types[col] =
+        (strongest == ColumnType::NULL_TYPE) ? ColumnType::STRING : strongest;
+  }
+  return types;
 }
 
-std::shared_ptr<arrow::Schema> ArrowConverter::build_schema(const std::vector<std::string>& names, const std::vector<ColumnType>& types) {
-    std::vector<std::shared_ptr<arrow::Field>> fields;
-    for (size_t i = 0; i < names.size(); ++i) {
-        auto arrow_type = (has_user_schema_ && i < columns_.size() && columns_[i].arrow_type) ? columns_[i].arrow_type : (i < types.size() ? column_type_to_arrow(types[i]) : arrow::utf8());
-        bool nullable = has_user_schema_ && i < columns_.size() ? columns_[i].nullable : true;
-        fields.push_back(arrow::field(names[i], arrow_type, nullable));
-    }
-    return arrow::schema(fields);
+std::shared_ptr<arrow::Schema>
+ArrowConverter::build_schema(const std::vector<std::string> &names,
+                             const std::vector<ColumnType> &types) {
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  for (size_t i = 0; i < names.size(); ++i) {
+    auto arrow_type =
+        (has_user_schema_ && i < columns_.size() && columns_[i].arrow_type)
+            ? columns_[i].arrow_type
+            : (i < types.size() ? column_type_to_arrow(types[i])
+                                : arrow::utf8());
+    bool nullable =
+        has_user_schema_ && i < columns_.size() ? columns_[i].nullable : true;
+    fields.push_back(arrow::field(names[i], arrow_type, nullable));
+  }
+  return arrow::schema(fields);
 }
 
-arrow::Result<std::shared_ptr<arrow::Array>> ArrowConverter::build_string_column(const uint8_t* buf, const std::vector<FieldRange>& ranges, const Dialect& dialect) {
-    arrow::StringBuilder builder(options_.memory_pool);
-    ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
-    for (const auto& range : ranges) {
-        auto cell = extract_field(buf, range.start, range.end, dialect);
-        if (is_null_value(cell)) ARROW_RETURN_NOT_OK(builder.AppendNull());
-        else ARROW_RETURN_NOT_OK(builder.Append(std::string(cell)));
-    }
-    return builder.Finish();
+arrow::Result<std::shared_ptr<arrow::Array>>
+ArrowConverter::build_string_column(const uint8_t *buf,
+                                    const std::vector<FieldRange> &ranges,
+                                    const Dialect &dialect) {
+  arrow::StringBuilder builder(options_.memory_pool);
+  ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
+  for (const auto &range : ranges) {
+    auto cell = extract_field(buf, range.start, range.end, dialect);
+    if (is_null_value(cell))
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+    else
+      ARROW_RETURN_NOT_OK(builder.Append(std::string(cell)));
+  }
+  return builder.Finish();
 }
 
-arrow::Result<std::shared_ptr<arrow::Array>> ArrowConverter::build_int64_column(const uint8_t* buf, const std::vector<FieldRange>& ranges, const Dialect& dialect) {
-    arrow::Int64Builder builder(options_.memory_pool);
-    ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
-    for (const auto& range : ranges) {
-        auto cell = extract_field(buf, range.start, range.end, dialect);
-        if (is_null_value(cell)) ARROW_RETURN_NOT_OK(builder.AppendNull());
-        else if (auto v = parse_int64(cell)) ARROW_RETURN_NOT_OK(builder.Append(*v));
-        else ARROW_RETURN_NOT_OK(builder.AppendNull());
-    }
-    return builder.Finish();
+arrow::Result<std::shared_ptr<arrow::Array>>
+ArrowConverter::build_int64_column(const uint8_t *buf,
+                                   const std::vector<FieldRange> &ranges,
+                                   const Dialect &dialect) {
+  arrow::Int64Builder builder(options_.memory_pool);
+  ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
+  for (const auto &range : ranges) {
+    auto cell = extract_field(buf, range.start, range.end, dialect);
+    if (is_null_value(cell))
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+    else if (auto v = parse_int64(cell))
+      ARROW_RETURN_NOT_OK(builder.Append(*v));
+    else
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+  }
+  return builder.Finish();
 }
 
-arrow::Result<std::shared_ptr<arrow::Array>> ArrowConverter::build_double_column(const uint8_t* buf, const std::vector<FieldRange>& ranges, const Dialect& dialect) {
-    arrow::DoubleBuilder builder(options_.memory_pool);
-    ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
-    for (const auto& range : ranges) {
-        auto cell = extract_field(buf, range.start, range.end, dialect);
-        if (is_null_value(cell)) ARROW_RETURN_NOT_OK(builder.AppendNull());
-        else if (auto v = parse_double(cell)) ARROW_RETURN_NOT_OK(builder.Append(*v));
-        else ARROW_RETURN_NOT_OK(builder.AppendNull());
-    }
-    return builder.Finish();
+arrow::Result<std::shared_ptr<arrow::Array>>
+ArrowConverter::build_double_column(const uint8_t *buf,
+                                    const std::vector<FieldRange> &ranges,
+                                    const Dialect &dialect) {
+  arrow::DoubleBuilder builder(options_.memory_pool);
+  ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
+  for (const auto &range : ranges) {
+    auto cell = extract_field(buf, range.start, range.end, dialect);
+    if (is_null_value(cell))
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+    else if (auto v = parse_double(cell))
+      ARROW_RETURN_NOT_OK(builder.Append(*v));
+    else
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+  }
+  return builder.Finish();
 }
 
-arrow::Result<std::shared_ptr<arrow::Array>> ArrowConverter::build_boolean_column(const uint8_t* buf, const std::vector<FieldRange>& ranges, const Dialect& dialect) {
-    arrow::BooleanBuilder builder(options_.memory_pool);
-    ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
-    for (const auto& range : ranges) {
-        auto cell = extract_field(buf, range.start, range.end, dialect);
-        if (is_null_value(cell)) ARROW_RETURN_NOT_OK(builder.AppendNull());
-        else if (auto v = parse_boolean(cell)) ARROW_RETURN_NOT_OK(builder.Append(*v));
-        else ARROW_RETURN_NOT_OK(builder.AppendNull());
-    }
-    return builder.Finish();
+arrow::Result<std::shared_ptr<arrow::Array>>
+ArrowConverter::build_boolean_column(const uint8_t *buf,
+                                     const std::vector<FieldRange> &ranges,
+                                     const Dialect &dialect) {
+  arrow::BooleanBuilder builder(options_.memory_pool);
+  ARROW_RETURN_NOT_OK(builder.Reserve(static_cast<int64_t>(ranges.size())));
+  for (const auto &range : ranges) {
+    auto cell = extract_field(buf, range.start, range.end, dialect);
+    if (is_null_value(cell))
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+    else if (auto v = parse_boolean(cell))
+      ARROW_RETURN_NOT_OK(builder.Append(*v));
+    else
+      ARROW_RETURN_NOT_OK(builder.AppendNull());
+  }
+  return builder.Finish();
 }
 
-arrow::Result<std::shared_ptr<arrow::Array>> ArrowConverter::build_column(const uint8_t* buf, const std::vector<FieldRange>& ranges, ColumnType type, const Dialect& dialect) {
-    switch (type) {
-        case ColumnType::INT64: return build_int64_column(buf, ranges, dialect);
-        case ColumnType::DOUBLE: return build_double_column(buf, ranges, dialect);
-        case ColumnType::BOOLEAN: return build_boolean_column(buf, ranges, dialect);
-        default: return build_string_column(buf, ranges, dialect);
-    }
+arrow::Result<std::shared_ptr<arrow::Array>>
+ArrowConverter::build_column(const uint8_t *buf,
+                             const std::vector<FieldRange> &ranges,
+                             ColumnType type, const Dialect &dialect) {
+  switch (type) {
+  case ColumnType::INT64:
+    return build_int64_column(buf, ranges, dialect);
+  case ColumnType::DOUBLE:
+    return build_double_column(buf, ranges, dialect);
+  case ColumnType::BOOLEAN:
+    return build_boolean_column(buf, ranges, dialect);
+  default:
+    return build_string_column(buf, ranges, dialect);
+  }
 }
 
-ArrowConvertResult ArrowConverter::convert(const uint8_t* buf, size_t len, const ParseIndex& idx, const Dialect& dialect) {
-    ArrowConvertResult result;
-    auto field_ranges = extract_field_ranges(buf, len, idx, dialect);
-    if (field_ranges.empty()) { result.error_message = "No data"; return result; }
-    size_t num_columns = field_ranges.size(), num_rows = field_ranges[0].size();
-
-    // Validate column count against security limit
-    if (options_.max_columns > 0 && num_columns > options_.max_columns) {
-        result.error_message = "Column count " + std::to_string(num_columns) +
-            " exceeds maximum allowed " + std::to_string(options_.max_columns);
-        return result;
-    }
-
-    // Validate row count against security limit
-    if (options_.max_rows > 0 && num_rows > options_.max_rows) {
-        result.error_message = "Row count " + std::to_string(num_rows) +
-            " exceeds maximum allowed " + std::to_string(options_.max_rows);
-        return result;
-    }
-
-    // Validate total cell count against security limit (with overflow protection)
-    // CSVs with individually acceptable dimensions can still exhaust memory through
-    // their multiplicative effect (e.g., 9999 columns × 1M rows = ~10B cells)
-    if (options_.max_total_cells > 0 && num_columns > 0) {
-        // Use division-based check to prevent integer overflow in multiplication.
-        // If num_rows > max_total_cells / num_columns, then num_rows * num_columns > max_total_cells.
-        // This is guaranteed by integer division properties and avoids computing the potentially
-        // overflowing product. The num_columns > 0 check prevents division by zero.
-        if (num_rows > options_.max_total_cells / num_columns) {
-            result.error_message = "Total cell count (" + std::to_string(num_columns) +
-                " columns × " + std::to_string(num_rows) + " rows) exceeds maximum allowed " +
-                std::to_string(options_.max_total_cells);
-            return result;
-        }
-    }
-
-    // Extract column names from header
-    std::vector<std::string> column_names;
-    size_t total_seps = 0;
-    for (uint8_t t = 0; t < idx.n_threads; ++t) total_seps += idx.n_indexes[t];
-    if (total_seps > 0) {
-        std::vector<uint64_t> all_positions;
-        for (uint8_t t = 0; t < idx.n_threads; ++t)
-            for (size_t i = 0; i < idx.n_indexes[t]; ++i) {
-                uint64_t pos = idx.indexes[t + i * idx.n_threads];
-                if (pos < len) all_positions.push_back(pos);  // Bounds check
-            }
-        std::sort(all_positions.begin(), all_positions.end());
-        size_t fs = 0;
-        for (size_t i = 0; i < all_positions.size() && column_names.size() < num_columns; ++i) {
-            column_names.push_back(std::string(extract_field(buf, fs, all_positions[i], dialect)));
-            fs = all_positions[i] + 1;
-            if (buf[all_positions[i]] == '\n') break;
-        }
-    }
-    while (column_names.size() < num_columns) column_names.push_back("column_" + std::to_string(column_names.size()));
-
-    // Get column types
-    auto column_types = options_.infer_types ? infer_types(buf, len, idx, dialect) : std::vector<ColumnType>(num_columns, ColumnType::STRING);
-    result.schema = build_schema(column_names, column_types);
-
-    // Build columns
-    std::vector<std::shared_ptr<arrow::Array>> arrays;
-    for (size_t col = 0; col < num_columns; ++col) {
-        auto arr = build_column(buf, field_ranges[col], column_types[col], dialect);
-        if (!arr.ok()) { result.error_message = arr.status().ToString(); return result; }
-        arrays.push_back(*arr);
-    }
-    result.table = arrow::Table::Make(result.schema, arrays);
-    result.num_rows = static_cast<int64_t>(num_rows);
-    result.num_columns = static_cast<int64_t>(num_columns);
+ArrowConvertResult ArrowConverter::convert(const uint8_t *buf, size_t len,
+                                           const ParseIndex &idx,
+                                           const Dialect &dialect) {
+  ArrowConvertResult result;
+  auto field_ranges = extract_field_ranges(buf, len, idx, dialect);
+  if (field_ranges.empty()) {
+    result.error_message = "No data";
     return result;
-}
+  }
+  size_t num_columns = field_ranges.size(), num_rows = field_ranges[0].size();
 
-ArrowConvertResult csv_to_arrow(const std::string& filename, const ArrowConvertOptions& options, const Dialect& dialect) {
-    ArrowConvertResult result;
-    try {
-        auto corpus = get_corpus(filename, 64);
-        // Use RAII to ensure memory is freed even if an exception is thrown
-        // during parsing or conversion. The buffer will be automatically freed
-        // when buffer_guard goes out of scope (either normally or via exception).
-        AlignedBufferPtr buffer_guard(const_cast<uint8_t*>(corpus.data()));
-
-        two_pass parser;
-        index idx = parser.init(corpus.size(), 1);
-        parser.parse(corpus.data(), idx, corpus.size(), dialect);
-        ArrowConverter converter(options);
-        result = converter.convert(corpus.data(), corpus.size(), idx, dialect);
-        // buffer_guard automatically frees memory when it goes out of scope
-    } catch (const std::exception& e) {
-        result.error_message = e.what();
-    }
+  // Validate column count against security limit
+  if (options_.max_columns > 0 && num_columns > options_.max_columns) {
+    result.error_message = "Column count " + std::to_string(num_columns) +
+                           " exceeds maximum allowed " +
+                           std::to_string(options_.max_columns);
     return result;
+  }
+
+  // Validate row count against security limit
+  if (options_.max_rows > 0 && num_rows > options_.max_rows) {
+    result.error_message = "Row count " + std::to_string(num_rows) +
+                           " exceeds maximum allowed " +
+                           std::to_string(options_.max_rows);
+    return result;
+  }
+
+  // Validate total cell count against security limit (with overflow protection)
+  // CSVs with individually acceptable dimensions can still exhaust memory
+  // through their multiplicative effect (e.g., 9999 columns × 1M rows = ~10B
+  // cells)
+  if (options_.max_total_cells > 0 && num_columns > 0) {
+    // Use division-based check to prevent integer overflow in multiplication.
+    // If num_rows > max_total_cells / num_columns, then num_rows * num_columns
+    // > max_total_cells. This is guaranteed by integer division properties and
+    // avoids computing the potentially overflowing product. The num_columns > 0
+    // check prevents division by zero.
+    if (num_rows > options_.max_total_cells / num_columns) {
+      result.error_message =
+          "Total cell count (" + std::to_string(num_columns) + " columns × " +
+          std::to_string(num_rows) + " rows) exceeds maximum allowed " +
+          std::to_string(options_.max_total_cells);
+      return result;
+    }
+  }
+
+  // Extract column names from header
+  std::vector<std::string> column_names;
+  size_t total_seps = 0;
+  for (uint16_t t = 0; t < idx.n_threads; ++t)
+    total_seps += idx.n_indexes[t];
+  if (total_seps > 0) {
+    std::vector<uint64_t> all_positions;
+    for (uint16_t t = 0; t < idx.n_threads; ++t)
+      for (size_t i = 0; i < idx.n_indexes[t]; ++i) {
+        uint64_t pos = idx.indexes[t + i * idx.n_threads];
+        if (pos < len)
+          all_positions.push_back(pos); // Bounds check
+      }
+    std::sort(all_positions.begin(), all_positions.end());
+    size_t fs = 0;
+    for (size_t i = 0;
+         i < all_positions.size() && column_names.size() < num_columns; ++i) {
+      column_names.push_back(
+          std::string(extract_field(buf, fs, all_positions[i], dialect)));
+      fs = all_positions[i] + 1;
+      if (buf[all_positions[i]] == '\n')
+        break;
+    }
+  }
+  while (column_names.size() < num_columns)
+    column_names.push_back("column_" + std::to_string(column_names.size()));
+
+  // Get column types
+  auto column_types =
+      options_.infer_types
+          ? infer_types(buf, len, idx, dialect)
+          : std::vector<ColumnType>(num_columns, ColumnType::STRING);
+  result.schema = build_schema(column_names, column_types);
+
+  // Build columns
+  std::vector<std::shared_ptr<arrow::Array>> arrays;
+  for (size_t col = 0; col < num_columns; ++col) {
+    auto arr = build_column(buf, field_ranges[col], column_types[col], dialect);
+    if (!arr.ok()) {
+      result.error_message = arr.status().ToString();
+      return result;
+    }
+    arrays.push_back(*arr);
+  }
+  result.table = arrow::Table::Make(result.schema, arrays);
+  result.num_rows = static_cast<int64_t>(num_rows);
+  result.num_columns = static_cast<int64_t>(num_columns);
+  return result;
 }
 
-ArrowConvertResult csv_to_arrow_from_memory(const uint8_t* data, size_t len, const ArrowConvertOptions& options, const Dialect& dialect) {
-    ArrowConvertResult result;
-    uint8_t* buf = allocate_padded_buffer(len, 64);
-    if (!buf) {
-        result.error_message = "Allocation failed";
-        return result;
-    }
+ArrowConvertResult csv_to_arrow(const std::string &filename,
+                                const ArrowConvertOptions &options,
+                                const Dialect &dialect) {
+  ArrowConvertResult result;
+  try {
+    auto corpus = get_corpus(filename, 64);
     // Use RAII to ensure memory is freed even if an exception is thrown
-    AlignedBufferPtr buffer_guard(buf);
+    // during parsing or conversion. The buffer will be automatically freed
+    // when buffer_guard goes out of scope (either normally or via exception).
+    AlignedBufferPtr buffer_guard(const_cast<uint8_t *>(corpus.data()));
 
-    try {
-        std::memcpy(buf, data, len);
-        two_pass parser;
-        index idx = parser.init(len, 1);
-        parser.parse(buf, idx, len, dialect);
-        ArrowConverter converter(options);
-        result = converter.convert(buf, len, idx, dialect);
-        // buffer_guard automatically frees memory when it goes out of scope
-    } catch (const std::exception& e) {
-        result.error_message = e.what();
-    }
-    return result;
+    two_pass parser;
+    index idx = parser.init(corpus.size(), 1);
+    parser.parse(corpus.data(), idx, corpus.size(), dialect);
+    ArrowConverter converter(options);
+    result = converter.convert(corpus.data(), corpus.size(), idx, dialect);
+    // buffer_guard automatically frees memory when it goes out of scope
+  } catch (const std::exception &e) {
+    result.error_message = e.what();
+  }
+  return result;
 }
 
-}  // namespace libvroom
+ArrowConvertResult csv_to_arrow_from_memory(const uint8_t *data, size_t len,
+                                            const ArrowConvertOptions &options,
+                                            const Dialect &dialect) {
+  ArrowConvertResult result;
+  uint8_t *buf = allocate_padded_buffer(len, 64);
+  if (!buf) {
+    result.error_message = "Allocation failed";
+    return result;
+  }
+  // Use RAII to ensure memory is freed even if an exception is thrown
+  AlignedBufferPtr buffer_guard(buf);
 
-#endif  // LIBVROOM_ENABLE_ARROW
+  try {
+    std::memcpy(buf, data, len);
+    two_pass parser;
+    index idx = parser.init(len, 1);
+    parser.parse(buf, idx, len, dialect);
+    ArrowConverter converter(options);
+    result = converter.convert(buf, len, idx, dialect);
+    // buffer_guard automatically frees memory when it goes out of scope
+  } catch (const std::exception &e) {
+    result.error_message = e.what();
+  }
+  return result;
+}
+
+} // namespace libvroom
+
+#endif // LIBVROOM_ENABLE_ARROW

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -31,8 +31,8 @@
 using namespace std;
 
 // Constants
-// Note: MAX_THREADS is limited to 255 due to uint8_t n_threads in index struct
-constexpr int MAX_THREADS = 255;
+// MAX_THREADS raised to 1024 with uint16_t n_threads in index struct
+constexpr int MAX_THREADS = 1024;
 constexpr int MIN_THREADS = 1;
 constexpr size_t MAX_COLUMN_WIDTH = 40;
 constexpr size_t DEFAULT_NUM_ROWS = 10;

--- a/src/two_pass.cpp
+++ b/src/two_pass.cpp
@@ -16,386 +16,449 @@ namespace libvroom {
 // ParseIndex class implementations
 //-----------------------------------------------------------------------------
 
-void ParseIndex::write(const std::string& filename) {
-    std::FILE* fp = std::fopen(filename.c_str(), "wb");
-    if (!fp) {
-        throw std::runtime_error("error opening file for writing");
-    }
-    if (!((std::fwrite(&columns, sizeof(uint64_t), 1, fp) == 1) &&
-          (std::fwrite(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
-          (std::fwrite(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
-        std::fclose(fp);
-        throw std::runtime_error("error writing index");
-    }
-    size_t total_size = 0;
-    for (int i = 0; i < n_threads; ++i) {
-        total_size += n_indexes[i];
-    }
-    if (std::fwrite(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
-        std::fclose(fp);
-        throw std::runtime_error("error writing index2");
-    }
+// Index file format version for backward compatibility
+// Version 1 (legacy): columns (uint64_t), n_threads (uint8_t), n_indexes,
+// indexes Version 2: version (uint8_t=2), columns (uint64_t), n_threads
+// (uint16_t), n_indexes, indexes
+static constexpr uint8_t INDEX_FORMAT_VERSION = 2;
 
+void ParseIndex::write(const std::string &filename) {
+  std::FILE *fp = std::fopen(filename.c_str(), "wb");
+  if (!fp) {
+    throw std::runtime_error("error opening file for writing");
+  }
+  // Write version 2 format: version byte, columns, n_threads (16-bit),
+  // n_indexes, indexes
+  uint8_t version = INDEX_FORMAT_VERSION;
+  if (!((std::fwrite(&version, sizeof(uint8_t), 1, fp) == 1) &&
+        (std::fwrite(&columns, sizeof(uint64_t), 1, fp) == 1) &&
+        (std::fwrite(&n_threads, sizeof(uint16_t), 1, fp) == 1) &&
+        (std::fwrite(n_indexes, sizeof(uint64_t), n_threads, fp) ==
+         n_threads))) {
     std::fclose(fp);
+    throw std::runtime_error("error writing index");
+  }
+  size_t total_size = 0;
+  for (uint16_t i = 0; i < n_threads; ++i) {
+    total_size += n_indexes[i];
+  }
+  if (std::fwrite(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
+    std::fclose(fp);
+    throw std::runtime_error("error writing index2");
+  }
+
+  std::fclose(fp);
 }
 
-void ParseIndex::read(const std::string& filename) {
-    std::FILE* fp = std::fopen(filename.c_str(), "rb");
-    if (!fp) {
-        throw std::runtime_error("error opening file for reading");
-    }
-    if (!((std::fread(&columns, sizeof(uint64_t), 1, fp) == 1) &&
-          (std::fread(&n_threads, sizeof(uint8_t), 1, fp) == 1) &&
-          (std::fread(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads))) {
-        std::fclose(fp);
-        throw std::runtime_error("error reading index");
-    }
-    size_t total_size = 0;
-    for (int i = 0; i < n_threads; ++i) {
-        total_size += n_indexes[i];
-    }
-    if (std::fread(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
-        std::fclose(fp);
-        throw std::runtime_error("error reading index2");
-    }
-
+void ParseIndex::read(const std::string &filename) {
+  std::FILE *fp = std::fopen(filename.c_str(), "rb");
+  if (!fp) {
+    throw std::runtime_error("error opening file for reading");
+  }
+  // Read first byte to detect version
+  // Version 2 starts with version byte (value 2)
+  // Version 1 (legacy) starts with columns (uint64_t), so first byte is part of
+  // that
+  uint8_t first_byte;
+  if (std::fread(&first_byte, sizeof(uint8_t), 1, fp) != 1) {
     std::fclose(fp);
+    throw std::runtime_error("error reading index version");
+  }
+
+  if (first_byte == INDEX_FORMAT_VERSION) {
+    // Version 2 format: read columns, n_threads (16-bit), n_indexes, indexes
+    if (!((std::fread(&columns, sizeof(uint64_t), 1, fp) == 1) &&
+          (std::fread(&n_threads, sizeof(uint16_t), 1, fp) == 1) &&
+          (std::fread(n_indexes, sizeof(uint64_t), n_threads, fp) ==
+           n_threads))) {
+      std::fclose(fp);
+      throw std::runtime_error("error reading index v2");
+    }
+  } else {
+    // Version 1 (legacy) format: first_byte is part of columns
+    // Read remaining 7 bytes of columns, then n_threads (8-bit)
+    uint8_t columns_rest[7];
+    if (std::fread(columns_rest, 1, 7, fp) != 7) {
+      std::fclose(fp);
+      throw std::runtime_error("error reading index v1 columns");
+    }
+    // Reconstruct columns from first_byte + columns_rest (little-endian)
+    columns = first_byte;
+    for (int i = 0; i < 7; ++i) {
+      columns |= static_cast<uint64_t>(columns_rest[i]) << (8 * (i + 1));
+    }
+    // Read n_threads as uint8_t and convert to uint16_t
+    uint8_t n_threads_v1;
+    if (std::fread(&n_threads_v1, sizeof(uint8_t), 1, fp) != 1) {
+      std::fclose(fp);
+      throw std::runtime_error("error reading index v1 n_threads");
+    }
+    n_threads = n_threads_v1;
+    if (std::fread(n_indexes, sizeof(uint64_t), n_threads, fp) != n_threads) {
+      std::fclose(fp);
+      throw std::runtime_error("error reading index v1 n_indexes");
+    }
+  }
+
+  size_t total_size = 0;
+  for (uint16_t i = 0; i < n_threads; ++i) {
+    total_size += n_indexes[i];
+  }
+  if (std::fread(indexes, sizeof(uint64_t), total_size, fp) != total_size) {
+    std::fclose(fp);
+    throw std::runtime_error("error reading index2");
+  }
+
+  std::fclose(fp);
 }
 
 //-----------------------------------------------------------------------------
 // TwoPass scalar first pass implementations
 //-----------------------------------------------------------------------------
 
-TwoPass::Stats TwoPass::first_pass_chunk(const uint8_t* buf, size_t start, size_t end,
-                                          char quote_char) {
-    Stats out;
-    uint64_t i = start;
-    bool needs_even = out.first_even_nl == null_pos;
-    bool needs_odd = out.first_odd_nl == null_pos;
-    while (i < end) {
-        // Support LF, CRLF, and CR-only line endings
-        // Check for line ending: \n, or \r not followed by \n
-        bool is_line_ending = false;
-        if (buf[i] == '\n') {
-            is_line_ending = true;
-        } else if (buf[i] == '\r') {
-            // CR is a line ending only if not followed by LF
-            if (i + 1 >= end || buf[i + 1] != '\n') {
-                is_line_ending = true;
-            }
-            // If followed by LF, skip this CR (the LF will be the line ending)
-        }
-
-        if (is_line_ending) {
-            bool is_even = (out.n_quotes % 2) == 0;
-            if (needs_even && is_even) {
-                out.first_even_nl = i;
-                needs_even = false;
-            } else if (needs_odd && !is_even) {
-                out.first_odd_nl = i;
-                needs_odd = false;
-            }
-        } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
-            ++out.n_quotes;
-        }
-        ++i;
+TwoPass::Stats TwoPass::first_pass_chunk(const uint8_t *buf, size_t start,
+                                         size_t end, char quote_char) {
+  Stats out;
+  uint64_t i = start;
+  bool needs_even = out.first_even_nl == null_pos;
+  bool needs_odd = out.first_odd_nl == null_pos;
+  while (i < end) {
+    // Support LF, CRLF, and CR-only line endings
+    // Check for line ending: \n, or \r not followed by \n
+    bool is_line_ending = false;
+    if (buf[i] == '\n') {
+      is_line_ending = true;
+    } else if (buf[i] == '\r') {
+      // CR is a line ending only if not followed by LF
+      if (i + 1 >= end || buf[i + 1] != '\n') {
+        is_line_ending = true;
+      }
+      // If followed by LF, skip this CR (the LF will be the line ending)
     }
-    return out;
+
+    if (is_line_ending) {
+      bool is_even = (out.n_quotes % 2) == 0;
+      if (needs_even && is_even) {
+        out.first_even_nl = i;
+        needs_even = false;
+      } else if (needs_odd && !is_even) {
+        out.first_odd_nl = i;
+        needs_odd = false;
+      }
+    } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
+      ++out.n_quotes;
+    }
+    ++i;
+  }
+  return out;
 }
 
-TwoPass::Stats TwoPass::first_pass_naive(const uint8_t* buf, size_t start, size_t end) {
-    Stats out;
-    uint64_t i = start;
-    while (i < end) {
-        // Support LF, CRLF, and CR-only line endings
-        if (buf[i] == '\n') {
-            out.first_even_nl = i;
-            return out;
-        } else if (buf[i] == '\r') {
-            // CR is a line ending only if not followed by LF
-            if (i + 1 >= end || buf[i + 1] != '\n') {
-                out.first_even_nl = i;
-                return out;
-            }
-            // If followed by LF, continue - the LF will be the line ending
-        }
-        ++i;
+TwoPass::Stats TwoPass::first_pass_naive(const uint8_t *buf, size_t start,
+                                         size_t end) {
+  Stats out;
+  uint64_t i = start;
+  while (i < end) {
+    // Support LF, CRLF, and CR-only line endings
+    if (buf[i] == '\n') {
+      out.first_even_nl = i;
+      return out;
+    } else if (buf[i] == '\r') {
+      // CR is a line ending only if not followed by LF
+      if (i + 1 >= end || buf[i + 1] != '\n') {
+        out.first_even_nl = i;
+        return out;
+      }
+      // If followed by LF, continue - the LF will be the line ending
     }
-    return out;
+    ++i;
+  }
+  return out;
 }
 
-TwoPass::quote_state TwoPass::get_quotation_state(const uint8_t* buf, size_t start,
-                                                   char delimiter, char quote_char) {
-    // 64kb
-    constexpr int SPECULATION_SIZE = 1 << 16;
+TwoPass::quote_state TwoPass::get_quotation_state(const uint8_t *buf,
+                                                  size_t start, char delimiter,
+                                                  char quote_char) {
+  // 64kb
+  constexpr int SPECULATION_SIZE = 1 << 16;
 
-    if (start == 0) {
-        return UNQUOTED;
+  if (start == 0) {
+    return UNQUOTED;
+  }
+
+  size_t end = start > SPECULATION_SIZE ? start - SPECULATION_SIZE : 0;
+  size_t i = start;
+  size_t num_quotes = 0;
+
+  // FIXED: Use i > end to avoid unsigned underflow when i reaches 0
+  while (i > end) {
+    if (buf[i] == static_cast<uint8_t>(quote_char)) {
+      // q-o case
+      if (i + 1 < start && is_other(buf[i + 1], delimiter, quote_char)) {
+        return num_quotes % 2 == 0 ? QUOTED : UNQUOTED;
+      }
+
+      // o-q case
+      else if (i > end && is_other(buf[i - 1], delimiter, quote_char)) {
+        return num_quotes % 2 == 0 ? UNQUOTED : QUOTED;
+      }
+      ++num_quotes;
     }
-
-    size_t end = start > SPECULATION_SIZE ? start - SPECULATION_SIZE : 0;
-    size_t i = start;
-    size_t num_quotes = 0;
-
-    // FIXED: Use i > end to avoid unsigned underflow when i reaches 0
-    while (i > end) {
-        if (buf[i] == static_cast<uint8_t>(quote_char)) {
-            // q-o case
-            if (i + 1 < start && is_other(buf[i + 1], delimiter, quote_char)) {
-                return num_quotes % 2 == 0 ? QUOTED : UNQUOTED;
-            }
-
-            // o-q case
-            else if (i > end && is_other(buf[i - 1], delimiter, quote_char)) {
-                return num_quotes % 2 == 0 ? UNQUOTED : QUOTED;
-            }
-            ++num_quotes;
-        }
-        --i;
-    }
-    // Check the last position (i == end)
-    if (buf[end] == static_cast<uint8_t>(quote_char)) {
-        ++num_quotes;
-    }
-    return AMBIGUOUS;
+    --i;
+  }
+  // Check the last position (i == end)
+  if (buf[end] == static_cast<uint8_t>(quote_char)) {
+    ++num_quotes;
+  }
+  return AMBIGUOUS;
 }
 
-TwoPass::Stats TwoPass::first_pass_speculate(const uint8_t* buf, size_t start, size_t end,
-                                              char delimiter, char quote_char) {
-    auto is_quoted = get_quotation_state(buf, start, delimiter, quote_char);
+TwoPass::Stats TwoPass::first_pass_speculate(const uint8_t *buf, size_t start,
+                                             size_t end, char delimiter,
+                                             char quote_char) {
+  auto is_quoted = get_quotation_state(buf, start, delimiter, quote_char);
 
-    for (size_t i = start; i < end; ++i) {
-        // Support LF, CRLF, and CR-only line endings
-        bool is_line_ending = false;
-        if (buf[i] == '\n') {
-            is_line_ending = true;
-        } else if (buf[i] == '\r') {
-            // CR is a line ending only if not followed by LF
-            if (i + 1 >= end || buf[i + 1] != '\n') {
-                is_line_ending = true;
-            }
-        }
-
-        if (is_line_ending) {
-            if (is_quoted == UNQUOTED || is_quoted == AMBIGUOUS) {
-                return {0, i, null_pos};
-            } else {
-                return {1, null_pos, i};
-            }
-        } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
-            is_quoted = is_quoted == UNQUOTED ? QUOTED : UNQUOTED;
-        }
+  for (size_t i = start; i < end; ++i) {
+    // Support LF, CRLF, and CR-only line endings
+    bool is_line_ending = false;
+    if (buf[i] == '\n') {
+      is_line_ending = true;
+    } else if (buf[i] == '\r') {
+      // CR is a line ending only if not followed by LF
+      if (i + 1 >= end || buf[i + 1] != '\n') {
+        is_line_ending = true;
+      }
     }
-    return {0, null_pos, null_pos};
+
+    if (is_line_ending) {
+      if (is_quoted == UNQUOTED || is_quoted == AMBIGUOUS) {
+        return {0, i, null_pos};
+      } else {
+        return {1, null_pos, i};
+      }
+    } else if (buf[i] == static_cast<uint8_t>(quote_char)) {
+      is_quoted = is_quoted == UNQUOTED ? QUOTED : UNQUOTED;
+    }
+  }
+  return {0, null_pos, null_pos};
 }
 
 //-----------------------------------------------------------------------------
 // TwoPass helper functions
 //-----------------------------------------------------------------------------
 
-std::string TwoPass::get_context(const uint8_t* buf, size_t len, size_t pos,
-                                  size_t context_size) {
-    // Handle empty buffer case
-    if (len == 0 || buf == nullptr) return "";
+std::string TwoPass::get_context(const uint8_t *buf, size_t len, size_t pos,
+                                 size_t context_size) {
+  // Handle empty buffer case
+  if (len == 0 || buf == nullptr)
+    return "";
 
-    // Bounds check
-    size_t safe_pos = pos < len ? pos : len - 1;
-    size_t ctx_start = safe_pos > context_size ? safe_pos - context_size : 0;
-    size_t ctx_end = std::min(safe_pos + context_size, len);
+  // Bounds check
+  size_t safe_pos = pos < len ? pos : len - 1;
+  size_t ctx_start = safe_pos > context_size ? safe_pos - context_size : 0;
+  size_t ctx_end = std::min(safe_pos + context_size, len);
 
-    std::string ctx;
-    // Reserve space to avoid reallocations (worst case: every char becomes 2 chars like \n)
-    ctx.reserve((ctx_end - ctx_start) * 2);
+  std::string ctx;
+  // Reserve space to avoid reallocations (worst case: every char becomes 2
+  // chars like \n)
+  ctx.reserve((ctx_end - ctx_start) * 2);
 
-    for (size_t i = ctx_start; i < ctx_end; ++i) {
-        char c = static_cast<char>(buf[i]);
-        if (c == '\n') ctx += "\\n";
-        else if (c == '\r') ctx += "\\r";
-        else if (c == '\0') ctx += "\\0";
-        else if (c >= 32 && c < 127) ctx += c;
-        else ctx += "?";
-    }
-    return ctx;
+  for (size_t i = ctx_start; i < ctx_end; ++i) {
+    char c = static_cast<char>(buf[i]);
+    if (c == '\n')
+      ctx += "\\n";
+    else if (c == '\r')
+      ctx += "\\r";
+    else if (c == '\0')
+      ctx += "\\0";
+    else if (c >= 32 && c < 127)
+      ctx += c;
+    else
+      ctx += "?";
+  }
+  return ctx;
 }
 
-void TwoPass::get_line_column(const uint8_t* buf, size_t buf_len, size_t offset,
-                               size_t& line, size_t& column) {
-    line = 1;
-    column = 1;
-    // Ensure we don't read past buffer bounds
-    size_t safe_offset = offset < buf_len ? offset : buf_len;
-    for (size_t i = 0; i < safe_offset; ++i) {
-        if (buf[i] == '\n') {
-            ++line;
-            column = 1;
-        } else if (buf[i] != '\r') {
-            ++column;
-        }
+void TwoPass::get_line_column(const uint8_t *buf, size_t buf_len, size_t offset,
+                              size_t &line, size_t &column) {
+  line = 1;
+  column = 1;
+  // Ensure we don't read past buffer bounds
+  size_t safe_offset = offset < buf_len ? offset : buf_len;
+  for (size_t i = 0; i < safe_offset; ++i) {
+    if (buf[i] == '\n') {
+      ++line;
+      column = 1;
+    } else if (buf[i] != '\r') {
+      ++column;
     }
+  }
 }
 
 //-----------------------------------------------------------------------------
 // TwoPass scalar second pass implementations
 //-----------------------------------------------------------------------------
 
-uint64_t TwoPass::second_pass_chunk(const uint8_t* buf, size_t start, size_t end,
-                                     ParseIndex* out, size_t thread_id,
-                                     ErrorCollector* errors,
-                                     size_t total_len,
-                                     char delimiter, char quote_char) {
-    uint64_t pos = start;
-    size_t n_indexes = 0;
-    size_t i = thread_id;
-    csv_state s = RECORD_START;
+uint64_t TwoPass::second_pass_chunk(const uint8_t *buf, size_t start,
+                                    size_t end, ParseIndex *out,
+                                    size_t thread_id, ErrorCollector *errors,
+                                    size_t total_len, char delimiter,
+                                    char quote_char) {
+  uint64_t pos = start;
+  size_t n_indexes = 0;
+  size_t i = thread_id;
+  csv_state s = RECORD_START;
 
-    while (pos < end) {
-        uint8_t value = buf[pos];
-
-        // Use effective buffer length for bounds checking
-        size_t buf_len = total_len > 0 ? total_len : end;
-
-        // Check for null bytes
-        if (value == '\0' && errors) {
-            size_t line, col;
-            get_line_column(buf, buf_len, pos, line, col);
-            errors->add_error(ErrorCode::NULL_BYTE, ErrorSeverity::ERROR,
-                              line, col, pos, "Null byte in data",
-                              get_context(buf, buf_len, pos));
-            if (errors->should_stop()) return n_indexes;
-            ++pos;
-            continue;
-        }
-
-        StateResult result;
-        if (value == static_cast<uint8_t>(quote_char)) {
-            result = quoted_state(s);
-            if (result.error != ErrorCode::NONE && errors) {
-                size_t line, col;
-                get_line_column(buf, buf_len, pos, line, col);
-                std::string msg = "Quote character '";
-                msg += quote_char;
-                msg += "' in unquoted field";
-                errors->add_error(result.error, ErrorSeverity::ERROR,
-                                  line, col, pos, msg,
-                                  get_context(buf, buf_len, pos));
-                if (errors->should_stop()) return n_indexes;
-            }
-            s = result.state;
-        } else if (value == static_cast<uint8_t>(delimiter)) {
-            if (s != QUOTED_FIELD) {
-                i = add_position(out, i, pos);
-                ++n_indexes;
-            }
-            result = comma_state(s);
-            s = result.state;
-        } else if (value == '\n') {
-            if (s != QUOTED_FIELD) {
-                i = add_position(out, i, pos);
-                ++n_indexes;
-            }
-            result = newline_state(s);
-            s = result.state;
-        } else if (value == '\r') {
-            // Support CR-only line endings: CR is a line ending if not followed by LF
-            bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
-            if (is_line_ending && s != QUOTED_FIELD) {
-                i = add_position(out, i, pos);
-                ++n_indexes;
-                result = newline_state(s);
-                s = result.state;
-            }
-            // If CR is followed by LF (CRLF), treat CR as regular character
-            // The LF will be the line ending; CR will be stripped during value extraction
-        } else {
-            result = other_state(s);
-            if (result.error != ErrorCode::NONE && errors) {
-                size_t line, col;
-                get_line_column(buf, buf_len, pos, line, col);
-                std::string msg = "Invalid character after closing quote '";
-                msg += quote_char;
-                msg += "'";
-                errors->add_error(result.error, ErrorSeverity::ERROR,
-                                  line, col, pos, msg,
-                                  get_context(buf, buf_len, pos));
-                if (errors->should_stop()) return n_indexes;
-            }
-            s = result.state;
-        }
-        ++pos;
-    }
+  while (pos < end) {
+    uint8_t value = buf[pos];
 
     // Use effective buffer length for bounds checking
     size_t buf_len = total_len > 0 ? total_len : end;
 
-    // Check for unclosed quote at end of chunk
-    if (s == QUOTED_FIELD && errors && end == buf_len) {
-        size_t line, col;
-        get_line_column(buf, buf_len, pos > 0 ? pos - 1 : 0, line, col);
-        std::string msg = "Unclosed quote '";
-        msg += quote_char;
-        msg += "' at end of file";
-        errors->add_error(ErrorCode::UNCLOSED_QUOTE, ErrorSeverity::FATAL,
-                          line, col, pos, msg,
-                          get_context(buf, buf_len, pos > 20 ? pos - 20 : 0));
+    // Check for null bytes
+    if (value == '\0' && errors) {
+      size_t line, col;
+      get_line_column(buf, buf_len, pos, line, col);
+      errors->add_error(ErrorCode::NULL_BYTE, ErrorSeverity::ERROR, line, col,
+                        pos, "Null byte in data",
+                        get_context(buf, buf_len, pos));
+      if (errors->should_stop())
+        return n_indexes;
+      ++pos;
+      continue;
     }
 
-    return n_indexes;
+    StateResult result;
+    if (value == static_cast<uint8_t>(quote_char)) {
+      result = quoted_state(s);
+      if (result.error != ErrorCode::NONE && errors) {
+        size_t line, col;
+        get_line_column(buf, buf_len, pos, line, col);
+        std::string msg = "Quote character '";
+        msg += quote_char;
+        msg += "' in unquoted field";
+        errors->add_error(result.error, ErrorSeverity::ERROR, line, col, pos,
+                          msg, get_context(buf, buf_len, pos));
+        if (errors->should_stop())
+          return n_indexes;
+      }
+      s = result.state;
+    } else if (value == static_cast<uint8_t>(delimiter)) {
+      if (s != QUOTED_FIELD) {
+        i = add_position(out, i, pos);
+        ++n_indexes;
+      }
+      result = comma_state(s);
+      s = result.state;
+    } else if (value == '\n') {
+      if (s != QUOTED_FIELD) {
+        i = add_position(out, i, pos);
+        ++n_indexes;
+      }
+      result = newline_state(s);
+      s = result.state;
+    } else if (value == '\r') {
+      // Support CR-only line endings: CR is a line ending if not followed by LF
+      bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
+      if (is_line_ending && s != QUOTED_FIELD) {
+        i = add_position(out, i, pos);
+        ++n_indexes;
+        result = newline_state(s);
+        s = result.state;
+      }
+      // If CR is followed by LF (CRLF), treat CR as regular character
+      // The LF will be the line ending; CR will be stripped during value
+      // extraction
+    } else {
+      result = other_state(s);
+      if (result.error != ErrorCode::NONE && errors) {
+        size_t line, col;
+        get_line_column(buf, buf_len, pos, line, col);
+        std::string msg = "Invalid character after closing quote '";
+        msg += quote_char;
+        msg += "'";
+        errors->add_error(result.error, ErrorSeverity::ERROR, line, col, pos,
+                          msg, get_context(buf, buf_len, pos));
+        if (errors->should_stop())
+          return n_indexes;
+      }
+      s = result.state;
+    }
+    ++pos;
+  }
+
+  // Use effective buffer length for bounds checking
+  size_t buf_len = total_len > 0 ? total_len : end;
+
+  // Check for unclosed quote at end of chunk
+  if (s == QUOTED_FIELD && errors && end == buf_len) {
+    size_t line, col;
+    get_line_column(buf, buf_len, pos > 0 ? pos - 1 : 0, line, col);
+    std::string msg = "Unclosed quote '";
+    msg += quote_char;
+    msg += "' at end of file";
+    errors->add_error(ErrorCode::UNCLOSED_QUOTE, ErrorSeverity::FATAL, line,
+                      col, pos, msg,
+                      get_context(buf, buf_len, pos > 20 ? pos - 20 : 0));
+  }
+
+  return n_indexes;
 }
 
-uint64_t TwoPass::second_pass_chunk_throwing(const uint8_t* buf, size_t start, size_t end,
-                                              ParseIndex* out, size_t thread_id,
-                                              char delimiter, char quote_char) {
-    uint64_t pos = start;
-    size_t n_indexes = 0;
-    size_t i = thread_id;
-    csv_state s = RECORD_START;
+uint64_t TwoPass::second_pass_chunk_throwing(const uint8_t *buf, size_t start,
+                                             size_t end, ParseIndex *out,
+                                             size_t thread_id, char delimiter,
+                                             char quote_char) {
+  uint64_t pos = start;
+  size_t n_indexes = 0;
+  size_t i = thread_id;
+  csv_state s = RECORD_START;
 
-    while (pos < end) {
-        uint8_t value = buf[pos];
-        StateResult result;
-        if (value == static_cast<uint8_t>(quote_char)) {
-            result = quoted_state(s);
-            if (result.error != ErrorCode::NONE) {
-                std::string msg = "Quote character '";
-                msg += quote_char;
-                msg += "' in unquoted field";
-                throw std::runtime_error(msg);
-            }
-            s = result.state;
-        } else if (value == static_cast<uint8_t>(delimiter)) {
-            if (s != QUOTED_FIELD) {
-                i = add_position(out, i, pos);
-                ++n_indexes;
-            }
-            s = comma_state(s).state;
-        } else if (value == '\n') {
-            if (s != QUOTED_FIELD) {
-                i = add_position(out, i, pos);
-                ++n_indexes;
-            }
-            s = newline_state(s).state;
-        } else if (value == '\r') {
-            // Support CR-only line endings: CR is a line ending if not followed by LF
-            bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
-            if (is_line_ending && s != QUOTED_FIELD) {
-                i = add_position(out, i, pos);
-                ++n_indexes;
-                s = newline_state(s).state;
-            }
-            // If CR is followed by LF (CRLF), treat CR as regular character
-        } else {
-            result = other_state(s);
-            if (result.error != ErrorCode::NONE) {
-                std::string msg = "Invalid character after closing quote '";
-                msg += quote_char;
-                msg += "'";
-                throw std::runtime_error(msg);
-            }
-            s = result.state;
-        }
-        ++pos;
+  while (pos < end) {
+    uint8_t value = buf[pos];
+    StateResult result;
+    if (value == static_cast<uint8_t>(quote_char)) {
+      result = quoted_state(s);
+      if (result.error != ErrorCode::NONE) {
+        std::string msg = "Quote character '";
+        msg += quote_char;
+        msg += "' in unquoted field";
+        throw std::runtime_error(msg);
+      }
+      s = result.state;
+    } else if (value == static_cast<uint8_t>(delimiter)) {
+      if (s != QUOTED_FIELD) {
+        i = add_position(out, i, pos);
+        ++n_indexes;
+      }
+      s = comma_state(s).state;
+    } else if (value == '\n') {
+      if (s != QUOTED_FIELD) {
+        i = add_position(out, i, pos);
+        ++n_indexes;
+      }
+      s = newline_state(s).state;
+    } else if (value == '\r') {
+      // Support CR-only line endings: CR is a line ending if not followed by LF
+      bool is_line_ending = (pos + 1 >= end || buf[pos + 1] != '\n');
+      if (is_line_ending && s != QUOTED_FIELD) {
+        i = add_position(out, i, pos);
+        ++n_indexes;
+        s = newline_state(s).state;
+      }
+      // If CR is followed by LF (CRLF), treat CR as regular character
+    } else {
+      result = other_state(s);
+      if (result.error != ErrorCode::NONE) {
+        std::string msg = "Invalid character after closing quote '";
+        msg += quote_char;
+        msg += "'";
+        throw std::runtime_error(msg);
+      }
+      s = result.state;
     }
-    return n_indexes;
+    ++pos;
+  }
+  return n_indexes;
 }
 
 //-----------------------------------------------------------------------------
@@ -404,527 +467,558 @@ uint64_t TwoPass::second_pass_chunk_throwing(const uint8_t* buf, size_t start, s
 
 LIBVROOM_SUPPRESS_DEPRECATION_START
 
-bool TwoPass::parse_speculate(const uint8_t* buf, ParseIndex& out, size_t len,
-                               const Dialect& dialect) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    uint8_t n_threads = out.n_threads;
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-    if (n_threads == 1) {
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-    }
-    size_t chunk_size = len / n_threads;
-    // If chunk size is too small, small chunks may not contain any newlines,
-    // causing first_pass_speculate to return null_pos. Fall back to single-threaded.
-    if (chunk_size < 64) {
-        // CRITICAL: Must update n_threads to 1 for correct stride in write()
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-    }
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-        first_pass_fut[i] = std::async(std::launch::async,
-            [buf, chunk_size, i, delim, quote]() {
-                return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
-            });
-    }
-
-    auto st = first_pass_fut[0].get();
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-        auto st = first_pass_fut[i].get();
-        chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-        if (chunk_pos[i] == null_pos) {
-            // CRITICAL: Must update n_threads to 1 for correct stride in write()
-            out.n_threads = 1;
-            out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-            return true;
-        }
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-        second_pass_fut[i] = std::async(std::launch::async,
-            [buf, &out, &chunk_pos, i, delim, quote]() {
-                return second_pass_simd(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
-            });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-        out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
+bool TwoPass::parse_speculate(const uint8_t *buf, ParseIndex &out, size_t len,
+                              const Dialect &dialect) {
+  char delim = dialect.delimiter;
+  char quote = dialect.quote_char;
+  uint16_t n_threads = out.n_threads;
+  // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+  if (n_threads == 0)
+    n_threads = 1;
+  if (n_threads == 1) {
+    out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
     return true;
+  }
+  size_t chunk_size = len / n_threads;
+  // If chunk size is too small, small chunks may not contain any newlines,
+  // causing first_pass_speculate to return null_pos. Fall back to
+  // single-threaded.
+  if (chunk_size < 64) {
+    // CRITICAL: Must update n_threads to 1 for correct stride in write()
+    out.n_threads = 1;
+    out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+    return true;
+  }
+  std::vector<uint64_t> chunk_pos(n_threads + 1);
+  std::vector<std::future<Stats>> first_pass_fut(n_threads);
+  std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+  for (int i = 0; i < n_threads; ++i) {
+    first_pass_fut[i] =
+        std::async(std::launch::async, [buf, chunk_size, i, delim, quote]() {
+          return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1),
+                                      delim, quote);
+        });
+  }
+
+  auto st = first_pass_fut[0].get();
+  chunk_pos[0] = 0;
+  for (int i = 1; i < n_threads; ++i) {
+    auto st = first_pass_fut[i].get();
+    chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
+  }
+  chunk_pos[n_threads] = len;
+
+  // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+  for (int i = 1; i < n_threads; ++i) {
+    if (chunk_pos[i] == null_pos) {
+      // CRITICAL: Must update n_threads to 1 for correct stride in write()
+      out.n_threads = 1;
+      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+      return true;
+    }
+  }
+
+  for (int i = 0; i < n_threads; ++i) {
+    second_pass_fut[i] = std::async(
+        std::launch::async, [buf, &out, &chunk_pos, i, delim, quote]() {
+          return second_pass_simd(buf, chunk_pos[i], chunk_pos[i + 1], &out, i,
+                                  delim, quote);
+        });
+  }
+
+  for (int i = 0; i < n_threads; ++i) {
+    out.n_indexes[i] = second_pass_fut[i].get();
+  }
+
+  return true;
 }
 
-bool TwoPass::parse_two_pass(const uint8_t* buf, ParseIndex& out, size_t len,
-                              const Dialect& dialect) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    uint8_t n_threads = out.n_threads;
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
-    if (n_threads == 1) {
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-    }
-    size_t chunk_size = len / n_threads;
-    // If chunk size is too small, small chunks may not contain any newlines,
-    // causing first_pass_chunk to return null_pos. Fall back to single-threaded.
-    if (chunk_size < 64) {
-        // CRITICAL: Must update n_threads to 1 for correct stride in write()
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-        return true;
-    }
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-        first_pass_fut[i] = std::async(std::launch::async,
-            [buf, chunk_size, i, quote]() {
-                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-            });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-        auto st = first_pass_fut[i].get();
-        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-        n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-        if (chunk_pos[i] == null_pos) {
-            // CRITICAL: Must update n_threads to 1 for correct stride in write()
-            out.n_threads = 1;
-            out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
-            return true;
-        }
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-        second_pass_fut[i] = std::async(std::launch::async,
-            [buf, &out, &chunk_pos, i, delim, quote]() {
-                return second_pass_chunk_throwing(buf, chunk_pos[i], chunk_pos[i + 1], &out, i, delim, quote);
-            });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-        out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
+bool TwoPass::parse_two_pass(const uint8_t *buf, ParseIndex &out, size_t len,
+                             const Dialect &dialect) {
+  char delim = dialect.delimiter;
+  char quote = dialect.quote_char;
+  uint16_t n_threads = out.n_threads;
+  // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+  if (n_threads == 0)
+    n_threads = 1;
+  if (n_threads == 1) {
+    out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
     return true;
+  }
+  size_t chunk_size = len / n_threads;
+  // If chunk size is too small, small chunks may not contain any newlines,
+  // causing first_pass_chunk to return null_pos. Fall back to single-threaded.
+  if (chunk_size < 64) {
+    // CRITICAL: Must update n_threads to 1 for correct stride in write()
+    out.n_threads = 1;
+    out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+    return true;
+  }
+  std::vector<uint64_t> chunk_pos(n_threads + 1);
+  std::vector<std::future<Stats>> first_pass_fut(n_threads);
+  std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+  for (int i = 0; i < n_threads; ++i) {
+    first_pass_fut[i] = std::async(std::launch::async, [buf, chunk_size, i,
+                                                        quote]() {
+      return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+    });
+  }
+
+  auto st = first_pass_fut[0].get();
+  size_t n_quotes = st.n_quotes;
+  chunk_pos[0] = 0;
+  for (int i = 1; i < n_threads; ++i) {
+    auto st = first_pass_fut[i].get();
+    chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+    n_quotes += st.n_quotes;
+  }
+  chunk_pos[n_threads] = len;
+
+  // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+  for (int i = 1; i < n_threads; ++i) {
+    if (chunk_pos[i] == null_pos) {
+      // CRITICAL: Must update n_threads to 1 for correct stride in write()
+      out.n_threads = 1;
+      out.n_indexes[0] = second_pass_simd(buf, 0, len, &out, 0, delim, quote);
+      return true;
+    }
+  }
+
+  for (int i = 0; i < n_threads; ++i) {
+    second_pass_fut[i] = std::async(
+        std::launch::async, [buf, &out, &chunk_pos, i, delim, quote]() {
+          return second_pass_chunk_throwing(buf, chunk_pos[i], chunk_pos[i + 1],
+                                            &out, i, delim, quote);
+        });
+  }
+
+  for (int i = 0; i < n_threads; ++i) {
+    out.n_indexes[i] = second_pass_fut[i].get();
+  }
+
+  return true;
 }
 
-bool TwoPass::parse(const uint8_t* buf, ParseIndex& out, size_t len,
-                     const Dialect& dialect) {
-    return parse_speculate(buf, out, len, dialect);
+bool TwoPass::parse(const uint8_t *buf, ParseIndex &out, size_t len,
+                    const Dialect &dialect) {
+  return parse_speculate(buf, out, len, dialect);
 }
 
 LIBVROOM_SUPPRESS_DEPRECATION_END
 
-TwoPass::branchless_chunk_result TwoPass::second_pass_branchless_chunk_with_errors(
-    const BranchlessStateMachine& sm,
-    const uint8_t* buf, size_t start, size_t end,
-    ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode) {
-    branchless_chunk_result result;
-    result.errors.set_mode(mode);
-    result.n_indexes = second_pass_branchless_with_errors(
-        sm, buf, start, end, out->indexes, thread_id, out->n_threads,
-        &result.errors, total_len);
-    return result;
+TwoPass::branchless_chunk_result
+TwoPass::second_pass_branchless_chunk_with_errors(
+    const BranchlessStateMachine &sm, const uint8_t *buf, size_t start,
+    size_t end, ParseIndex *out, size_t thread_id, size_t total_len,
+    ErrorMode mode) {
+  branchless_chunk_result result;
+  result.errors.set_mode(mode);
+  result.n_indexes = second_pass_branchless_with_errors(
+      sm, buf, start, end, out->indexes, thread_id, out->n_threads,
+      &result.errors, total_len);
+  return result;
 }
 
-bool TwoPass::parse_branchless_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
-                                            ErrorCollector& errors,
-                                            const Dialect& dialect) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-    char escape = dialect.escape_char;
-    bool double_quote = dialect.double_quote;
+bool TwoPass::parse_branchless_with_errors(const uint8_t *buf, ParseIndex &out,
+                                           size_t len, ErrorCollector &errors,
+                                           const Dialect &dialect) {
+  char delim = dialect.delimiter;
+  char quote = dialect.quote_char;
+  char escape = dialect.escape_char;
+  bool double_quote = dialect.double_quote;
 
-    // Handle empty input
-    if (len == 0) return true;
+  // Handle empty input
+  if (len == 0)
+    return true;
 
-    // Check structural issues first (single-threaded, fast)
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
+  // Check structural issues first (single-threaded, fast)
+  check_empty_header(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
+  check_duplicate_columns(buf, len, errors, delim, quote);
+  if (errors.should_stop())
+    return false;
 
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
+  check_line_endings(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    BranchlessStateMachine sm(delim, quote, escape, double_quote);
-    uint8_t n_threads = out.n_threads;
+  BranchlessStateMachine sm(delim, quote, escape, double_quote);
+  uint16_t n_threads = out.n_threads;
 
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
+  // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+  if (n_threads == 0)
+    n_threads = 1;
 
-    // For single-threaded, use the simpler path
-    if (n_threads == 1) {
-        out.n_indexes[0] = second_pass_branchless_with_errors(
-            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-        check_field_counts(buf, len, errors, delim, quote);
-        return !errors.has_fatal_errors();
-    }
-
-    size_t chunk_size = len / n_threads;
-
-    // If chunk size is too small, fall back to single-threaded
-    if (chunk_size < 64) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_branchless_with_errors(
-            sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-        check_field_counts(buf, len, errors, delim, quote);
-        return !errors.has_fatal_errors();
-    }
-
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<branchless_chunk_result>> second_pass_fut(n_threads);
-
-    // First pass: find chunk boundaries
-    for (int i = 0; i < n_threads; ++i) {
-        first_pass_fut[i] = std::async(std::launch::async,
-            [buf, chunk_size, i, quote]() {
-                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-            });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-        auto st = first_pass_fut[i].get();
-        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-        n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-        if (chunk_pos[i] == null_pos) {
-            out.n_threads = 1;
-            out.n_indexes[0] = second_pass_branchless_with_errors(
-                sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
-            check_field_counts(buf, len, errors, delim, quote);
-            return !errors.has_fatal_errors();
-        }
-    }
-
-    // Second pass: parse with thread-local error collectors using branchless
-    ErrorMode mode = errors.mode();
-    for (int i = 0; i < n_threads; ++i) {
-        second_pass_fut[i] = std::async(std::launch::async,
-            [sm, buf, &out, &chunk_pos, i, len, mode]() {
-                return second_pass_branchless_chunk_with_errors(
-                    sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i, len, mode);
-            });
-    }
-
-    // Collect results and merge errors
-    std::vector<ErrorCollector> thread_errors;
-    thread_errors.reserve(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-        auto result = second_pass_fut[i].get();
-        out.n_indexes[i] = result.n_indexes;
-        thread_errors.push_back(std::move(result.errors));
-    }
-
-    // Merge all thread-local errors, sorted by byte offset
-    errors.merge_sorted(thread_errors);
-
-    // Check field counts after parsing (single-threaded, scans file linearly)
+  // For single-threaded, use the simpler path
+  if (n_threads == 1) {
+    out.n_indexes[0] = second_pass_branchless_with_errors(
+        sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
     check_field_counts(buf, len, errors, delim, quote);
-
     return !errors.has_fatal_errors();
+  }
+
+  size_t chunk_size = len / n_threads;
+
+  // If chunk size is too small, fall back to single-threaded
+  if (chunk_size < 64) {
+    out.n_threads = 1;
+    out.n_indexes[0] = second_pass_branchless_with_errors(
+        sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+    check_field_counts(buf, len, errors, delim, quote);
+    return !errors.has_fatal_errors();
+  }
+
+  std::vector<uint64_t> chunk_pos(n_threads + 1);
+  std::vector<std::future<Stats>> first_pass_fut(n_threads);
+  std::vector<std::future<branchless_chunk_result>> second_pass_fut(n_threads);
+
+  // First pass: find chunk boundaries
+  for (int i = 0; i < n_threads; ++i) {
+    first_pass_fut[i] = std::async(std::launch::async, [buf, chunk_size, i,
+                                                        quote]() {
+      return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+    });
+  }
+
+  auto st = first_pass_fut[0].get();
+  size_t n_quotes = st.n_quotes;
+  chunk_pos[0] = 0;
+  for (int i = 1; i < n_threads; ++i) {
+    auto st = first_pass_fut[i].get();
+    chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+    n_quotes += st.n_quotes;
+  }
+  chunk_pos[n_threads] = len;
+
+  // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+  for (int i = 1; i < n_threads; ++i) {
+    if (chunk_pos[i] == null_pos) {
+      out.n_threads = 1;
+      out.n_indexes[0] = second_pass_branchless_with_errors(
+          sm, buf, 0, len, out.indexes, 0, 1, &errors, len);
+      check_field_counts(buf, len, errors, delim, quote);
+      return !errors.has_fatal_errors();
+    }
+  }
+
+  // Second pass: parse with thread-local error collectors using branchless
+  ErrorMode mode = errors.mode();
+  for (int i = 0; i < n_threads; ++i) {
+    second_pass_fut[i] = std::async(
+        std::launch::async, [sm, buf, &out, &chunk_pos, i, len, mode]() {
+          return second_pass_branchless_chunk_with_errors(
+              sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i, len, mode);
+        });
+  }
+
+  // Collect results and merge errors
+  std::vector<ErrorCollector> thread_errors;
+  thread_errors.reserve(n_threads);
+
+  for (int i = 0; i < n_threads; ++i) {
+    auto result = second_pass_fut[i].get();
+    out.n_indexes[i] = result.n_indexes;
+    thread_errors.push_back(std::move(result.errors));
+  }
+
+  // Merge all thread-local errors, sorted by byte offset
+  errors.merge_sorted(thread_errors);
+
+  // Check field counts after parsing (single-threaded, scans file linearly)
+  check_field_counts(buf, len, errors, delim, quote);
+
+  return !errors.has_fatal_errors();
 }
 
 LIBVROOM_SUPPRESS_DEPRECATION_START
 
-bool TwoPass::parse_branchless(const uint8_t* buf, ParseIndex& out, size_t len,
-                                const Dialect& dialect) {
-    BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char,
-                               dialect.escape_char, dialect.double_quote);
-    uint8_t n_threads = out.n_threads;
+bool TwoPass::parse_branchless(const uint8_t *buf, ParseIndex &out, size_t len,
+                               const Dialect &dialect) {
+  BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char,
+                            dialect.escape_char, dialect.double_quote);
+  uint16_t n_threads = out.n_threads;
 
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
+  // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+  if (n_threads == 0)
+    n_threads = 1;
 
-    if (n_threads == 1) {
-        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-        return true;
-    }
-
-    // Multi-threaded parsing with branchless second pass
-    size_t chunk_size = len / n_threads;
-
-    // If chunk size is too small, fall back to single-threaded
-    if (chunk_size < 64) {
-        out.n_threads = 1;
-        out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-        return true;
-    }
-
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
-
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
-
-    // First pass: find chunk boundaries (reuse existing implementation)
-    for (int i = 0; i < n_threads; ++i) {
-        first_pass_fut[i] = std::async(std::launch::async,
-            [buf, chunk_size, i, delim, quote]() {
-                return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1), delim, quote);
-            });
-    }
-
-    auto st = first_pass_fut[0].get();
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-        auto st = first_pass_fut[i].get();
-        chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-        if (chunk_pos[i] == null_pos) {
-            out.n_threads = 1;
-            out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
-            return true;
-        }
-    }
-
-    // Second pass: branchless parsing of each chunk
-    // Capture sm by value since it's small (~300 bytes) and we need thread safety
-    for (int i = 0; i < n_threads; ++i) {
-        second_pass_fut[i] = std::async(std::launch::async,
-            [sm, buf, &out, &chunk_pos, i]() {
-                return second_pass_simd_branchless(sm, buf, chunk_pos[i], chunk_pos[i + 1], &out, i);
-            });
-    }
-
-    for (int i = 0; i < n_threads; ++i) {
-        out.n_indexes[i] = second_pass_fut[i].get();
-    }
-
+  if (n_threads == 1) {
+    out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
     return true;
+  }
+
+  // Multi-threaded parsing with branchless second pass
+  size_t chunk_size = len / n_threads;
+
+  // If chunk size is too small, fall back to single-threaded
+  if (chunk_size < 64) {
+    out.n_threads = 1;
+    out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+    return true;
+  }
+
+  std::vector<uint64_t> chunk_pos(n_threads + 1);
+  std::vector<std::future<Stats>> first_pass_fut(n_threads);
+  std::vector<std::future<uint64_t>> second_pass_fut(n_threads);
+
+  char delim = dialect.delimiter;
+  char quote = dialect.quote_char;
+
+  // First pass: find chunk boundaries (reuse existing implementation)
+  for (int i = 0; i < n_threads; ++i) {
+    first_pass_fut[i] =
+        std::async(std::launch::async, [buf, chunk_size, i, delim, quote]() {
+          return first_pass_speculate(buf, chunk_size * i, chunk_size * (i + 1),
+                                      delim, quote);
+        });
+  }
+
+  auto st = first_pass_fut[0].get();
+  chunk_pos[0] = 0;
+  for (int i = 1; i < n_threads; ++i) {
+    auto st = first_pass_fut[i].get();
+    chunk_pos[i] = st.n_quotes == 0 ? st.first_even_nl : st.first_odd_nl;
+  }
+  chunk_pos[n_threads] = len;
+
+  // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+  for (int i = 1; i < n_threads; ++i) {
+    if (chunk_pos[i] == null_pos) {
+      out.n_threads = 1;
+      out.n_indexes[0] = second_pass_simd_branchless(sm, buf, 0, len, &out, 0);
+      return true;
+    }
+  }
+
+  // Second pass: branchless parsing of each chunk
+  // Capture sm by value since it's small (~300 bytes) and we need thread safety
+  for (int i = 0; i < n_threads; ++i) {
+    second_pass_fut[i] =
+        std::async(std::launch::async, [sm, buf, &out, &chunk_pos, i]() {
+          return second_pass_simd_branchless(sm, buf, chunk_pos[i],
+                                             chunk_pos[i + 1], &out, i);
+        });
+  }
+
+  for (int i = 0; i < n_threads; ++i) {
+    out.n_indexes[i] = second_pass_fut[i].get();
+  }
+
+  return true;
 }
 
-bool TwoPass::parse_auto(const uint8_t* buf, ParseIndex& out, size_t len,
-                          ErrorCollector& errors, DetectionResult* detected,
-                          const DetectionOptions& detection_options) {
-    // Perform dialect detection
-    DialectDetector detector(detection_options);
-    DetectionResult result = detector.detect(buf, len);
+bool TwoPass::parse_auto(const uint8_t *buf, ParseIndex &out, size_t len,
+                         ErrorCollector &errors, DetectionResult *detected,
+                         const DetectionOptions &detection_options) {
+  // Perform dialect detection
+  DialectDetector detector(detection_options);
+  DetectionResult result = detector.detect(buf, len);
 
-    // Store detection result if requested
-    if (detected != nullptr) {
-        *detected = result;
+  // Store detection result if requested
+  if (detected != nullptr) {
+    *detected = result;
+  }
+
+  // Use detected dialect if successful, otherwise fall back to standard CSV
+  Dialect dialect = result.success() ? result.dialect : Dialect::csv();
+
+  // Add info message about detected dialect
+  if (result.success()) {
+    Dialect csv = Dialect::csv();
+    if (result.dialect.delimiter != csv.delimiter ||
+        result.dialect.quote_char != csv.quote_char) {
+      std::string msg = "Auto-detected dialect: " + result.dialect.to_string();
+      errors.add_error(ErrorCode::NONE, ErrorSeverity::WARNING, 1, 1, 0, msg,
+                       "");
     }
+  }
 
-    // Use detected dialect if successful, otherwise fall back to standard CSV
-    Dialect dialect = result.success() ? result.dialect : Dialect::csv();
-
-    // Add info message about detected dialect
-    if (result.success()) {
-        Dialect csv = Dialect::csv();
-        if (result.dialect.delimiter != csv.delimiter ||
-            result.dialect.quote_char != csv.quote_char) {
-            std::string msg = "Auto-detected dialect: " + result.dialect.to_string();
-            errors.add_error(ErrorCode::NONE, ErrorSeverity::WARNING,
-                             1, 1, 0, msg, "");
-        }
-    }
-
-    // Parse with detected dialect
-    return parse_two_pass_with_errors(buf, out, len, errors, dialect);
+  // Parse with detected dialect
+  return parse_two_pass_with_errors(buf, out, len, errors, dialect);
 }
 
 LIBVROOM_SUPPRESS_DEPRECATION_END
 
-DetectionResult TwoPass::detect_dialect(const uint8_t* buf, size_t len,
-                                         const DetectionOptions& options) {
-    DialectDetector detector(options);
-    return detector.detect(buf, len);
+DetectionResult TwoPass::detect_dialect(const uint8_t *buf, size_t len,
+                                        const DetectionOptions &options) {
+  DialectDetector detector(options);
+  return detector.detect(buf, len);
 }
 
 TwoPass::chunk_result TwoPass::second_pass_chunk_with_errors(
-    const uint8_t* buf, size_t start, size_t end,
-    ParseIndex* out, size_t thread_id, size_t total_len, ErrorMode mode,
-    char delimiter, char quote_char) {
-    chunk_result result;
-    result.errors.set_mode(mode);
-    result.n_indexes = second_pass_chunk(buf, start, end, out, thread_id,
-                                         &result.errors, total_len, delimiter, quote_char);
-    return result;
+    const uint8_t *buf, size_t start, size_t end, ParseIndex *out,
+    size_t thread_id, size_t total_len, ErrorMode mode, char delimiter,
+    char quote_char) {
+  chunk_result result;
+  result.errors.set_mode(mode);
+  result.n_indexes =
+      second_pass_chunk(buf, start, end, out, thread_id, &result.errors,
+                        total_len, delimiter, quote_char);
+  return result;
 }
 
 LIBVROOM_SUPPRESS_DEPRECATION_START
 
-bool TwoPass::parse_two_pass_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
-                                          ErrorCollector& errors,
-                                          const Dialect& dialect) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
+bool TwoPass::parse_two_pass_with_errors(const uint8_t *buf, ParseIndex &out,
+                                         size_t len, ErrorCollector &errors,
+                                         const Dialect &dialect) {
+  char delim = dialect.delimiter;
+  char quote = dialect.quote_char;
 
-    // Handle empty input
-    if (len == 0) return true;
+  // Handle empty input
+  if (len == 0)
+    return true;
 
-    // Check structural issues first (single-threaded, fast)
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
+  // Check structural issues first (single-threaded, fast)
+  check_empty_header(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
+  check_duplicate_columns(buf, len, errors, delim, quote);
+  if (errors.should_stop())
+    return false;
 
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
+  check_line_endings(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    uint8_t n_threads = out.n_threads;
+  uint16_t n_threads = out.n_threads;
 
-    // Validate n_threads: treat 0 as single-threaded to avoid division by zero
-    if (n_threads == 0) n_threads = 1;
+  // Validate n_threads: treat 0 as single-threaded to avoid division by zero
+  if (n_threads == 0)
+    n_threads = 1;
 
-    // For single-threaded, use the simpler path
-    if (n_threads == 1) {
-        out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-        check_field_counts(buf, len, errors, delim, quote);
-        return !errors.has_fatal_errors();
-    }
-
-    size_t chunk_size = len / n_threads;
-    std::vector<uint64_t> chunk_pos(n_threads + 1);
-    std::vector<std::future<Stats>> first_pass_fut(n_threads);
-    std::vector<std::future<chunk_result>> second_pass_fut(n_threads);
-
-    // First pass: find chunk boundaries
-    for (int i = 0; i < n_threads; ++i) {
-        first_pass_fut[i] = std::async(std::launch::async,
-            [buf, chunk_size, i, quote]() {
-                return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
-            });
-    }
-
-    auto st = first_pass_fut[0].get();
-    size_t n_quotes = st.n_quotes;
-    chunk_pos[0] = 0;
-    for (int i = 1; i < n_threads; ++i) {
-        auto st = first_pass_fut[i].get();
-        chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
-        n_quotes += st.n_quotes;
-    }
-    chunk_pos[n_threads] = len;
-
-    // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
-    for (int i = 1; i < n_threads; ++i) {
-        if (chunk_pos[i] == null_pos) {
-            out.n_threads = 1;
-            out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
-            check_field_counts(buf, len, errors, delim, quote);
-            return !errors.has_fatal_errors();
-        }
-    }
-
-    // Second pass: parse with thread-local error collectors
-    ErrorMode mode = errors.mode();
-    for (int i = 0; i < n_threads; ++i) {
-        second_pass_fut[i] = std::async(std::launch::async,
-            [buf, &out, &chunk_pos, i, len, mode, delim, quote]() {
-                return second_pass_chunk_with_errors(buf, chunk_pos[i], chunk_pos[i + 1],
-                                                      &out, i, len, mode, delim, quote);
-            });
-    }
-
-    // Collect results and merge errors
-    std::vector<ErrorCollector> thread_errors;
-    thread_errors.reserve(n_threads);
-
-    for (int i = 0; i < n_threads; ++i) {
-        auto result = second_pass_fut[i].get();
-        out.n_indexes[i] = result.n_indexes;
-        thread_errors.push_back(std::move(result.errors));
-    }
-
-    // Merge all thread-local errors, sorted by byte offset
-    errors.merge_sorted(thread_errors);
-
-    // Check field counts after parsing (single-threaded, scans file linearly)
+  // For single-threaded, use the simpler path
+  if (n_threads == 1) {
+    out.n_indexes[0] =
+        second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
     check_field_counts(buf, len, errors, delim, quote);
-
     return !errors.has_fatal_errors();
+  }
+
+  size_t chunk_size = len / n_threads;
+  std::vector<uint64_t> chunk_pos(n_threads + 1);
+  std::vector<std::future<Stats>> first_pass_fut(n_threads);
+  std::vector<std::future<chunk_result>> second_pass_fut(n_threads);
+
+  // First pass: find chunk boundaries
+  for (int i = 0; i < n_threads; ++i) {
+    first_pass_fut[i] = std::async(std::launch::async, [buf, chunk_size, i,
+                                                        quote]() {
+      return first_pass_chunk(buf, chunk_size * i, chunk_size * (i + 1), quote);
+    });
+  }
+
+  auto st = first_pass_fut[0].get();
+  size_t n_quotes = st.n_quotes;
+  chunk_pos[0] = 0;
+  for (int i = 1; i < n_threads; ++i) {
+    auto st = first_pass_fut[i].get();
+    chunk_pos[i] = (n_quotes % 2) == 0 ? st.first_even_nl : st.first_odd_nl;
+    n_quotes += st.n_quotes;
+  }
+  chunk_pos[n_threads] = len;
+
+  // Safety check: if any chunk_pos is null_pos, fall back to single-threaded
+  for (int i = 1; i < n_threads; ++i) {
+    if (chunk_pos[i] == null_pos) {
+      out.n_threads = 1;
+      out.n_indexes[0] =
+          second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+      check_field_counts(buf, len, errors, delim, quote);
+      return !errors.has_fatal_errors();
+    }
+  }
+
+  // Second pass: parse with thread-local error collectors
+  ErrorMode mode = errors.mode();
+  for (int i = 0; i < n_threads; ++i) {
+    second_pass_fut[i] = std::async(std::launch::async, [buf, &out, &chunk_pos,
+                                                         i, len, mode, delim,
+                                                         quote]() {
+      return second_pass_chunk_with_errors(buf, chunk_pos[i], chunk_pos[i + 1],
+                                           &out, i, len, mode, delim, quote);
+    });
+  }
+
+  // Collect results and merge errors
+  std::vector<ErrorCollector> thread_errors;
+  thread_errors.reserve(n_threads);
+
+  for (int i = 0; i < n_threads; ++i) {
+    auto result = second_pass_fut[i].get();
+    out.n_indexes[i] = result.n_indexes;
+    thread_errors.push_back(std::move(result.errors));
+  }
+
+  // Merge all thread-local errors, sorted by byte offset
+  errors.merge_sorted(thread_errors);
+
+  // Check field counts after parsing (single-threaded, scans file linearly)
+  check_field_counts(buf, len, errors, delim, quote);
+
+  return !errors.has_fatal_errors();
 }
 
-bool TwoPass::parse_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
-                                 ErrorCollector& errors,
-                                 const Dialect& dialect) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
+bool TwoPass::parse_with_errors(const uint8_t *buf, ParseIndex &out, size_t len,
+                                ErrorCollector &errors,
+                                const Dialect &dialect) {
+  char delim = dialect.delimiter;
+  char quote = dialect.quote_char;
 
-    // Check structural issues first
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
+  // Check structural issues first
+  check_empty_header(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
+  check_duplicate_columns(buf, len, errors, delim, quote);
+  if (errors.should_stop())
+    return false;
 
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
+  check_line_endings(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    // Single-threaded parsing for accurate error position tracking
-    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+  // Single-threaded parsing for accurate error position tracking
+  out.n_indexes[0] =
+      second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
 
-    // Check field counts after parsing
-    check_field_counts(buf, len, errors, delim, quote);
+  // Check field counts after parsing
+  check_field_counts(buf, len, errors, delim, quote);
 
-    return !errors.has_fatal_errors();
+  return !errors.has_fatal_errors();
 }
 
-bool TwoPass::parse_validate(const uint8_t* buf, ParseIndex& out, size_t len,
-                              ErrorCollector& errors,
-                              const Dialect& dialect) {
-    char delim = dialect.delimiter;
-    char quote = dialect.quote_char;
+bool TwoPass::parse_validate(const uint8_t *buf, ParseIndex &out, size_t len,
+                             ErrorCollector &errors, const Dialect &dialect) {
+  char delim = dialect.delimiter;
+  char quote = dialect.quote_char;
 
-    // Check structural issues first
-    check_empty_header(buf, len, errors);
-    if (errors.should_stop()) return false;
+  // Check structural issues first
+  check_empty_header(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    check_duplicate_columns(buf, len, errors, delim, quote);
-    if (errors.should_stop()) return false;
+  check_duplicate_columns(buf, len, errors, delim, quote);
+  if (errors.should_stop())
+    return false;
 
-    check_line_endings(buf, len, errors);
-    if (errors.should_stop()) return false;
+  check_line_endings(buf, len, errors);
+  if (errors.should_stop())
+    return false;
 
-    // Parse with error collection
-    out.n_indexes[0] = second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
+  // Parse with error collection
+  out.n_indexes[0] =
+      second_pass_chunk(buf, 0, len, &out, 0, &errors, len, delim, quote);
 
-    // Check field counts after parsing
-    check_field_counts(buf, len, errors, delim, quote);
+  // Check field counts after parsing
+  check_field_counts(buf, len, errors, delim, quote);
 
-    return !errors.has_fatal_errors();
+  return !errors.has_fatal_errors();
 }
 
 LIBVROOM_SUPPRESS_DEPRECATION_END
@@ -933,125 +1027,138 @@ LIBVROOM_SUPPRESS_DEPRECATION_END
 // TwoPass validation functions
 //-----------------------------------------------------------------------------
 
-bool TwoPass::check_empty_header(const uint8_t* buf, size_t len, ErrorCollector& errors) {
-    if (len == 0) return true;
-    if (buf[0] == '\n' || buf[0] == '\r') {
-        errors.add_error(ErrorCode::EMPTY_HEADER, ErrorSeverity::ERROR,
-                         1, 1, 0, "Header row is empty", "");
-        return false;
-    }
+bool TwoPass::check_empty_header(const uint8_t *buf, size_t len,
+                                 ErrorCollector &errors) {
+  if (len == 0)
     return true;
+  if (buf[0] == '\n' || buf[0] == '\r') {
+    errors.add_error(ErrorCode::EMPTY_HEADER, ErrorSeverity::ERROR, 1, 1, 0,
+                     "Header row is empty", "");
+    return false;
+  }
+  return true;
 }
 
-void TwoPass::check_duplicate_columns(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                       char delimiter, char quote_char) {
-    if (len == 0) return;
+void TwoPass::check_duplicate_columns(const uint8_t *buf, size_t len,
+                                      ErrorCollector &errors, char delimiter,
+                                      char quote_char) {
+  if (len == 0)
+    return;
 
-    // Find end of first line
-    size_t header_end = 0;
-    bool in_quote = false;
-    while (header_end < len) {
-        if (buf[header_end] == static_cast<uint8_t>(quote_char)) in_quote = !in_quote;
-        else if (!in_quote && (buf[header_end] == '\n' || buf[header_end] == '\r')) break;
-        ++header_end;
-    }
+  // Find end of first line
+  size_t header_end = 0;
+  bool in_quote = false;
+  while (header_end < len) {
+    if (buf[header_end] == static_cast<uint8_t>(quote_char))
+      in_quote = !in_quote;
+    else if (!in_quote && (buf[header_end] == '\n' || buf[header_end] == '\r'))
+      break;
+    ++header_end;
+  }
 
-    // Parse header fields
-    std::vector<std::string> fields;
-    std::string current;
-    in_quote = false;
-    for (size_t i = 0; i < header_end; ++i) {
-        if (buf[i] == static_cast<uint8_t>(quote_char)) {
-            in_quote = !in_quote;
-        } else if (!in_quote && buf[i] == static_cast<uint8_t>(delimiter)) {
-            fields.push_back(current);
-            current.clear();
-        } else if (buf[i] != '\r') {
-            current += static_cast<char>(buf[i]);
-        }
+  // Parse header fields
+  std::vector<std::string> fields;
+  std::string current;
+  in_quote = false;
+  for (size_t i = 0; i < header_end; ++i) {
+    if (buf[i] == static_cast<uint8_t>(quote_char)) {
+      in_quote = !in_quote;
+    } else if (!in_quote && buf[i] == static_cast<uint8_t>(delimiter)) {
+      fields.push_back(current);
+      current.clear();
+    } else if (buf[i] != '\r') {
+      current += static_cast<char>(buf[i]);
     }
-    fields.push_back(current);
+  }
+  fields.push_back(current);
 
-    // Check for duplicates
-    std::unordered_set<std::string> seen;
-    for (size_t i = 0; i < fields.size(); ++i) {
-        if (seen.count(fields[i]) > 0) {
-            errors.add_error(ErrorCode::DUPLICATE_COLUMN_NAMES, ErrorSeverity::WARNING,
-                             1, i + 1, 0, "Duplicate column name: '" + fields[i] + "'", fields[i]);
-        }
-        seen.insert(fields[i]);
+  // Check for duplicates
+  std::unordered_set<std::string> seen;
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (seen.count(fields[i]) > 0) {
+      errors.add_error(ErrorCode::DUPLICATE_COLUMN_NAMES,
+                       ErrorSeverity::WARNING, 1, i + 1, 0,
+                       "Duplicate column name: '" + fields[i] + "'", fields[i]);
     }
+    seen.insert(fields[i]);
+  }
 }
 
-void TwoPass::check_field_counts(const uint8_t* buf, size_t len, ErrorCollector& errors,
-                                  char delimiter, char quote_char) {
-    if (len == 0) return;
+void TwoPass::check_field_counts(const uint8_t *buf, size_t len,
+                                 ErrorCollector &errors, char delimiter,
+                                 char quote_char) {
+  if (len == 0)
+    return;
 
-    size_t expected_fields = 0;
-    size_t current_fields = 1;
-    size_t current_line = 1;
-    size_t line_start = 0;
-    bool in_quote = false;
-    bool header_done = false;
+  size_t expected_fields = 0;
+  size_t current_fields = 1;
+  size_t current_line = 1;
+  size_t line_start = 0;
+  bool in_quote = false;
+  bool header_done = false;
 
-    for (size_t i = 0; i < len; ++i) {
-        if (buf[i] == static_cast<uint8_t>(quote_char)) {
-            in_quote = !in_quote;
-        } else if (!in_quote) {
-            if (buf[i] == static_cast<uint8_t>(delimiter)) {
-                ++current_fields;
-            } else if (buf[i] == '\n') {
-                if (!header_done) {
-                    expected_fields = current_fields;
-                    header_done = true;
-                } else if (current_fields != expected_fields) {
-                    std::ostringstream msg;
-                    msg << "Expected " << expected_fields << " fields but found " << current_fields;
-                    errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
-                                     current_line, 1, line_start, msg.str(),
-                                     get_context(buf, len, line_start, 40));
-                    if (errors.should_stop()) return;
-                }
-                current_fields = 1;
-                ++current_line;
-                line_start = i + 1;
-            }
+  for (size_t i = 0; i < len; ++i) {
+    if (buf[i] == static_cast<uint8_t>(quote_char)) {
+      in_quote = !in_quote;
+    } else if (!in_quote) {
+      if (buf[i] == static_cast<uint8_t>(delimiter)) {
+        ++current_fields;
+      } else if (buf[i] == '\n') {
+        if (!header_done) {
+          expected_fields = current_fields;
+          header_done = true;
+        } else if (current_fields != expected_fields) {
+          std::ostringstream msg;
+          msg << "Expected " << expected_fields << " fields but found "
+              << current_fields;
+          errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT,
+                           ErrorSeverity::ERROR, current_line, 1, line_start,
+                           msg.str(), get_context(buf, len, line_start, 40));
+          if (errors.should_stop())
+            return;
         }
+        current_fields = 1;
+        ++current_line;
+        line_start = i + 1;
+      }
     }
+  }
 
-    // Check last line if no trailing newline
-    if (header_done && current_fields != expected_fields && line_start < len) {
-        std::ostringstream msg;
-        msg << "Expected " << expected_fields << " fields but found " << current_fields;
-        errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
-                         current_line, 1, line_start, msg.str(),
-                         get_context(buf, len, line_start, 40));
-    }
+  // Check last line if no trailing newline
+  if (header_done && current_fields != expected_fields && line_start < len) {
+    std::ostringstream msg;
+    msg << "Expected " << expected_fields << " fields but found "
+        << current_fields;
+    errors.add_error(ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::ERROR,
+                     current_line, 1, line_start, msg.str(),
+                     get_context(buf, len, line_start, 40));
+  }
 }
 
-void TwoPass::check_line_endings(const uint8_t* buf, size_t len, ErrorCollector& errors) {
-    bool has_crlf = false;
-    bool has_lf = false;
-    bool has_cr = false;
+void TwoPass::check_line_endings(const uint8_t *buf, size_t len,
+                                 ErrorCollector &errors) {
+  bool has_crlf = false;
+  bool has_lf = false;
+  bool has_cr = false;
 
-    for (size_t i = 0; i < len; ++i) {
-        if (buf[i] == '\r') {
-            if (i + 1 < len && buf[i + 1] == '\n') {
-                has_crlf = true;
-                ++i;
-            } else {
-                has_cr = true;
-            }
-        } else if (buf[i] == '\n') {
-            has_lf = true;
-        }
+  for (size_t i = 0; i < len; ++i) {
+    if (buf[i] == '\r') {
+      if (i + 1 < len && buf[i + 1] == '\n') {
+        has_crlf = true;
+        ++i;
+      } else {
+        has_cr = true;
+      }
+    } else if (buf[i] == '\n') {
+      has_lf = true;
     }
+  }
 
-    int types = (has_crlf ? 1 : 0) + (has_lf ? 1 : 0) + (has_cr ? 1 : 0);
-    if (types > 1) {
-        errors.add_error(ErrorCode::MIXED_LINE_ENDINGS, ErrorSeverity::WARNING,
-                         1, 1, 0, "Mixed line endings detected", "");
-    }
+  int types = (has_crlf ? 1 : 0) + (has_lf ? 1 : 0) + (has_cr ? 1 : 0);
+  if (types > 1) {
+    errors.add_error(ErrorCode::MIXED_LINE_ENDINGS, ErrorSeverity::WARNING, 1,
+                     1, 0, "Mixed line endings detected", "");
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -1059,93 +1166,98 @@ void TwoPass::check_line_endings(const uint8_t* buf, size_t len, ErrorCollector&
 //-----------------------------------------------------------------------------
 
 ParseIndex TwoPass::init(size_t len, size_t n_threads) {
-    ParseIndex out;
-    // Ensure at least 1 thread for valid memory allocation
-    if (n_threads == 0) n_threads = 1;
-    out.n_threads = n_threads;
+  ParseIndex out;
+  // Ensure at least 1 thread for valid memory allocation
+  if (n_threads == 0)
+    n_threads = 1;
+  out.n_threads = n_threads;
 
-    // Allocate n_indexes array with RAII ownership
-    out.n_indexes_ptr_ = std::make_unique<uint64_t[]>(n_threads);
-    out.n_indexes = out.n_indexes_ptr_.get();
+  // Allocate n_indexes array with RAII ownership
+  out.n_indexes_ptr_ = std::make_unique<uint64_t[]>(n_threads);
+  out.n_indexes = out.n_indexes_ptr_.get();
 
-    // Allocate space for interleaved index storage.
-    size_t allocation_size;
-    if (n_threads == 1) {
-        // Single-threaded: simple allocation with padding for speculative writes
-        allocation_size = len + 8;
-    } else {
-        // Multi-threaded: need space for interleaved storage
-        allocation_size = (len + 8) * n_threads;
-    }
+  // Allocate space for interleaved index storage.
+  size_t allocation_size;
+  if (n_threads == 1) {
+    // Single-threaded: simple allocation with padding for speculative writes
+    allocation_size = len + 8;
+  } else {
+    // Multi-threaded: need space for interleaved storage
+    allocation_size = (len + 8) * n_threads;
+  }
 
-    // Allocate indexes array with RAII ownership
-    out.indexes_ptr_ = std::make_unique<uint64_t[]>(allocation_size);
-    out.indexes = out.indexes_ptr_.get();
+  // Allocate indexes array with RAII ownership
+  out.indexes_ptr_ = std::make_unique<uint64_t[]>(allocation_size);
+  out.indexes = out.indexes_ptr_.get();
 
-    return out;
+  return out;
 }
 
-ParseIndex TwoPass::init_safe(size_t len, size_t n_threads, ErrorCollector* errors) {
-    ParseIndex out;
-    // Ensure at least 1 thread for valid memory allocation
-    if (n_threads == 0) n_threads = 1;
-    out.n_threads = n_threads;
+ParseIndex TwoPass::init_safe(size_t len, size_t n_threads,
+                              ErrorCollector *errors) {
+  ParseIndex out;
+  // Ensure at least 1 thread for valid memory allocation
+  if (n_threads == 0)
+    n_threads = 1;
+  out.n_threads = n_threads;
 
-    // Calculate allocation size with overflow checking
-    size_t allocation_size;
-    bool overflow = false;
+  // Calculate allocation size with overflow checking
+  size_t allocation_size;
+  bool overflow = false;
 
-    if (n_threads == 1) {
-        // Single-threaded: simple allocation with padding for speculative writes
-        // allocation_size = len + 8
-        if (len > std::numeric_limits<size_t>::max() - 8) {
-            overflow = true;
-        } else {
-            allocation_size = len + 8;
-        }
+  if (n_threads == 1) {
+    // Single-threaded: simple allocation with padding for speculative writes
+    // allocation_size = len + 8
+    if (len > std::numeric_limits<size_t>::max() - 8) {
+      overflow = true;
     } else {
-        // Multi-threaded: need space for interleaved storage
-        // allocation_size = (len + 8) * n_threads
-        size_t len_plus_8;
-        if (len > std::numeric_limits<size_t>::max() - 8) {
-            overflow = true;
-        } else {
-            len_plus_8 = len + 8;
-            // Check (len + 8) * n_threads for overflow
-            if (len_plus_8 > std::numeric_limits<size_t>::max() / n_threads) {
-                overflow = true;
-            } else {
-                allocation_size = len_plus_8 * n_threads;
-            }
-        }
+      allocation_size = len + 8;
     }
-
-    // Check final allocation: allocation_size * sizeof(uint64_t)
-    if (!overflow && allocation_size > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
+  } else {
+    // Multi-threaded: need space for interleaved storage
+    // allocation_size = (len + 8) * n_threads
+    size_t len_plus_8;
+    if (len > std::numeric_limits<size_t>::max() - 8) {
+      overflow = true;
+    } else {
+      len_plus_8 = len + 8;
+      // Check (len + 8) * n_threads for overflow
+      if (len_plus_8 > std::numeric_limits<size_t>::max() / n_threads) {
         overflow = true;
+      } else {
+        allocation_size = len_plus_8 * n_threads;
+      }
     }
+  }
 
-    if (overflow) {
-        std::string msg = "Index allocation would overflow: len=" + std::to_string(len) +
-                          ", n_threads=" + std::to_string(n_threads);
-        if (errors != nullptr) {
-            errors->add_error(ErrorCode::INDEX_ALLOCATION_OVERFLOW, ErrorSeverity::FATAL,
-                              1, 1, 0, msg);
-            // Return empty index to signal failure
-            return out;
-        } else {
-            throw std::runtime_error(msg);
-        }
+  // Check final allocation: allocation_size * sizeof(uint64_t)
+  if (!overflow &&
+      allocation_size > std::numeric_limits<size_t>::max() / sizeof(uint64_t)) {
+    overflow = true;
+  }
+
+  if (overflow) {
+    std::string msg =
+        "Index allocation would overflow: len=" + std::to_string(len) +
+        ", n_threads=" + std::to_string(n_threads);
+    if (errors != nullptr) {
+      errors->add_error(ErrorCode::INDEX_ALLOCATION_OVERFLOW,
+                        ErrorSeverity::FATAL, 1, 1, 0, msg);
+      // Return empty index to signal failure
+      return out;
+    } else {
+      throw std::runtime_error(msg);
     }
+  }
 
-    // Safe to allocate - use RAII to ensure proper cleanup
-    out.n_indexes_ptr_ = std::make_unique<uint64_t[]>(n_threads);
-    out.n_indexes = out.n_indexes_ptr_.get();
+  // Safe to allocate - use RAII to ensure proper cleanup
+  out.n_indexes_ptr_ = std::make_unique<uint64_t[]>(n_threads);
+  out.n_indexes = out.n_indexes_ptr_.get();
 
-    out.indexes_ptr_ = std::make_unique<uint64_t[]>(allocation_size);
-    out.indexes = out.indexes_ptr_.get();
+  out.indexes_ptr_ = std::make_unique<uint64_t[]>(allocation_size);
+  out.indexes = out.indexes_ptr_.get();
 
-    return out;
+  return out;
 }
 
-}  // namespace libvroom
+} // namespace libvroom

--- a/src/value_extraction.cpp
+++ b/src/value_extraction.cpp
@@ -6,118 +6,167 @@
 
 namespace libvroom {
 
-ValueExtractor::ValueExtractor(const uint8_t* buf, size_t len, const ParseIndex& idx,
-                               const Dialect& dialect, const ExtractionConfig& config)
+ValueExtractor::ValueExtractor(const uint8_t *buf, size_t len,
+                               const ParseIndex &idx, const Dialect &dialect,
+                               const ExtractionConfig &config)
     : buf_(buf), len_(len), idx_(idx), dialect_(dialect), config_(config) {
-    uint64_t total_indexes = 0;
-    for (uint8_t i = 0; i < idx_.n_threads; ++i) total_indexes += idx_.n_indexes[i];
-    linear_indexes_.reserve(total_indexes);
-    for (uint8_t t = 0; t < idx_.n_threads; ++t)
-        for (uint64_t j = 0; j < idx_.n_indexes[t]; ++j)
-            linear_indexes_.push_back(idx_.indexes[t + (j * idx_.n_threads)]);
-    std::sort(linear_indexes_.begin(), linear_indexes_.end());
-    size_t first_nl = 0;
-    for (size_t i = 0; i < linear_indexes_.size(); ++i) {
-        if (linear_indexes_[i] >= len_) continue;  // Bounds check
-        // Support LF, CRLF, and CR-only line endings
-        uint8_t c = buf_[linear_indexes_[i]];
-        if (c == '\n' || c == '\r') { first_nl = i; break; }
+  uint64_t total_indexes = 0;
+  for (uint16_t i = 0; i < idx_.n_threads; ++i)
+    total_indexes += idx_.n_indexes[i];
+  linear_indexes_.reserve(total_indexes);
+  for (uint16_t t = 0; t < idx_.n_threads; ++t)
+    for (uint64_t j = 0; j < idx_.n_indexes[t]; ++j)
+      linear_indexes_.push_back(idx_.indexes[t + (j * idx_.n_threads)]);
+  std::sort(linear_indexes_.begin(), linear_indexes_.end());
+  size_t first_nl = 0;
+  for (size_t i = 0; i < linear_indexes_.size(); ++i) {
+    if (linear_indexes_[i] >= len_)
+      continue; // Bounds check
+    // Support LF, CRLF, and CR-only line endings
+    uint8_t c = buf_[linear_indexes_[i]];
+    if (c == '\n' || c == '\r') {
+      first_nl = i;
+      break;
     }
-    num_columns_ = first_nl + 1;
-    recalculate_num_rows();
+  }
+  num_columns_ = first_nl + 1;
+  recalculate_num_rows();
 }
 
 std::string_view ValueExtractor::get_string_view(size_t row, size_t col) const {
-    if (row >= num_rows_) throw std::out_of_range("Row index out of range");
-    if (col >= num_columns_) throw std::out_of_range("Column index out of range");
-    return get_string_view_internal(row, col);
+  if (row >= num_rows_)
+    throw std::out_of_range("Row index out of range");
+  if (col >= num_columns_)
+    throw std::out_of_range("Column index out of range");
+  return get_string_view_internal(row, col);
 }
 
-std::string_view ValueExtractor::get_string_view_internal(size_t row, size_t col) const {
-    size_t field_idx = compute_field_index(row, col);
-    // Return empty view with valid pointer to avoid undefined behavior when converting to std::string
-    if (field_idx >= linear_indexes_.size()) return std::string_view(reinterpret_cast<const char*>(buf_), 0);
-    size_t start = (field_idx == 0) ? 0 : linear_indexes_[field_idx - 1] + 1;
-    size_t end = linear_indexes_[field_idx];
-    if (end > len_) end = len_;  // Bounds check
-    if (start > len_) start = len_;  // Bounds check
-    if (end > start && buf_[end - 1] == '\r') --end;
-    if (end > start && buf_[start] == static_cast<uint8_t>(dialect_.quote_char))
-        if (buf_[end - 1] == static_cast<uint8_t>(dialect_.quote_char)) { ++start; --end; }
-    if (end < start) end = start;
-    assert(end >= start && "Invalid range: end must be >= start");
-    return std::string_view(reinterpret_cast<const char*>(buf_ + start), end - start);
+std::string_view ValueExtractor::get_string_view_internal(size_t row,
+                                                          size_t col) const {
+  size_t field_idx = compute_field_index(row, col);
+  // Return empty view with valid pointer to avoid undefined behavior when
+  // converting to std::string
+  if (field_idx >= linear_indexes_.size())
+    return std::string_view(reinterpret_cast<const char *>(buf_), 0);
+  size_t start = (field_idx == 0) ? 0 : linear_indexes_[field_idx - 1] + 1;
+  size_t end = linear_indexes_[field_idx];
+  if (end > len_)
+    end = len_; // Bounds check
+  if (start > len_)
+    start = len_; // Bounds check
+  if (end > start && buf_[end - 1] == '\r')
+    --end;
+  if (end > start && buf_[start] == static_cast<uint8_t>(dialect_.quote_char))
+    if (buf_[end - 1] == static_cast<uint8_t>(dialect_.quote_char)) {
+      ++start;
+      --end;
+    }
+  if (end < start)
+    end = start;
+  assert(end >= start && "Invalid range: end must be >= start");
+  return std::string_view(reinterpret_cast<const char *>(buf_ + start),
+                          end - start);
 }
 
 std::string ValueExtractor::get_string(size_t row, size_t col) const {
-    size_t field_idx = compute_field_index(row, col);
-    if (field_idx >= linear_indexes_.size()) return std::string();  // Bounds check
-    size_t start = (field_idx == 0) ? 0 : linear_indexes_[field_idx - 1] + 1;
-    size_t end = linear_indexes_[field_idx];
-    if (end > len_) end = len_;  // Bounds check
-    if (start > len_) start = len_;  // Bounds check
-    if (end > start && buf_[end - 1] == '\r') --end;
-    if (end < start) end = start;  // Normalize range
-    assert(end >= start && "Invalid range: end must be >= start");
-    return unescape_field(std::string_view(reinterpret_cast<const char*>(buf_ + start), end - start));
+  size_t field_idx = compute_field_index(row, col);
+  if (field_idx >= linear_indexes_.size())
+    return std::string(); // Bounds check
+  size_t start = (field_idx == 0) ? 0 : linear_indexes_[field_idx - 1] + 1;
+  size_t end = linear_indexes_[field_idx];
+  if (end > len_)
+    end = len_; // Bounds check
+  if (start > len_)
+    start = len_; // Bounds check
+  if (end > start && buf_[end - 1] == '\r')
+    --end;
+  if (end < start)
+    end = start; // Normalize range
+  assert(end >= start && "Invalid range: end must be >= start");
+  return unescape_field(std::string_view(
+      reinterpret_cast<const char *>(buf_ + start), end - start));
 }
 
 size_t ValueExtractor::compute_field_index(size_t row, size_t col) const {
-    return (has_header_ ? row + 1 : row) * num_columns_ + col;
+  return (has_header_ ? row + 1 : row) * num_columns_ + col;
 }
 
 std::string ValueExtractor::unescape_field(std::string_view field) const {
-    if (field.empty() || field.front() != dialect_.quote_char) return std::string(field);
-    if (field.size() < 2 || field.back() != dialect_.quote_char) return std::string(field);
-    std::string_view inner = field.substr(1, field.size() - 2);
-    std::string result; result.reserve(inner.size());
-    for (size_t i = 0; i < inner.size(); ++i) {
-        char c = inner[i];
-        if (c == dialect_.escape_char && i + 1 < inner.size() && inner[i + 1] == dialect_.quote_char) {
-            result += dialect_.quote_char; ++i;
-        } else result += c;
-    }
-    return result;
+  if (field.empty() || field.front() != dialect_.quote_char)
+    return std::string(field);
+  if (field.size() < 2 || field.back() != dialect_.quote_char)
+    return std::string(field);
+  std::string_view inner = field.substr(1, field.size() - 2);
+  std::string result;
+  result.reserve(inner.size());
+  for (size_t i = 0; i < inner.size(); ++i) {
+    char c = inner[i];
+    if (c == dialect_.escape_char && i + 1 < inner.size() &&
+        inner[i + 1] == dialect_.quote_char) {
+      result += dialect_.quote_char;
+      ++i;
+    } else
+      result += c;
+  }
+  return result;
 }
 
-std::vector<std::string_view> ValueExtractor::extract_column_string_view(size_t col) const {
-    if (col >= num_columns_) throw std::out_of_range("Column index out of range");
-    std::vector<std::string_view> result; result.reserve(num_rows_);
-    for (size_t row = 0; row < num_rows_; ++row) result.push_back(get_string_view_internal(row, col));
-    return result;
+std::vector<std::string_view>
+ValueExtractor::extract_column_string_view(size_t col) const {
+  if (col >= num_columns_)
+    throw std::out_of_range("Column index out of range");
+  std::vector<std::string_view> result;
+  result.reserve(num_rows_);
+  for (size_t row = 0; row < num_rows_; ++row)
+    result.push_back(get_string_view_internal(row, col));
+  return result;
 }
 
-std::vector<std::string> ValueExtractor::extract_column_string(size_t col) const {
-    if (col >= num_columns_) throw std::out_of_range("Column index out of range");
-    std::vector<std::string> result; result.reserve(num_rows_);
-    for (size_t row = 0; row < num_rows_; ++row) result.push_back(get_string(row, col));
-    return result;
+std::vector<std::string>
+ValueExtractor::extract_column_string(size_t col) const {
+  if (col >= num_columns_)
+    throw std::out_of_range("Column index out of range");
+  std::vector<std::string> result;
+  result.reserve(num_rows_);
+  for (size_t row = 0; row < num_rows_; ++row)
+    result.push_back(get_string(row, col));
+  return result;
 }
 
 std::vector<std::string> ValueExtractor::get_header() const {
-    if (!has_header_) throw std::runtime_error("CSV has no header row");
-    std::vector<std::string> headers; headers.reserve(num_columns_);
-    for (size_t col = 0; col < num_columns_; ++col) {
-        if (col >= linear_indexes_.size()) break;  // Bounds check
-        size_t start = (col == 0) ? 0 : linear_indexes_[col - 1] + 1;
-        size_t end = linear_indexes_[col];
-        if (end > len_) end = len_;  // Bounds check
-        if (start > len_) start = len_;  // Bounds check
-        if (end > start && buf_[end - 1] == '\r') --end;
-        if (end < start) end = start;  // Normalize range
-        assert(end >= start && "Invalid range: end must be >= start");
-        headers.push_back(unescape_field(std::string_view(reinterpret_cast<const char*>(buf_ + start), end - start)));
-    }
-    return headers;
+  if (!has_header_)
+    throw std::runtime_error("CSV has no header row");
+  std::vector<std::string> headers;
+  headers.reserve(num_columns_);
+  for (size_t col = 0; col < num_columns_; ++col) {
+    if (col >= linear_indexes_.size())
+      break; // Bounds check
+    size_t start = (col == 0) ? 0 : linear_indexes_[col - 1] + 1;
+    size_t end = linear_indexes_[col];
+    if (end > len_)
+      end = len_; // Bounds check
+    if (start > len_)
+      start = len_; // Bounds check
+    if (end > start && buf_[end - 1] == '\r')
+      --end;
+    if (end < start)
+      end = start; // Normalize range
+    assert(end >= start && "Invalid range: end must be >= start");
+    headers.push_back(unescape_field(std::string_view(
+        reinterpret_cast<const char *>(buf_ + start), end - start)));
+  }
+  return headers;
 }
 
-bool ValueExtractor::get_field_bounds(size_t row, size_t col, size_t& start, size_t& end) const {
-    if (row >= num_rows_ || col >= num_columns_) return false;
-    size_t field_idx = compute_field_index(row, col);
-    start = (field_idx == 0) ? 0 : linear_indexes_[field_idx - 1] + 1;
-    end = linear_indexes_[field_idx];
-    assert(end >= start && "Invalid field bounds: end must be >= start");
-    return true;
+bool ValueExtractor::get_field_bounds(size_t row, size_t col, size_t &start,
+                                      size_t &end) const {
+  if (row >= num_rows_ || col >= num_columns_)
+    return false;
+  size_t field_idx = compute_field_index(row, col);
+  start = (field_idx == 0) ? 0 : linear_indexes_[field_idx - 1] + 1;
+  end = linear_indexes_[field_idx];
+  assert(end >= start && "Invalid field bounds: end must be >= start");
+  return true;
 }
 
-}  // namespace libvroom
+} // namespace libvroom

--- a/test/cli_test.cpp
+++ b/test/cli_test.cpp
@@ -24,15 +24,15 @@
 
 // Helper class to run CLI commands and capture output
 class CliRunner {
- public:
+public:
   struct Result {
     int exit_code;
-    std::string output;  // Combined stdout/stderr output
+    std::string output; // Combined stdout/stderr output
   };
 
   // Run vroom with given arguments
   // Note: stderr is redirected to stdout for simpler output capture
-  static Result run(const std::string& args) {
+  static Result run(const std::string &args) {
     Result result;
 
     // Build command - vroom binary is in the build directory
@@ -40,7 +40,8 @@ class CliRunner {
 
     // Open pipe to command
     std::array<char, 4096> buffer;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"),
+                                                  pclose);
 
     if (!pipe) {
       result.exit_code = -1;
@@ -58,7 +59,7 @@ class CliRunner {
     if (WIFEXITED(status)) {
       result.exit_code = WEXITSTATUS(status);
     } else if (WIFSIGNALED(status)) {
-      result.exit_code = 128 + WTERMSIG(status);  // Common convention
+      result.exit_code = 128 + WTERMSIG(status); // Common convention
     } else {
       result.exit_code = -1;
     }
@@ -68,12 +69,14 @@ class CliRunner {
 
   // Run with stdin from a file via redirection
   // Note: file_path is expected to be a trusted path from test fixtures
-  static Result runWithFileStdin(const std::string& args, const std::string& file_path) {
+  static Result runWithFileStdin(const std::string &args,
+                                 const std::string &file_path) {
     Result result;
     std::string cmd = "./vroom " + args + " < " + file_path + " 2>&1";
 
     std::array<char, 4096> buffer;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"),
+                                                  pclose);
 
     if (!pipe) {
       result.exit_code = -1;
@@ -100,8 +103,8 @@ class CliRunner {
 };
 
 class CliTest : public ::testing::Test {
- protected:
-  static std::string testDataPath(const std::string& relative_path) {
+protected:
+  static std::string testDataPath(const std::string &relative_path) {
     return "test/data/" + relative_path;
   }
 };
@@ -166,7 +169,8 @@ TEST_F(CliTest, CountNoHeader) {
 }
 
 TEST_F(CliTest, CountEmptyFile) {
-  auto result = CliRunner::run("count " + testDataPath("edge_cases/empty_file.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("0") != std::string::npos);
 }
@@ -178,13 +182,15 @@ TEST_F(CliTest, CountManyRows) {
 }
 
 TEST_F(CliTest, CountWithThreads) {
-  auto result = CliRunner::run("count -t 2 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("count -t 2 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, CountQuotedFields) {
-  auto result = CliRunner::run("count " + testDataPath("quoted/escaped_quotes.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("quoted/escaped_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // escaped_quotes.csv has header + 5 data rows
   EXPECT_TRUE(result.output.find("5") != std::string::npos);
@@ -220,12 +226,14 @@ TEST_F(CliTest, HeadZeroRows) {
 }
 
 TEST_F(CliTest, HeadEmptyFile) {
-  auto result = CliRunner::run("head " + testDataPath("edge_cases/empty_file.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, HeadQuotedNewlines) {
-  auto result = CliRunner::run("head " + testDataPath("quoted/newlines_in_quotes.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("quoted/newlines_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -234,7 +242,8 @@ TEST_F(CliTest, HeadQuotedNewlines) {
 // =============================================================================
 
 TEST_F(CliTest, SelectByIndex) {
-  auto result = CliRunner::run("select -c 0 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -c 0 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A") != std::string::npos);
   EXPECT_TRUE(result.output.find("1") != std::string::npos);
@@ -243,14 +252,16 @@ TEST_F(CliTest, SelectByIndex) {
 }
 
 TEST_F(CliTest, SelectByName) {
-  auto result = CliRunner::run("select -c B " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -c B " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("B") != std::string::npos);
   EXPECT_TRUE(result.output.find("2") != std::string::npos);
 }
 
 TEST_F(CliTest, SelectMultipleColumns) {
-  auto result = CliRunner::run("select -c 0,2 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -c 0,2 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A") != std::string::npos);
   EXPECT_TRUE(result.output.find("C") != std::string::npos);
@@ -259,13 +270,15 @@ TEST_F(CliTest, SelectMultipleColumns) {
 }
 
 TEST_F(CliTest, SelectInvalidColumnIndex) {
-  auto result = CliRunner::run("select -c 99 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -c 99 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
   EXPECT_TRUE(result.output.find("out of range") != std::string::npos);
 }
 
 TEST_F(CliTest, SelectInvalidColumnName) {
-  auto result = CliRunner::run("select -c nonexistent " + testDataPath("basic/simple.csv"));
+  auto result = CliRunner::run("select -c nonexistent " +
+                               testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
   EXPECT_TRUE(result.output.find("not found") != std::string::npos);
 }
@@ -277,9 +290,11 @@ TEST_F(CliTest, SelectMissingColumnArg) {
 }
 
 TEST_F(CliTest, SelectNoHeaderWithColumnName) {
-  auto result = CliRunner::run("select -H -c name " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -H -c name " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
-  EXPECT_TRUE(result.output.find("Cannot use column names") != std::string::npos);
+  EXPECT_TRUE(result.output.find("Cannot use column names") !=
+              std::string::npos);
 }
 
 // =============================================================================
@@ -293,7 +308,7 @@ TEST_F(CliTest, InfoBasicFile) {
   EXPECT_TRUE(result.output.find("Size:") != std::string::npos);
   EXPECT_TRUE(result.output.find("Rows:") != std::string::npos);
   EXPECT_TRUE(result.output.find("Columns:") != std::string::npos);
-  EXPECT_TRUE(result.output.find("3") != std::string::npos);  // columns
+  EXPECT_TRUE(result.output.find("3") != std::string::npos); // columns
 }
 
 TEST_F(CliTest, InfoShowsColumnNames) {
@@ -313,7 +328,8 @@ TEST_F(CliTest, InfoNoHeader) {
 }
 
 TEST_F(CliTest, InfoEmptyFile) {
-  auto result = CliRunner::run("info " + testDataPath("edge_cases/empty_file.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("Size: 0 bytes") != std::string::npos);
 }
@@ -332,7 +348,8 @@ TEST_F(CliTest, PrettyBasicFile) {
 }
 
 TEST_F(CliTest, PrettyWithNumRows) {
-  auto result = CliRunner::run("pretty -n 1 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("pretty -n 1 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have table format
   EXPECT_TRUE(result.output.find("+") != std::string::npos);
@@ -341,7 +358,8 @@ TEST_F(CliTest, PrettyWithNumRows) {
 }
 
 TEST_F(CliTest, PrettyEmptyFile) {
-  auto result = CliRunner::run("pretty " + testDataPath("edge_cases/empty_file.csv"));
+  auto result =
+      CliRunner::run("pretty " + testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -350,31 +368,36 @@ TEST_F(CliTest, PrettyEmptyFile) {
 // =============================================================================
 
 TEST_F(CliTest, TabDelimiter) {
-  auto result = CliRunner::run("count -d tab " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("count -d tab " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, SemicolonDelimiter) {
-  auto result = CliRunner::run("count -d semicolon " + testDataPath("separators/semicolon.csv"));
+  auto result = CliRunner::run("count -d semicolon " +
+                               testDataPath("separators/semicolon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, PipeDelimiter) {
-  auto result = CliRunner::run("count -d pipe " + testDataPath("separators/pipe.csv"));
+  auto result =
+      CliRunner::run("count -d pipe " + testDataPath("separators/pipe.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, SingleCharDelimiter) {
-  auto result = CliRunner::run("count -d , " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("count -d , " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, HeadWithTabDelimiter) {
-  auto result = CliRunner::run("head -d tab " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("head -d tab " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Output should use tab delimiter
   EXPECT_TRUE(result.output.find("\t") != std::string::npos);
@@ -383,7 +406,8 @@ TEST_F(CliTest, HeadWithTabDelimiter) {
 TEST_F(CliTest, AutoDetectDialect) {
   // Auto-detect is now enabled by default, so we just run head without -d flag
   // and verify it correctly parses the semicolon-separated file
-  auto result = CliRunner::run("head " + testDataPath("separators/semicolon.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("separators/semicolon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should auto-detect semicolon delimiter and output using semicolons
   EXPECT_TRUE(result.output.find(";") != std::string::npos);
@@ -391,7 +415,8 @@ TEST_F(CliTest, AutoDetectDialect) {
 
 TEST_F(CliTest, DialectCommandText) {
   // Test the dialect command with human-readable output
-  auto result = CliRunner::run("dialect " + testDataPath("separators/semicolon.csv"));
+  auto result =
+      CliRunner::run("dialect " + testDataPath("separators/semicolon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("semicolon") != std::string::npos);
   EXPECT_TRUE(result.output.find("CLI flags:") != std::string::npos);
@@ -399,16 +424,19 @@ TEST_F(CliTest, DialectCommandText) {
 
 TEST_F(CliTest, DialectCommandJson) {
   // Test the dialect command with JSON output
-  auto result = CliRunner::run("dialect -j " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("dialect -j " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
-  EXPECT_TRUE(result.output.find("\"delimiter\": \"\\t\"") != std::string::npos);
+  EXPECT_TRUE(result.output.find("\"delimiter\": \"\\t\"") !=
+              std::string::npos);
   EXPECT_TRUE(result.output.find("\"confidence\":") != std::string::npos);
 }
 
 TEST_F(CliTest, AutoDetectDisabledWithExplicitDelimiter) {
   // When -d is specified, auto-detect should be disabled
   // Even for a semicolon file, if we specify comma, it should use comma
-  auto result = CliRunner::run("head -d comma " + testDataPath("separators/semicolon.csv"));
+  auto result = CliRunner::run("head -d comma " +
+                               testDataPath("separators/semicolon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Output should NOT have semicolon as delimiter (would be comma)
   // The file has "A;B;C" as content - if we parse as comma-separated,
@@ -427,33 +455,40 @@ TEST_F(CliTest, NonexistentFile) {
 }
 
 TEST_F(CliTest, InvalidThreadCount) {
-  auto result = CliRunner::run("count -t 0 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("count -t 0 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
   EXPECT_TRUE(result.output.find("Thread count") != std::string::npos);
 }
 
 TEST_F(CliTest, InvalidThreadCountTooHigh) {
-  auto result = CliRunner::run("count -t 300 " + testDataPath("basic/simple.csv"));
+  // 1025 exceeds new MAX_THREADS of 1024
+  auto result =
+      CliRunner::run("count -t 1025 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
   EXPECT_TRUE(result.output.find("Thread count") != std::string::npos);
 }
 
 TEST_F(CliTest, InvalidRowCount) {
-  auto result = CliRunner::run("head -n abc " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("head -n abc " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
   EXPECT_TRUE(result.output.find("Invalid row count") != std::string::npos);
 }
 
 TEST_F(CliTest, NegativeRowCount) {
-  auto result = CliRunner::run("head -n -5 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("head -n -5 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
 }
 
 TEST_F(CliTest, InvalidQuoteChar) {
-  auto result = CliRunner::run("count -q abc " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("count -q abc " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
-  EXPECT_TRUE(result.output.find("Quote character must be a single character") !=
-              std::string::npos);
+  EXPECT_TRUE(
+      result.output.find("Quote character must be a single character") !=
+      std::string::npos);
 }
 
 // =============================================================================
@@ -461,25 +496,29 @@ TEST_F(CliTest, InvalidQuoteChar) {
 // =============================================================================
 
 TEST_F(CliTest, CountFromStdin) {
-  auto result = CliRunner::runWithFileStdin("count -", testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::runWithFileStdin("count -", testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, CountFromStdinNoExplicitDash) {
-  auto result = CliRunner::runWithFileStdin("count", testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::runWithFileStdin("count", testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, HeadFromStdin) {
-  auto result = CliRunner::runWithFileStdin("head -n 2 -", testDataPath("basic/simple.csv"));
+  auto result = CliRunner::runWithFileStdin("head -n 2 -",
+                                            testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
 }
 
 TEST_F(CliTest, InfoFromStdin) {
-  auto result = CliRunner::runWithFileStdin("info -", testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::runWithFileStdin("info -", testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("<stdin>") != std::string::npos);
 }
@@ -489,27 +528,32 @@ TEST_F(CliTest, InfoFromStdin) {
 // =============================================================================
 
 TEST_F(CliTest, SingleColumn) {
-  auto result = CliRunner::run("count " + testDataPath("basic/single_column.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("basic/single_column.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, WideColumns) {
-  auto result = CliRunner::run("info " + testDataPath("basic/wide_columns.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("basic/wide_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, EmptyFields) {
-  auto result = CliRunner::run("count " + testDataPath("edge_cases/empty_fields.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("edge_cases/empty_fields.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, WhitespaceFields) {
-  auto result = CliRunner::run("count " + testDataPath("edge_cases/whitespace_fields.csv"));
+  auto result = CliRunner::run(
+      "count " + testDataPath("edge_cases/whitespace_fields.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, CrlfLineEndings) {
-  auto result = CliRunner::run("count " + testDataPath("line_endings/crlf.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("line_endings/crlf.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -519,22 +563,26 @@ TEST_F(CliTest, CrLineEndings) {
 }
 
 TEST_F(CliTest, NoFinalNewline) {
-  auto result = CliRunner::run("count " + testDataPath("line_endings/no_final_newline.csv"));
+  auto result = CliRunner::run(
+      "count " + testDataPath("line_endings/no_final_newline.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, QuotedFieldsWithNewlines) {
-  auto result = CliRunner::run("count " + testDataPath("quoted/newlines_in_quotes.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("quoted/newlines_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, EscapedQuotes) {
-  auto result = CliRunner::run("head " + testDataPath("quoted/escaped_quotes.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("quoted/escaped_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SingleRowHeaderOnly) {
-  auto result = CliRunner::run("count " + testDataPath("edge_cases/single_row_header_only.csv"));
+  auto result = CliRunner::run(
+      "count " + testDataPath("edge_cases/single_row_header_only.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("0") != std::string::npos);
 }
@@ -560,14 +608,15 @@ TEST_F(CliTest, VersionAfterCommand) {
 // =============================================================================
 
 TEST_F(CliTest, HeadWithMultipleOptions) {
-  auto result =
-      CliRunner::run("head -n 2 -t 2 -d comma " + testDataPath("basic/simple.csv"));
+  auto result = CliRunner::run("head -n 2 -t 2 -d comma " +
+                               testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
 }
 
 TEST_F(CliTest, SelectWithMultipleColumns) {
-  auto result = CliRunner::run("select -c A,C " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -c A,C " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A") != std::string::npos);
   EXPECT_TRUE(result.output.find("C") != std::string::npos);
@@ -575,7 +624,8 @@ TEST_F(CliTest, SelectWithMultipleColumns) {
 
 TEST_F(CliTest, InfoWithAutoDetect) {
   // Auto-detect is now enabled by default
-  auto result = CliRunner::run("info " + testDataPath("separators/semicolon.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("separators/semicolon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should show dialect info with detected semicolon
   EXPECT_TRUE(result.output.find("Dialect:") != std::string::npos);
@@ -587,16 +637,18 @@ TEST_F(CliTest, InfoWithAutoDetect) {
 
 TEST_F(CliTest, MalformedUnclosedQuote) {
   // File has an unclosed quote in the middle - parser should handle gracefully
-  auto result = CliRunner::run("count " + testDataPath("malformed/unclosed_quote.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("malformed/unclosed_quote.csv"));
   EXPECT_EQ(result.exit_code, 0);
-  // Parser processes what it can - row count may vary based on quote interpretation
-  // but should return some reasonable value (not crash or hang)
+  // Parser processes what it can - row count may vary based on quote
+  // interpretation but should return some reasonable value (not crash or hang)
   EXPECT_FALSE(result.output.empty());
 }
 
 TEST_F(CliTest, MalformedUnclosedQuoteEof) {
   // Quote never closes until end of file
-  auto result = CliRunner::run("head " + testDataPath("malformed/unclosed_quote_eof.csv"));
+  auto result = CliRunner::run(
+      "head " + testDataPath("malformed/unclosed_quote_eof.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should output what it can parse
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
@@ -604,14 +656,16 @@ TEST_F(CliTest, MalformedUnclosedQuoteEof) {
 
 TEST_F(CliTest, MalformedUnescapedQuoteInQuoted) {
   // Has unescaped quote inside quoted field: "has " unescaped quote"
-  auto result = CliRunner::run("count " + testDataPath("malformed/unescaped_quote_in_quoted.csv"));
+  auto result = CliRunner::run(
+      "count " + testDataPath("malformed/unescaped_quote_in_quoted.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Parser handles this - may interpret differently than expected
 }
 
 TEST_F(CliTest, MalformedQuoteNotAtStart) {
   // Quote appears mid-field: x"quoted"
-  auto result = CliRunner::run("head " + testDataPath("malformed/quote_not_at_start.csv"));
+  auto result = CliRunner::run(
+      "head " + testDataPath("malformed/quote_not_at_start.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Parser should process the file
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
@@ -619,7 +673,8 @@ TEST_F(CliTest, MalformedQuoteNotAtStart) {
 
 TEST_F(CliTest, MalformedTripleQuote) {
   // Contains triple quotes which is ambiguous
-  auto result = CliRunner::run("count " + testDataPath("malformed/triple_quote.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("malformed/triple_quote.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should process the file and return a count
   EXPECT_FALSE(result.output.empty());
@@ -627,7 +682,8 @@ TEST_F(CliTest, MalformedTripleQuote) {
 
 TEST_F(CliTest, MalformedNullByte) {
   // Contains a null byte in data
-  auto result = CliRunner::run("count " + testDataPath("malformed/null_byte.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("malformed/null_byte.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should count rows despite null byte
   EXPECT_TRUE(result.output.find("2") != std::string::npos);
@@ -635,17 +691,19 @@ TEST_F(CliTest, MalformedNullByte) {
 
 TEST_F(CliTest, MalformedInconsistentColumns) {
   // Rows have different numbers of columns
-  auto result = CliRunner::run("info " + testDataPath("malformed/inconsistent_columns.csv"));
+  auto result = CliRunner::run(
+      "info " + testDataPath("malformed/inconsistent_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Info command should still work
   EXPECT_TRUE(result.output.find("Columns:") != std::string::npos);
 }
 
 TEST_F(CliTest, MalformedVariableColumns) {
-  // Regression test for GitHub issue #263: SIGABRT crash on variable column count
-  // File has ~30 rows with column counts varying from 20-26
-  // This previously caused an assertion failure with SIGABRT
-  auto result = CliRunner::run("head -n 5 " + testDataPath("malformed/variable_columns.csv"));
+  // Regression test for GitHub issue #263: SIGABRT crash on variable column
+  // count File has ~30 rows with column counts varying from 20-26 This
+  // previously caused an assertion failure with SIGABRT
+  auto result = CliRunner::run("head -n 5 " +
+                               testDataPath("malformed/variable_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should handle variable column counts gracefully without crashing
   EXPECT_FALSE(result.output.empty());
@@ -653,20 +711,23 @@ TEST_F(CliTest, MalformedVariableColumns) {
 
 TEST_F(CliTest, MalformedVariableColumnsExplicitDelimiter) {
   // Test with explicit delimiter (disables auto-detection)
-  auto result = CliRunner::run("head -d comma -n 5 " + testDataPath("malformed/variable_columns.csv"));
+  auto result = CliRunner::run("head -d comma -n 5 " +
+                               testDataPath("malformed/variable_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_FALSE(result.output.empty());
 }
 
 TEST_F(CliTest, MalformedEmptyHeader) {
   // Header row has empty column names
-  auto result = CliRunner::run("head " + testDataPath("malformed/empty_header.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("malformed/empty_header.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, MalformedDuplicateColumnNames) {
   // Header has duplicate column names
-  auto result = CliRunner::run("info " + testDataPath("malformed/duplicate_column_names.csv"));
+  auto result = CliRunner::run(
+      "info " + testDataPath("malformed/duplicate_column_names.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Info command should work
   EXPECT_TRUE(result.output.find("Column names:") != std::string::npos);
@@ -674,7 +735,8 @@ TEST_F(CliTest, MalformedDuplicateColumnNames) {
 
 TEST_F(CliTest, MalformedMixedLineEndings) {
   // File has mix of CRLF, LF, and CR line endings
-  auto result = CliRunner::run("count " + testDataPath("malformed/mixed_line_endings.csv"));
+  auto result = CliRunner::run(
+      "count " + testDataPath("malformed/mixed_line_endings.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should process the file and return a count
   EXPECT_FALSE(result.output.empty());
@@ -682,7 +744,8 @@ TEST_F(CliTest, MalformedMixedLineEndings) {
 
 TEST_F(CliTest, MalformedTrailingQuote) {
   // Field ends with quote in unexpected position
-  auto result = CliRunner::run("head " + testDataPath("malformed/trailing_quote.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("malformed/trailing_quote.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should produce some output
   EXPECT_FALSE(result.output.empty());
@@ -690,7 +753,8 @@ TEST_F(CliTest, MalformedTrailingQuote) {
 
 TEST_F(CliTest, MalformedMultipleErrors) {
   // File with multiple types of malformed content
-  auto result = CliRunner::run("count " + testDataPath("malformed/multiple_errors.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("malformed/multiple_errors.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should process the file and return a count
   EXPECT_FALSE(result.output.empty());
@@ -698,7 +762,8 @@ TEST_F(CliTest, MalformedMultipleErrors) {
 
 TEST_F(CliTest, MalformedSelectFromBadFile) {
   // Try selecting columns from malformed file
-  auto result = CliRunner::run("select -c 0 " + testDataPath("malformed/unclosed_quote.csv"));
+  auto result = CliRunner::run("select -c 0 " +
+                               testDataPath("malformed/unclosed_quote.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should output first column from parseable rows
   EXPECT_TRUE(result.output.find("A") != std::string::npos);
@@ -706,7 +771,8 @@ TEST_F(CliTest, MalformedSelectFromBadFile) {
 
 TEST_F(CliTest, MalformedPrettyFromBadFile) {
   // Pretty print of malformed file
-  auto result = CliRunner::run("pretty -n 5 " + testDataPath("malformed/inconsistent_columns.csv"));
+  auto result = CliRunner::run(
+      "pretty -n 5 " + testDataPath("malformed/inconsistent_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should still produce table output
   EXPECT_TRUE(result.output.find("+") != std::string::npos);
@@ -718,15 +784,18 @@ TEST_F(CliTest, MalformedPrettyFromBadFile) {
 
 TEST_F(CliTest, LargeFileParallelCount) {
   // Test parallel counting on a multi-MB file
-  auto result = CliRunner::run("count -t 4 " + testDataPath("large/parallel_chunk_boundary.csv"));
+  auto result = CliRunner::run(
+      "count -t 4 " + testDataPath("large/parallel_chunk_boundary.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should return a valid count without error
 }
 
 TEST_F(CliTest, LargeFileParallelCountVerify) {
   // Verify parallel counting produces same result as single-threaded
-  auto single = CliRunner::run("count -t 1 " + testDataPath("large/parallel_chunk_boundary.csv"));
-  auto parallel = CliRunner::run("count -t 4 " + testDataPath("large/parallel_chunk_boundary.csv"));
+  auto single = CliRunner::run(
+      "count -t 1 " + testDataPath("large/parallel_chunk_boundary.csv"));
+  auto parallel = CliRunner::run(
+      "count -t 4 " + testDataPath("large/parallel_chunk_boundary.csv"));
   EXPECT_EQ(single.exit_code, 0);
   EXPECT_EQ(parallel.exit_code, 0);
   // Both should produce the same count
@@ -735,32 +804,37 @@ TEST_F(CliTest, LargeFileParallelCountVerify) {
 
 TEST_F(CliTest, LargeFileParallelMaxThreads) {
   // Test with higher thread count
-  auto result = CliRunner::run("count -t 8 " + testDataPath("large/parallel_chunk_boundary.csv"));
+  auto result = CliRunner::run(
+      "count -t 8 " + testDataPath("large/parallel_chunk_boundary.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, LargeFileHead) {
   // Head command on large file should be fast (only reads what's needed)
-  auto result = CliRunner::run("head -n 5 " + testDataPath("large/parallel_chunk_boundary.csv"));
+  auto result = CliRunner::run(
+      "head -n 5 " + testDataPath("large/parallel_chunk_boundary.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should output header + 5 data rows
 }
 
 TEST_F(CliTest, LargeFieldFile) {
   // File with a very large field (70KB)
-  auto result = CliRunner::run("count " + testDataPath("large/large_field.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("large/large_field.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, LongLineFile) {
   // File with very long lines
-  auto result = CliRunner::run("head -n 2 " + testDataPath("large/long_line.csv"));
+  auto result =
+      CliRunner::run("head -n 2 " + testDataPath("large/long_line.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, BufferBoundaryFile) {
   // File designed to test SIMD buffer boundaries (200 rows)
-  auto result = CliRunner::run("count -t 2 " + testDataPath("large/buffer_boundary.csv"));
+  auto result =
+      CliRunner::run("count -t 2 " + testDataPath("large/buffer_boundary.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should count all 200 rows
   EXPECT_TRUE(result.output.find("200") != std::string::npos);
@@ -773,7 +847,8 @@ TEST_F(CliTest, BufferBoundaryFile) {
 TEST_F(CliTest, ExplicitDelimiterDisablesAutoDetect) {
   // When -d (explicit delimiter) is used, auto-detect should be disabled
   // For a comma file with -d semicolon, it should treat each line as one field
-  auto result = CliRunner::run("head -d semicolon " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("head -d semicolon " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should NOT show auto-detect message since -d was specified
   EXPECT_TRUE(result.output.find("Auto-detected") == std::string::npos);
@@ -781,7 +856,8 @@ TEST_F(CliTest, ExplicitDelimiterDisablesAutoDetect) {
 
 TEST_F(CliTest, AutoDetectByDefault) {
   // Verify auto-detect works by default without -a flag
-  auto result = CliRunner::run("info " + testDataPath("separators/semicolon.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("separators/semicolon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should auto-detect semicolon
   EXPECT_TRUE(result.output.find("';'") != std::string::npos);
@@ -789,26 +865,31 @@ TEST_F(CliTest, AutoDetectByDefault) {
 
 TEST_F(CliTest, NoHeaderWithColumnNameSelect) {
   // Already tested, but included here for completeness of option combinations
-  auto result = CliRunner::run("select -H -c name " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -H -c name " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
-  EXPECT_TRUE(result.output.find("Cannot use column names") != std::string::npos);
+  EXPECT_TRUE(result.output.find("Cannot use column names") !=
+              std::string::npos);
 }
 
 TEST_F(CliTest, ExcessiveThreadsInvalid) {
-  // More than 255 threads is invalid (limited by uint8_t in index struct)
-  auto result = CliRunner::run("count -t 300 " + testDataPath("basic/simple.csv"));
+  // More than 1024 threads is invalid (limited by MAX_THREADS)
+  auto result =
+      CliRunner::run("count -t 2000 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
 }
 
 TEST_F(CliTest, NegativeThreadCount) {
   // Negative thread count
-  auto result = CliRunner::run("count -t -5 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("count -t -5 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
 }
 
 TEST_F(CliTest, HeadWithZeroAndFile) {
   // head -n 0 should show nothing (or just header depending on implementation)
-  auto result = CliRunner::run("head -n 0 -H " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("head -n 0 -H " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -822,7 +903,8 @@ TEST_F(CliTest, SelectMissingFile) {
 
 TEST_F(CliTest, MultipleDelimiterSpecs) {
   // Multiple -d flags - last one should win
-  auto result = CliRunner::run("count -d tab -d comma " + testDataPath("basic/simple.csv"));
+  auto result = CliRunner::run("count -d tab -d comma " +
+                               testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should use comma (the last specified)
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
@@ -834,7 +916,8 @@ TEST_F(CliTest, MultipleDelimiterSpecs) {
 
 TEST_F(CliTest, Utf8BomFile) {
   // File with UTF-8 BOM
-  auto result = CliRunner::run("count " + testDataPath("encoding/utf8_bom.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("encoding/utf8_bom.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -883,7 +966,8 @@ TEST_F(CliTest, TailWithNumRowsOne) {
 
 TEST_F(CliTest, TailMoreRowsThanExist) {
   // Request more rows than exist - should return all data rows
-  auto result = CliRunner::run("tail -n 100 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("tail -n 100 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
   EXPECT_TRUE(result.output.find("1,2,3") != std::string::npos);
@@ -899,25 +983,30 @@ TEST_F(CliTest, TailZeroRows) {
 }
 
 TEST_F(CliTest, TailEmptyFile) {
-  auto result = CliRunner::run("tail " + testDataPath("edge_cases/empty_file.csv"));
+  auto result =
+      CliRunner::run("tail " + testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, TailNoHeader) {
-  auto result = CliRunner::run("tail -n 2 -H " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("tail -n 2 -H " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should output last 2 rows without treating first as header
   // So we get rows "4,5,6" and "7,8,9" (last 2 of 4 total rows)
   EXPECT_TRUE(result.output.find("4,5,6") != std::string::npos);
   EXPECT_TRUE(result.output.find("7,8,9") != std::string::npos);
-  // Header "A,B,C" should NOT be in output since we're not treating it as header
+  // Header "A,B,C" should NOT be in output since we're not treating it as
+  // header
   EXPECT_TRUE(result.output.find("A,B,C") == std::string::npos);
 }
 
 TEST_F(CliTest, TailManyRows) {
   // Test with file that has 20 data rows
-  // Uses default multi-threaded parsing (PR #303 fixed SIMD delimiter masking on macOS)
-  auto result = CliRunner::run("tail -n 5 " + testDataPath("basic/many_rows.csv"));
+  // Uses default multi-threaded parsing (PR #303 fixed SIMD delimiter masking
+  // on macOS)
+  auto result =
+      CliRunner::run("tail -n 5 " + testDataPath("basic/many_rows.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have header
   EXPECT_TRUE(result.output.find("ID,Value,Label") != std::string::npos);
@@ -929,14 +1018,16 @@ TEST_F(CliTest, TailManyRows) {
 }
 
 TEST_F(CliTest, TailFromStdin) {
-  auto result = CliRunner::runWithFileStdin("tail -n 2 -", testDataPath("basic/simple.csv"));
+  auto result = CliRunner::runWithFileStdin("tail -n 2 -",
+                                            testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
   EXPECT_TRUE(result.output.find("7,8,9") != std::string::npos);
 }
 
 TEST_F(CliTest, TailWithTabDelimiter) {
-  auto result = CliRunner::run("tail -d tab " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("tail -d tab " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("\t") != std::string::npos);
 }
@@ -953,7 +1044,8 @@ TEST_F(CliTest, SampleDefault) {
 }
 
 TEST_F(CliTest, SampleWithNumRows) {
-  auto result = CliRunner::run("sample -n 2 -s 42 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("sample -n 2 -s 42 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should output header + 2 data rows
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
@@ -961,15 +1053,19 @@ TEST_F(CliTest, SampleWithNumRows) {
   // simple.csv has rows: 1,2,3 and 4,5,6 and 7,8,9
   // With seed 42, sample should select specific rows from the 3 available
   int data_rows = 0;
-  if (result.output.find("1,2,3") != std::string::npos) data_rows++;
-  if (result.output.find("4,5,6") != std::string::npos) data_rows++;
-  if (result.output.find("7,8,9") != std::string::npos) data_rows++;
-  EXPECT_EQ(data_rows, 2);  // We requested 2 rows
+  if (result.output.find("1,2,3") != std::string::npos)
+    data_rows++;
+  if (result.output.find("4,5,6") != std::string::npos)
+    data_rows++;
+  if (result.output.find("7,8,9") != std::string::npos)
+    data_rows++;
+  EXPECT_EQ(data_rows, 2); // We requested 2 rows
 }
 
 TEST_F(CliTest, SampleMoreRowsThanExist) {
   // Request more samples than exist - should return all data rows
-  auto result = CliRunner::run("sample -n 100 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("sample -n 100 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
   EXPECT_TRUE(result.output.find("1,2,3") != std::string::npos);
@@ -978,7 +1074,8 @@ TEST_F(CliTest, SampleMoreRowsThanExist) {
 }
 
 TEST_F(CliTest, SampleZeroRows) {
-  auto result = CliRunner::run("sample -n 0 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("sample -n 0 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should output only the header
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
@@ -989,23 +1086,29 @@ TEST_F(CliTest, SampleZeroRows) {
 }
 
 TEST_F(CliTest, SampleEmptyFile) {
-  auto result = CliRunner::run("sample " + testDataPath("edge_cases/empty_file.csv"));
+  auto result =
+      CliRunner::run("sample " + testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SampleReproducibleWithSeed) {
   // Same seed should produce same sample
-  auto result1 = CliRunner::run("sample -n 5 -s 42 " + testDataPath("basic/many_rows.csv"));
-  auto result2 = CliRunner::run("sample -n 5 -s 42 " + testDataPath("basic/many_rows.csv"));
+  auto result1 = CliRunner::run("sample -n 5 -s 42 " +
+                                testDataPath("basic/many_rows.csv"));
+  auto result2 = CliRunner::run("sample -n 5 -s 42 " +
+                                testDataPath("basic/many_rows.csv"));
   EXPECT_EQ(result1.exit_code, 0);
   EXPECT_EQ(result2.exit_code, 0);
   EXPECT_EQ(result1.output, result2.output);
 }
 
 TEST_F(CliTest, SampleDifferentSeeds) {
-  // Different seeds should likely produce different samples (not guaranteed but highly probable)
-  auto result1 = CliRunner::run("sample -n 5 -s 1 " + testDataPath("basic/many_rows.csv"));
-  auto result2 = CliRunner::run("sample -n 5 -s 999 " + testDataPath("basic/many_rows.csv"));
+  // Different seeds should likely produce different samples (not guaranteed but
+  // highly probable)
+  auto result1 =
+      CliRunner::run("sample -n 5 -s 1 " + testDataPath("basic/many_rows.csv"));
+  auto result2 = CliRunner::run("sample -n 5 -s 999 " +
+                                testDataPath("basic/many_rows.csv"));
   EXPECT_EQ(result1.exit_code, 0);
   EXPECT_EQ(result2.exit_code, 0);
   // Both should have header
@@ -1014,23 +1117,30 @@ TEST_F(CliTest, SampleDifferentSeeds) {
 }
 
 TEST_F(CliTest, SampleNoHeader) {
-  auto result = CliRunner::run("sample -n 2 -H -s 42 " + testDataPath("basic/simple.csv"));
+  auto result = CliRunner::run("sample -n 2 -H -s 42 " +
+                               testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should output 2 rows without header treatment
   // With -H, all 4 rows (including "A,B,C") are treated as data
   // Verify we got exactly 2 data rows
   int data_rows = 0;
-  if (result.output.find("A,B,C") != std::string::npos) data_rows++;
-  if (result.output.find("1,2,3") != std::string::npos) data_rows++;
-  if (result.output.find("4,5,6") != std::string::npos) data_rows++;
-  if (result.output.find("7,8,9") != std::string::npos) data_rows++;
+  if (result.output.find("A,B,C") != std::string::npos)
+    data_rows++;
+  if (result.output.find("1,2,3") != std::string::npos)
+    data_rows++;
+  if (result.output.find("4,5,6") != std::string::npos)
+    data_rows++;
+  if (result.output.find("7,8,9") != std::string::npos)
+    data_rows++;
   EXPECT_EQ(data_rows, 2);
 }
 
 TEST_F(CliTest, SampleManyRows) {
   // Sample from file with 20 data rows
-  // Uses default multi-threaded parsing (PR #303 fixed SIMD delimiter masking on macOS)
-  auto result = CliRunner::run("sample -n 5 -s 42 " + testDataPath("basic/many_rows.csv"));
+  // Uses default multi-threaded parsing (PR #303 fixed SIMD delimiter masking
+  // on macOS)
+  auto result = CliRunner::run("sample -n 5 -s 42 " +
+                               testDataPath("basic/many_rows.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have header
   EXPECT_TRUE(result.output.find("ID,Value,Label") != std::string::npos);
@@ -1038,56 +1148,81 @@ TEST_F(CliTest, SampleManyRows) {
   // Each data row has format like "1,100,A" or "20,2000,T"
   // Use patterns that are unique to each row to avoid false matches
   int data_rows = 0;
-  if (result.output.find("1,100,A") != std::string::npos) data_rows++;
-  if (result.output.find("2,200,B") != std::string::npos) data_rows++;
-  if (result.output.find("3,300,C") != std::string::npos) data_rows++;
-  if (result.output.find("4,400,D") != std::string::npos) data_rows++;
-  if (result.output.find("5,500,E") != std::string::npos) data_rows++;
-  if (result.output.find("6,600,F") != std::string::npos) data_rows++;
-  if (result.output.find("7,700,G") != std::string::npos) data_rows++;
-  if (result.output.find("8,800,H") != std::string::npos) data_rows++;
-  if (result.output.find("9,900,I") != std::string::npos) data_rows++;
-  if (result.output.find("10,1000,J") != std::string::npos) data_rows++;
-  if (result.output.find("11,1100,K") != std::string::npos) data_rows++;
-  if (result.output.find("12,1200,L") != std::string::npos) data_rows++;
-  if (result.output.find("13,1300,M") != std::string::npos) data_rows++;
-  if (result.output.find("14,1400,N") != std::string::npos) data_rows++;
-  if (result.output.find("15,1500,O") != std::string::npos) data_rows++;
-  if (result.output.find("16,1600,P") != std::string::npos) data_rows++;
-  if (result.output.find("17,1700,Q") != std::string::npos) data_rows++;
-  if (result.output.find("18,1800,R") != std::string::npos) data_rows++;
-  if (result.output.find("19,1900,S") != std::string::npos) data_rows++;
-  if (result.output.find("20,2000,T") != std::string::npos) data_rows++;
+  if (result.output.find("1,100,A") != std::string::npos)
+    data_rows++;
+  if (result.output.find("2,200,B") != std::string::npos)
+    data_rows++;
+  if (result.output.find("3,300,C") != std::string::npos)
+    data_rows++;
+  if (result.output.find("4,400,D") != std::string::npos)
+    data_rows++;
+  if (result.output.find("5,500,E") != std::string::npos)
+    data_rows++;
+  if (result.output.find("6,600,F") != std::string::npos)
+    data_rows++;
+  if (result.output.find("7,700,G") != std::string::npos)
+    data_rows++;
+  if (result.output.find("8,800,H") != std::string::npos)
+    data_rows++;
+  if (result.output.find("9,900,I") != std::string::npos)
+    data_rows++;
+  if (result.output.find("10,1000,J") != std::string::npos)
+    data_rows++;
+  if (result.output.find("11,1100,K") != std::string::npos)
+    data_rows++;
+  if (result.output.find("12,1200,L") != std::string::npos)
+    data_rows++;
+  if (result.output.find("13,1300,M") != std::string::npos)
+    data_rows++;
+  if (result.output.find("14,1400,N") != std::string::npos)
+    data_rows++;
+  if (result.output.find("15,1500,O") != std::string::npos)
+    data_rows++;
+  if (result.output.find("16,1600,P") != std::string::npos)
+    data_rows++;
+  if (result.output.find("17,1700,Q") != std::string::npos)
+    data_rows++;
+  if (result.output.find("18,1800,R") != std::string::npos)
+    data_rows++;
+  if (result.output.find("19,1900,S") != std::string::npos)
+    data_rows++;
+  if (result.output.find("20,2000,T") != std::string::npos)
+    data_rows++;
   // Debug output to help diagnose flaky test failures
   if (data_rows != 5) {
     std::cerr << "SampleManyRows DEBUG: exit_code=" << result.exit_code
               << " output_size=" << result.output.size()
               << " data_rows=" << data_rows << "\n";
-    std::cerr << "SampleManyRows DEBUG: full output:\n[[[" << result.output << "]]]\n";
+    std::cerr << "SampleManyRows DEBUG: full output:\n[[[" << result.output
+              << "]]]\n";
   }
-  EXPECT_EQ(data_rows, 5);  // We requested 5 rows
+  EXPECT_EQ(data_rows, 5); // We requested 5 rows
 }
 
 TEST_F(CliTest, SampleFromStdin) {
-  auto result = CliRunner::runWithFileStdin("sample -n 2 -s 42 -", testDataPath("basic/simple.csv"));
+  auto result = CliRunner::runWithFileStdin("sample -n 2 -s 42 -",
+                                            testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
 }
 
 TEST_F(CliTest, SampleWithTabDelimiter) {
-  auto result = CliRunner::run("sample -d tab " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("sample -d tab " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("\t") != std::string::npos);
 }
 
 TEST_F(CliTest, SampleInvalidSeed) {
-  auto result = CliRunner::run("sample -s abc " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("sample -s abc " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
   EXPECT_TRUE(result.output.find("Invalid seed") != std::string::npos);
 }
 
 TEST_F(CliTest, SampleNegativeSeed) {
-  auto result = CliRunner::run("sample -s -5 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("sample -s -5 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 1);
 }
 
@@ -1097,15 +1232,18 @@ TEST_F(CliTest, SampleNegativeSeed) {
 
 TEST_F(CliTest, DialectJsonEscapesTab) {
   // Tab delimiter should be escaped as \t in JSON output
-  auto result = CliRunner::run("dialect -j " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("dialect -j " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // JSON should contain properly escaped tab
-  EXPECT_TRUE(result.output.find("\"delimiter\": \"\\t\"") != std::string::npos);
+  EXPECT_TRUE(result.output.find("\"delimiter\": \"\\t\"") !=
+              std::string::npos);
 }
 
 TEST_F(CliTest, DialectJsonEscapesDoubleQuote) {
   // Double quote should be escaped as \" in JSON output
-  auto result = CliRunner::run("dialect -j " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("dialect -j " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Quote character should be escaped (double quote is the default)
   EXPECT_TRUE(result.output.find("\"quote\": \"\\\"\"") != std::string::npos);
@@ -1113,7 +1251,8 @@ TEST_F(CliTest, DialectJsonEscapesDoubleQuote) {
 
 TEST_F(CliTest, DialectJsonValidStructure) {
   // Verify JSON output is well-formed
-  auto result = CliRunner::run("dialect -j " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("dialect -j " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Check for required JSON fields
   EXPECT_TRUE(result.output.find("\"delimiter\":") != std::string::npos);
@@ -1133,7 +1272,8 @@ TEST_F(CliTest, DialectJsonValidStructure) {
 
 TEST_F(CliTest, HeadFieldsWithCR) {
   // Fields containing \r should be properly quoted in output
-  auto result = CliRunner::run("head " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // The header should be present
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
@@ -1143,7 +1283,8 @@ TEST_F(CliTest, HeadFieldsWithCR) {
 
 TEST_F(CliTest, TailFieldsWithCR) {
   // Tail command should properly handle fields containing \r
-  auto result = CliRunner::run("tail -n 2 " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result =
+      CliRunner::run("tail -n 2 " + testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have header
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
@@ -1154,7 +1295,8 @@ TEST_F(CliTest, TailFieldsWithCR) {
 
 TEST_F(CliTest, TailFieldsWithCRVerifyQuoting) {
   // Verify that \r inside fields causes proper quoting
-  auto result = CliRunner::run("tail -n 1 " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result =
+      CliRunner::run("tail -n 1 " + testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // The last row has a field with mixed \r and \r\n
   // The output should quote fields containing \r
@@ -1163,7 +1305,8 @@ TEST_F(CliTest, TailFieldsWithCRVerifyQuoting) {
 
 TEST_F(CliTest, SampleFieldsWithCR) {
   // Sample command should properly handle fields containing \r
-  auto result = CliRunner::run("sample -n 2 -s 42 " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result = CliRunner::run("sample -n 2 -s 42 " +
+                               testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have header
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
@@ -1173,8 +1316,10 @@ TEST_F(CliTest, SampleFieldsWithCR) {
 
 TEST_F(CliTest, SampleFieldsWithCRReproducible) {
   // Same seed should produce same sample for file with \r in fields
-  auto result1 = CliRunner::run("sample -n 2 -s 123 " + testDataPath("quoted/cr_in_quotes.csv"));
-  auto result2 = CliRunner::run("sample -n 2 -s 123 " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result1 = CliRunner::run("sample -n 2 -s 123 " +
+                                testDataPath("quoted/cr_in_quotes.csv"));
+  auto result2 = CliRunner::run("sample -n 2 -s 123 " +
+                                testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result1.exit_code, 0);
   EXPECT_EQ(result2.exit_code, 0);
   EXPECT_EQ(result1.output, result2.output);
@@ -1182,7 +1327,8 @@ TEST_F(CliTest, SampleFieldsWithCRReproducible) {
 
 TEST_F(CliTest, CountFieldsWithCR) {
   // Count should work correctly with \r in quoted fields
-  auto result = CliRunner::run("count " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // File has 3 data rows (after header)
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
@@ -1190,7 +1336,8 @@ TEST_F(CliTest, CountFieldsWithCR) {
 
 TEST_F(CliTest, InfoFieldsWithCR) {
   // Info should work correctly with \r in quoted fields
-  auto result = CliRunner::run("info " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("Columns: 3") != std::string::npos);
   EXPECT_TRUE(result.output.find("Rows: 3") != std::string::npos);
@@ -1198,7 +1345,8 @@ TEST_F(CliTest, InfoFieldsWithCR) {
 
 TEST_F(CliTest, SelectFieldsWithCR) {
   // Select should properly quote fields containing \r in output
-  auto result = CliRunner::run("select -c B " + testDataPath("quoted/cr_in_quotes.csv"));
+  auto result =
+      CliRunner::run("select -c B " + testDataPath("quoted/cr_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Column B contains fields with \r, so output should have quoted fields
   EXPECT_TRUE(result.output.find("\"") != std::string::npos);
@@ -1206,23 +1354,26 @@ TEST_F(CliTest, SelectFieldsWithCR) {
 
 TEST_F(CliTest, TailCRLineEndingsFile) {
   // Test tail on file that uses CR as line ending (not in quoted fields)
-  auto result = CliRunner::run("tail -n 1 " + testDataPath("line_endings/cr.csv"));
+  auto result =
+      CliRunner::run("tail -n 1 " + testDataPath("line_endings/cr.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Output should not be empty - CR line endings should be handled gracefully
-  // Note: CR line endings cause the entire file to appear as one line to the parser,
-  // so exact content verification is complex
+  // Note: CR line endings cause the entire file to appear as one line to the
+  // parser, so exact content verification is complex
 }
 
 TEST_F(CliTest, SampleCRLineEndingsFile) {
   // Test sample on file that uses CR as line ending
-  auto result = CliRunner::run("sample -n 1 -s 42 " + testDataPath("line_endings/cr.csv"));
+  auto result = CliRunner::run("sample -n 1 -s 42 " +
+                               testDataPath("line_endings/cr.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should complete successfully with CR line endings
 }
 
 TEST_F(CliTest, TailCRLFLineEndingsFile) {
   // Test tail on file that uses CRLF line endings
-  auto result = CliRunner::run("tail -n 1 " + testDataPath("line_endings/crlf.csv"));
+  auto result =
+      CliRunner::run("tail -n 1 " + testDataPath("line_endings/crlf.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // CRLF files should work correctly with tail
   // The output should contain data, though CRLF may be converted to LF
@@ -1230,21 +1381,24 @@ TEST_F(CliTest, TailCRLFLineEndingsFile) {
 
 TEST_F(CliTest, SampleCRLFLineEndingsFile) {
   // Test sample on file that uses CRLF line endings
-  auto result = CliRunner::run("sample -n 1 -s 42 " + testDataPath("line_endings/crlf.csv"));
+  auto result = CliRunner::run("sample -n 1 -s 42 " +
+                               testDataPath("line_endings/crlf.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // CRLF files should work correctly with sample
 }
 
 TEST_F(CliTest, TailMixedLineEndingsFile) {
   // Test tail on file with mixed line endings
-  auto result = CliRunner::run("tail -n 2 " + testDataPath("malformed/mixed_line_endings.csv"));
+  auto result = CliRunner::run(
+      "tail -n 2 " + testDataPath("malformed/mixed_line_endings.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should handle mixed line endings gracefully
 }
 
 TEST_F(CliTest, SampleMixedLineEndingsFile) {
   // Test sample on file with mixed line endings
-  auto result = CliRunner::run("sample -n 2 -s 42 " + testDataPath("malformed/mixed_line_endings.csv"));
+  auto result = CliRunner::run(
+      "sample -n 2 -s 42 " + testDataPath("malformed/mixed_line_endings.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should handle mixed line endings gracefully
 }
@@ -1255,14 +1409,16 @@ TEST_F(CliTest, SampleMixedLineEndingsFile) {
 
 TEST_F(CliTest, ColonDelimiter) {
   // Test colon delimiter (exercises formatDelimiter colon case)
-  auto result = CliRunner::run("count -d : " + testDataPath("separators/colon.csv"));
+  auto result =
+      CliRunner::run("count -d : " + testDataPath("separators/colon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, DialectColonDelimiter) {
   // Test dialect command with colon-delimited file
-  auto result = CliRunner::run("dialect " + testDataPath("separators/colon.csv"));
+  auto result =
+      CliRunner::run("dialect " + testDataPath("separators/colon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should detect colon as delimiter
   EXPECT_TRUE(result.output.find("colon") != std::string::npos);
@@ -1270,7 +1426,8 @@ TEST_F(CliTest, DialectColonDelimiter) {
 
 TEST_F(CliTest, UnknownDelimiterWarning) {
   // Test the warning path for unknown multi-char delimiter string
-  auto result = CliRunner::run("count -d unknown_delim " + testDataPath("basic/simple.csv"));
+  auto result = CliRunner::run("count -d unknown_delim " +
+                               testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should show warning and fall back to comma
   EXPECT_TRUE(result.output.find("Warning:") != std::string::npos);
@@ -1279,21 +1436,24 @@ TEST_F(CliTest, UnknownDelimiterWarning) {
 
 TEST_F(CliTest, TabDelimiterBackslashT) {
   // Test escaped tab format (\t) for delimiter
-  auto result = CliRunner::run("count -d \\\\t " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("count -d \\\\t " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, PipeDelimiterSymbol) {
   // Test pipe delimiter using | symbol directly
-  auto result = CliRunner::run("count -d '|' " + testDataPath("separators/pipe.csv"));
+  auto result =
+      CliRunner::run("count -d '|' " + testDataPath("separators/pipe.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, SemicolonDelimiterSymbol) {
   // Test semicolon delimiter using ; symbol directly
-  auto result = CliRunner::run("count -d ';' " + testDataPath("separators/semicolon.csv"));
+  auto result = CliRunner::run("count -d ';' " +
+                               testDataPath("separators/semicolon.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
@@ -1304,13 +1464,15 @@ TEST_F(CliTest, SemicolonDelimiterSymbol) {
 
 TEST_F(CliTest, SingleQuoteChar) {
   // Test single quote as quote character
-  auto result = CliRunner::run("count -q \"'\" " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("count -q \"'\" " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, CustomQuoteCharForSelect) {
   // Test custom quote character with select command
-  auto result = CliRunner::run("select -c 0 -q \"'\" " + testDataPath("basic/simple.csv"));
+  auto result = CliRunner::run("select -c 0 -q \"'\" " +
+                               testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1321,33 +1483,39 @@ TEST_F(CliTest, CustomQuoteCharForSelect) {
 TEST_F(CliTest, DialectJsonBackslashDelimiter) {
   // Test JSON output with backslash escaping for delimiter
   // The backslash escape in JSON output (line 914) is tested with tab
-  auto result = CliRunner::run("dialect -j " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("dialect -j " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
-  EXPECT_TRUE(result.output.find("\"delimiter\": \"\\t\"") != std::string::npos);
+  EXPECT_TRUE(result.output.find("\"delimiter\": \"\\t\"") !=
+              std::string::npos);
 }
 
 TEST_F(CliTest, DialectPipeDelimiter) {
-  auto result = CliRunner::run("dialect " + testDataPath("separators/pipe.csv"));
+  auto result =
+      CliRunner::run("dialect " + testDataPath("separators/pipe.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("pipe") != std::string::npos);
 }
 
 TEST_F(CliTest, DialectJsonPipeDelimiter) {
-  auto result = CliRunner::run("dialect -j " + testDataPath("separators/pipe.csv"));
+  auto result =
+      CliRunner::run("dialect -j " + testDataPath("separators/pipe.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("\"delimiter\": \"|\"") != std::string::npos);
 }
 
 TEST_F(CliTest, DialectEmptyFile) {
   // Test dialect detection on empty file (should fail gracefully)
-  auto result = CliRunner::run("dialect " + testDataPath("edge_cases/empty_file.csv"));
+  auto result =
+      CliRunner::run("dialect " + testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 1);
   // Should error because nothing to detect
   EXPECT_TRUE(result.output.find("Error:") != std::string::npos);
 }
 
 TEST_F(CliTest, DialectFromStdin) {
-  auto result = CliRunner::runWithFileStdin("dialect -", testDataPath("basic/simple.csv"));
+  auto result = CliRunner::runWithFileStdin("dialect -",
+                                            testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("comma") != std::string::npos);
 }
@@ -1371,20 +1539,23 @@ TEST_F(CliTest, PrettyNoHeader) {
 
 TEST_F(CliTest, PrettyLongFieldTruncation) {
   // Test pretty print with field truncation to 40 chars max
-  auto result = CliRunner::run("pretty " + testDataPath("large/large_field.csv"));
+  auto result =
+      CliRunner::run("pretty " + testDataPath("large/large_field.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("...") != std::string::npos);
 }
 
 TEST_F(CliTest, PrettyNarrowColumns) {
   // Test pretty print with narrow columns (width < 3)
-  auto result = CliRunner::run("pretty " + testDataPath("basic/narrow_columns.csv"));
+  auto result =
+      CliRunner::run("pretty " + testDataPath("basic/narrow_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("+") != std::string::npos);
 }
 
 TEST_F(CliTest, PrettyFromStdin) {
-  auto result = CliRunner::runWithFileStdin("pretty -n 2 -", testDataPath("basic/simple.csv"));
+  auto result = CliRunner::runWithFileStdin("pretty -n 2 -",
+                                            testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("+") != std::string::npos);
 }
@@ -1400,7 +1571,8 @@ TEST_F(CliTest, PrettyManyRows) {
 
 TEST_F(CliTest, HeadFieldsWithCommas) {
   // Test head output properly quotes fields containing commas
-  auto result = CliRunner::run("head " + testDataPath("quoted/needs_quoting.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("quoted/needs_quoting.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // The output should contain quoted fields
   EXPECT_TRUE(result.output.find("\"") != std::string::npos);
@@ -1408,19 +1580,22 @@ TEST_F(CliTest, HeadFieldsWithCommas) {
 
 TEST_F(CliTest, SelectFieldsWithQuotes) {
   // Test select output properly escapes quotes in fields
-  auto result = CliRunner::run("select -c 0,1 " + testDataPath("quoted/needs_quoting.csv"));
+  auto result = CliRunner::run("select -c 0,1 " +
+                               testDataPath("quoted/needs_quoting.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, HeadFieldsWithContainsCR) {
   // Test head output properly quotes fields containing carriage returns
-  auto result = CliRunner::run("head " + testDataPath("quoted/contains_cr.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("quoted/contains_cr.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, TailFieldsWithNewlines) {
   // Test tail output with embedded newlines in fields
-  auto result = CliRunner::run("tail " + testDataPath("quoted/newlines_in_quotes.csv"));
+  auto result =
+      CliRunner::run("tail " + testDataPath("quoted/newlines_in_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1452,13 +1627,15 @@ TEST_F(CliTest, HeadTinyFile) {
 // =============================================================================
 
 TEST_F(CliTest, InfoFromStdinWithDelimiter) {
-  auto result = CliRunner::runWithFileStdin("info -d tab -", testDataPath("separators/tab.csv"));
+  auto result = CliRunner::runWithFileStdin("info -d tab -",
+                                            testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("<stdin>") != std::string::npos);
 }
 
 TEST_F(CliTest, InfoManyColumns) {
-  auto result = CliRunner::run("info " + testDataPath("basic/wide_columns.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("basic/wide_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("Columns:") != std::string::npos);
 }
@@ -1468,25 +1645,29 @@ TEST_F(CliTest, InfoManyColumns) {
 // =============================================================================
 
 TEST_F(CliTest, SelectWithTabDelimiter) {
-  auto result = CliRunner::run("select -c 0 -d tab " + testDataPath("separators/tab.csv"));
+  auto result = CliRunner::run("select -c 0 -d tab " +
+                               testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SelectMultipleByName) {
-  auto result = CliRunner::run("select -c A,B " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -c A,B " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("A") != std::string::npos);
   EXPECT_TRUE(result.output.find("B") != std::string::npos);
 }
 
 TEST_F(CliTest, SelectEmptyFile) {
-  auto result = CliRunner::run("select -c 0 " + testDataPath("edge_cases/empty_file.csv"));
+  auto result = CliRunner::run("select -c 0 " +
+                               testDataPath("edge_cases/empty_file.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SelectRaggedCsv) {
   // Test select on CSV with ragged columns (some rows have fewer columns)
-  auto result = CliRunner::run("select -c 0,2 " + testDataPath("ragged/fewer_columns.csv"));
+  auto result = CliRunner::run("select -c 0,2 " +
+                               testDataPath("ragged/fewer_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1495,23 +1676,27 @@ TEST_F(CliTest, SelectRaggedCsv) {
 // =============================================================================
 
 TEST_F(CliTest, HeadSingleColumn) {
-  auto result = CliRunner::run("head " + testDataPath("basic/single_column.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("basic/single_column.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, TailSingleColumn) {
-  auto result = CliRunner::run("tail " + testDataPath("basic/single_column.csv"));
+  auto result =
+      CliRunner::run("tail " + testDataPath("basic/single_column.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, HeadQuotedFieldsPreservation) {
   // Test that quoted fields are properly output
-  auto result = CliRunner::run("head " + testDataPath("quoted/escaped_quotes.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("quoted/escaped_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, TailQuotedFieldsPreservation) {
-  auto result = CliRunner::run("tail " + testDataPath("quoted/escaped_quotes.csv"));
+  auto result =
+      CliRunner::run("tail " + testDataPath("quoted/escaped_quotes.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1520,19 +1705,29 @@ TEST_F(CliTest, TailQuotedFieldsPreservation) {
 // =============================================================================
 
 TEST_F(CliTest, CountSingleThread) {
-  auto result = CliRunner::run("count -t 1 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("count -t 1 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("3") != std::string::npos);
 }
 
 TEST_F(CliTest, CountMaxThreads) {
-  // Test with maximum valid thread count
-  auto result = CliRunner::run("count -t 255 " + testDataPath("basic/simple.csv"));
+  // Test with maximum valid thread count (1024 after uint16_t change)
+  auto result =
+      CliRunner::run("count -t 1024 " + testDataPath("basic/simple.csv"));
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST_F(CliTest, CountManyThreads) {
+  // Test with thread count above old uint8_t limit (255)
+  auto result =
+      CliRunner::run("count -t 500 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, HeadWithManyThreads) {
-  auto result = CliRunner::run("head -t 16 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("head -t 16 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1541,19 +1736,22 @@ TEST_F(CliTest, HeadWithManyThreads) {
 // =============================================================================
 
 TEST_F(CliTest, SampleSingleRow) {
-  auto result = CliRunner::run("sample -n 1 -s 42 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("sample -n 1 -s 42 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should have header and 1 data row
   EXPECT_TRUE(result.output.find("A,B,C") != std::string::npos);
 }
 
 TEST_F(CliTest, SampleLargeFile) {
-  auto result = CliRunner::run("sample -n 10 -s 42 " + testDataPath("basic/many_rows.csv"));
+  auto result = CliRunner::run("sample -n 10 -s 42 " +
+                               testDataPath("basic/many_rows.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SampleWithPipeDelimiter) {
-  auto result = CliRunner::run("sample -d pipe " + testDataPath("separators/pipe.csv"));
+  auto result =
+      CliRunner::run("sample -d pipe " + testDataPath("separators/pipe.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("|") != std::string::npos);
 }
@@ -1563,23 +1761,27 @@ TEST_F(CliTest, SampleWithPipeDelimiter) {
 // =============================================================================
 
 TEST_F(CliTest, HeadRaggedCsv) {
-  auto result = CliRunner::run("head " + testDataPath("ragged/fewer_columns.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("ragged/fewer_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, TailRaggedCsv) {
-  auto result = CliRunner::run("tail " + testDataPath("ragged/fewer_columns.csv"));
+  auto result =
+      CliRunner::run("tail " + testDataPath("ragged/fewer_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, InfoRaggedCsv) {
-  auto result = CliRunner::run("info " + testDataPath("ragged/fewer_columns.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("ragged/fewer_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, PrettyRaggedCsv) {
   // Test pretty print with ragged columns (different column counts per row)
-  auto result = CliRunner::run("pretty " + testDataPath("ragged/fewer_columns.csv"));
+  auto result =
+      CliRunner::run("pretty " + testDataPath("ragged/fewer_columns.csv"));
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_TRUE(result.output.find("+") != std::string::npos);
 }
@@ -1589,17 +1791,20 @@ TEST_F(CliTest, PrettyRaggedCsv) {
 // =============================================================================
 
 TEST_F(CliTest, CountBlankRows) {
-  auto result = CliRunner::run("count " + testDataPath("whitespace/blank_rows_mixed.csv"));
+  auto result = CliRunner::run("count " +
+                               testDataPath("whitespace/blank_rows_mixed.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, HeadWhitespaceOnlyRows) {
-  auto result = CliRunner::run("head " + testDataPath("whitespace/whitespace_only_rows.csv"));
+  auto result = CliRunner::run(
+      "head " + testDataPath("whitespace/whitespace_only_rows.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, InfoBlankLeadingRows) {
-  auto result = CliRunner::run("info " + testDataPath("whitespace/blank_leading_rows.csv"));
+  auto result = CliRunner::run(
+      "info " + testDataPath("whitespace/blank_leading_rows.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1608,22 +1813,26 @@ TEST_F(CliTest, InfoBlankLeadingRows) {
 // =============================================================================
 
 TEST_F(CliTest, HeadFinancialData) {
-  auto result = CliRunner::run("head " + testDataPath("real_world/financial.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("real_world/financial.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, InfoContactsData) {
-  auto result = CliRunner::run("info " + testDataPath("real_world/contacts.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("real_world/contacts.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SelectUnicodeData) {
-  auto result = CliRunner::run("select -c 0 " + testDataPath("real_world/unicode.csv"));
+  auto result =
+      CliRunner::run("select -c 0 " + testDataPath("real_world/unicode.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, PrettyProductCatalog) {
-  auto result = CliRunner::run("pretty -n 3 " + testDataPath("real_world/product_catalog.csv"));
+  auto result = CliRunner::run("pretty -n 3 " +
+                               testDataPath("real_world/product_catalog.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1652,7 +1861,8 @@ TEST_F(CliTest, InfoMixedCr) {
 }
 
 TEST_F(CliTest, CountInvalidUtf8) {
-  auto result = CliRunner::run("count " + testDataPath("fuzz/invalid_utf8.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("fuzz/invalid_utf8.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1691,23 +1901,27 @@ TEST_F(CliTest, PrettyNonexistentFile) {
 // =============================================================================
 
 TEST_F(CliTest, HeadNoHeaderWithCustomDelimiter) {
-  auto result = CliRunner::run("head -H -d tab " + testDataPath("separators/tab.csv"));
+  auto result =
+      CliRunner::run("head -H -d tab " + testDataPath("separators/tab.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, TailNoHeaderWithRowCount) {
-  auto result = CliRunner::run("tail -H -n 1 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("tail -H -n 1 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SampleWithAllOptions) {
-  auto result = CliRunner::run("sample -n 2 -s 42 -H -d comma " + testDataPath("basic/simple.csv"));
+  auto result = CliRunner::run("sample -n 2 -s 42 -H -d comma " +
+                               testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, SelectNoHeaderWithIndex) {
   // Select with -H should work with numeric indices
-  auto result = CliRunner::run("select -H -c 0,1 " + testDataPath("basic/simple.csv"));
+  auto result =
+      CliRunner::run("select -H -c 0,1 " + testDataPath("basic/simple.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1726,7 +1940,8 @@ TEST_F(CliTest, CountLatin1) {
 }
 
 TEST_F(CliTest, InfoUtf16Bom) {
-  auto result = CliRunner::run("info " + testDataPath("encoding/utf16_bom.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("encoding/utf16_bom.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1735,12 +1950,14 @@ TEST_F(CliTest, InfoUtf16Bom) {
 // =============================================================================
 
 TEST_F(CliTest, CountHashComments) {
-  auto result = CliRunner::run("count " + testDataPath("comments/hash_comments.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("comments/hash_comments.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, HeadQuotedHash) {
-  auto result = CliRunner::run("head " + testDataPath("comments/quoted_hash.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("comments/quoted_hash.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1749,7 +1966,8 @@ TEST_F(CliTest, HeadQuotedHash) {
 // =============================================================================
 
 TEST_F(CliTest, HeadBackslashEscape) {
-  auto result = CliRunner::run("head " + testDataPath("escape/backslash_escape.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("escape/backslash_escape.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1758,17 +1976,20 @@ TEST_F(CliTest, HeadBackslashEscape) {
 // =============================================================================
 
 TEST_F(CliTest, CountSingleCell) {
-  auto result = CliRunner::run("count " + testDataPath("edge_cases/single_cell.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("edge_cases/single_cell.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, HeadSingleCell) {
-  auto result = CliRunner::run("head " + testDataPath("edge_cases/single_cell.csv"));
+  auto result =
+      CliRunner::run("head " + testDataPath("edge_cases/single_cell.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
 TEST_F(CliTest, InfoSingleCell) {
-  auto result = CliRunner::run("info " + testDataPath("edge_cases/single_cell.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("edge_cases/single_cell.csv"));
   EXPECT_EQ(result.exit_code, 0);
 }
 
@@ -1794,7 +2015,8 @@ TEST_F(CliTest, PrettyUtf8TruncationLimitation) {
   // - EmojiSplit: 36 ASCII + 2 emoji (4 bytes each) = 44 bytes
   // - CJKSplit: 17 CJK characters (3 bytes each) = 51 bytes
   // - MixedSplit: Mix of ASCII, CJK, emoji = 55 bytes
-  auto result = CliRunner::run("pretty " + testDataPath("edge_cases/utf8_truncation.csv"));
+  auto result = CliRunner::run("pretty " +
+                               testDataPath("edge_cases/utf8_truncation.csv"));
   EXPECT_EQ(result.exit_code, 0);
 
   // Verify the command succeeds and produces table output
@@ -1812,7 +2034,8 @@ TEST_F(CliTest, PrettyUtf8TruncationLimitation) {
 
 TEST_F(CliTest, PrettyUtf8ShortFieldsNotTruncated) {
   // Verify that short UTF-8 fields (< 40 bytes) are NOT truncated
-  auto result = CliRunner::run("pretty " + testDataPath("real_world/unicode.csv"));
+  auto result =
+      CliRunner::run("pretty " + testDataPath("real_world/unicode.csv"));
   EXPECT_EQ(result.exit_code, 0);
 
   // The unicode.csv file has fields < 40 bytes, so they should display fully
@@ -1827,25 +2050,28 @@ TEST_F(CliTest, PrettyUtf8ShortFieldsNotTruncated) {
 // ============================================================================
 
 TEST_F(CliTest, RegressionIssue264_ExtremelyWideCsv) {
-  // Regression test for GitHub issue #264: SIGSEGV crash on extremely wide CSV files
-  // The bug was in index buffer allocation for multi-threaded parsing.
+  // Regression test for GitHub issue #264: SIGSEGV crash on extremely wide CSV
+  // files The bug was in index buffer allocation for multi-threaded parsing.
   // Files with very high separator density (many columns) could overflow the
   // interleaved index buffer because the allocation didn't account for the
   // stride pattern used in multi-threaded mode.
   //
-  // The test file has 16384 columns and 74 rows (~868K separators in ~876KB file).
-  // This previously caused a segmentation fault.
-  auto result = CliRunner::run("head -n 5 " + testDataPath("edge_cases/extremely_wide.csv"));
+  // The test file has 16384 columns and 74 rows (~868K separators in ~876KB
+  // file). This previously caused a segmentation fault.
+  auto result = CliRunner::run("head -n 5 " +
+                               testDataPath("edge_cases/extremely_wide.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should successfully parse and output the first rows
   EXPECT_FALSE(result.output.empty());
   // First row should contain the expected header
-  EXPECT_TRUE(result.output.find("BUSINESS PLAN QUARTERLY DATA SUMMARY") != std::string::npos);
+  EXPECT_TRUE(result.output.find("BUSINESS PLAN QUARTERLY DATA SUMMARY") !=
+              std::string::npos);
 }
 
 TEST_F(CliTest, RegressionIssue264_ExtremelyWideCsvInfo) {
   // Also verify info command works on extremely wide files
-  auto result = CliRunner::run("info " + testDataPath("edge_cases/extremely_wide.csv"));
+  auto result =
+      CliRunner::run("info " + testDataPath("edge_cases/extremely_wide.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should report 16384 columns
   EXPECT_TRUE(result.output.find("Columns: 16384") != std::string::npos);
@@ -1853,7 +2079,8 @@ TEST_F(CliTest, RegressionIssue264_ExtremelyWideCsvInfo) {
 
 TEST_F(CliTest, RegressionIssue264_ExtremelyWideCsvCount) {
   // Verify count command works on extremely wide files
-  auto result = CliRunner::run("count " + testDataPath("edge_cases/extremely_wide.csv"));
+  auto result =
+      CliRunner::run("count " + testDataPath("edge_cases/extremely_wide.csv"));
   EXPECT_EQ(result.exit_code, 0);
   // Should return a valid row count
   EXPECT_FALSE(result.output.empty());

--- a/test/two_pass_coverage_test.cpp
+++ b/test/two_pass_coverage_test.cpp
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
-#include "two_pass.h"
+#include "dialect.h"
 #include "error.h"
 #include "io_util.h"
-#include "dialect.h"
+#include "two_pass.h"
 #include <cstring>
-#include <fstream>
 #include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
 #include <thread>
 
 namespace fs = std::filesystem;
@@ -17,121 +17,183 @@ using namespace libvroom;
 
 class IndexClassTest : public ::testing::Test {
 protected:
-    std::string temp_filename;
+  std::string temp_filename;
 
-    void SetUp() override {
-        temp_filename = "test_index_temp.bin";
-    }
+  void SetUp() override { temp_filename = "test_index_temp.bin"; }
 
-    void TearDown() override {
-        if (fs::exists(temp_filename)) {
-            fs::remove(temp_filename);
-        }
+  void TearDown() override {
+    if (fs::exists(temp_filename)) {
+      fs::remove(temp_filename);
     }
+  }
 };
 
 TEST_F(IndexClassTest, MoveConstructor) {
-    two_pass parser;
-    libvroom::index original = parser.init(100, 2);
+  two_pass parser;
+  libvroom::index original = parser.init(100, 2);
 
-    // Set some values
-    original.columns = 5;
-    original.n_indexes[0] = 10;
-    original.n_indexes[1] = 15;
-    original.indexes[0] = 42;
-    original.indexes[1] = 84;
+  // Set some values
+  original.columns = 5;
+  original.n_indexes[0] = 10;
+  original.n_indexes[1] = 15;
+  original.indexes[0] = 42;
+  original.indexes[1] = 84;
 
-    // Move construct
-    libvroom::index moved(std::move(original));
+  // Move construct
+  libvroom::index moved(std::move(original));
 
-    EXPECT_EQ(moved.columns, 5);
-    EXPECT_EQ(moved.n_threads, 2);
-    EXPECT_EQ(moved.n_indexes[0], 10);
-    EXPECT_EQ(moved.n_indexes[1], 15);
-    EXPECT_EQ(moved.indexes[0], 42);
-    EXPECT_EQ(moved.indexes[1], 84);
+  EXPECT_EQ(moved.columns, 5);
+  EXPECT_EQ(moved.n_threads, 2);
+  EXPECT_EQ(moved.n_indexes[0], 10);
+  EXPECT_EQ(moved.n_indexes[1], 15);
+  EXPECT_EQ(moved.indexes[0], 42);
+  EXPECT_EQ(moved.indexes[1], 84);
 
-    // Original should be nulled out
-    EXPECT_EQ(original.n_indexes, nullptr);
-    EXPECT_EQ(original.indexes, nullptr);
+  // Original should be nulled out
+  EXPECT_EQ(original.n_indexes, nullptr);
+  EXPECT_EQ(original.indexes, nullptr);
 }
 
 TEST_F(IndexClassTest, MoveAssignment) {
-    two_pass parser;
-    libvroom::index original = parser.init(100, 2);
-    libvroom::index target = parser.init(50, 1);
+  two_pass parser;
+  libvroom::index original = parser.init(100, 2);
+  libvroom::index target = parser.init(50, 1);
 
-    // Set values on original
-    original.columns = 7;
-    original.n_indexes[0] = 20;
-    original.n_indexes[1] = 25;
+  // Set values on original
+  original.columns = 7;
+  original.n_indexes[0] = 20;
+  original.n_indexes[1] = 25;
 
-    // Move assign
-    target = std::move(original);
+  // Move assign
+  target = std::move(original);
 
-    EXPECT_EQ(target.columns, 7);
-    EXPECT_EQ(target.n_threads, 2);
-    EXPECT_EQ(target.n_indexes[0], 20);
-    EXPECT_EQ(target.n_indexes[1], 25);
+  EXPECT_EQ(target.columns, 7);
+  EXPECT_EQ(target.n_threads, 2);
+  EXPECT_EQ(target.n_indexes[0], 20);
+  EXPECT_EQ(target.n_indexes[1], 25);
 
-    // Original should be nulled out
-    EXPECT_EQ(original.n_indexes, nullptr);
-    EXPECT_EQ(original.indexes, nullptr);
+  // Original should be nulled out
+  EXPECT_EQ(original.n_indexes, nullptr);
+  EXPECT_EQ(original.indexes, nullptr);
 }
 
 TEST_F(IndexClassTest, MoveAssignmentSelfAssignment) {
-    two_pass parser;
-    libvroom::index idx = parser.init(100, 2);
-    idx.columns = 3;
-    idx.n_indexes[0] = 10;
+  two_pass parser;
+  libvroom::index idx = parser.init(100, 2);
+  idx.columns = 3;
+  idx.n_indexes[0] = 10;
 
-    // Self-assignment should be safe
-    libvroom::index& ref = idx;
-    idx = std::move(ref);
+  // Self-assignment should be safe
+  libvroom::index &ref = idx;
+  idx = std::move(ref);
 
-    EXPECT_EQ(idx.columns, 3);
-    EXPECT_EQ(idx.n_threads, 2);
-    EXPECT_EQ(idx.n_indexes[0], 10);
+  EXPECT_EQ(idx.columns, 3);
+  EXPECT_EQ(idx.n_threads, 2);
+  EXPECT_EQ(idx.n_indexes[0], 10);
 }
 
 TEST_F(IndexClassTest, WriteAndRead) {
-    two_pass parser;
-    libvroom::index original = parser.init(100, 2);
+  two_pass parser;
+  libvroom::index original = parser.init(100, 2);
 
-    // Set values
-    original.columns = 10;
-    original.n_indexes[0] = 3;
-    original.n_indexes[1] = 2;
-    original.indexes[0] = 5;
-    original.indexes[1] = 10;
-    original.indexes[2] = 15;
-    original.indexes[3] = 20;
-    original.indexes[4] = 25;
+  // Set values
+  original.columns = 10;
+  original.n_indexes[0] = 3;
+  original.n_indexes[1] = 2;
+  original.indexes[0] = 5;
+  original.indexes[1] = 10;
+  original.indexes[2] = 15;
+  original.indexes[3] = 20;
+  original.indexes[4] = 25;
 
-    // Write to file
-    original.write(temp_filename);
+  // Write to file
+  original.write(temp_filename);
 
-    // Read into new index
-    libvroom::index restored = parser.init(100, 2);
-    restored.read(temp_filename);
+  // Read into new index
+  libvroom::index restored = parser.init(100, 2);
+  restored.read(temp_filename);
 
-    EXPECT_EQ(restored.columns, 10);
-    EXPECT_EQ(restored.n_threads, 2);
-    EXPECT_EQ(restored.n_indexes[0], 3);
-    EXPECT_EQ(restored.n_indexes[1], 2);
-    EXPECT_EQ(restored.indexes[0], 5);
-    EXPECT_EQ(restored.indexes[1], 10);
-    EXPECT_EQ(restored.indexes[2], 15);
-    EXPECT_EQ(restored.indexes[3], 20);
-    EXPECT_EQ(restored.indexes[4], 25);
+  EXPECT_EQ(restored.columns, 10);
+  EXPECT_EQ(restored.n_threads, 2);
+  EXPECT_EQ(restored.n_indexes[0], 3);
+  EXPECT_EQ(restored.n_indexes[1], 2);
+  EXPECT_EQ(restored.indexes[0], 5);
+  EXPECT_EQ(restored.indexes[1], 10);
+  EXPECT_EQ(restored.indexes[2], 15);
+  EXPECT_EQ(restored.indexes[3], 20);
+  EXPECT_EQ(restored.indexes[4], 25);
 }
 
 TEST_F(IndexClassTest, DefaultConstructor) {
-    libvroom::index idx;
-    EXPECT_EQ(idx.columns, 0);
-    EXPECT_EQ(idx.n_threads, 0);
-    EXPECT_EQ(idx.n_indexes, nullptr);
-    EXPECT_EQ(idx.indexes, nullptr);
+  libvroom::index idx;
+  EXPECT_EQ(idx.columns, 0);
+  EXPECT_EQ(idx.n_threads, 0);
+  EXPECT_EQ(idx.n_indexes, nullptr);
+  EXPECT_EQ(idx.indexes, nullptr);
+}
+
+TEST_F(IndexClassTest, WriteAndReadLargeThreadCount) {
+  // Test with thread count > 255 to verify uint16_t support
+  two_pass parser;
+  libvroom::index original = parser.init(100, 300); // 300 threads
+
+  // Set values
+  original.columns = 10;
+  // Set some non-zero indexes for first few threads
+  original.n_indexes[0] = 2;
+  original.n_indexes[1] = 1;
+  original.n_indexes[299] = 1; // Last thread
+  original.indexes[0] = 5;
+  original.indexes[1] = 10;
+  original.indexes[300] = 15; // Index for thread 0, position 1
+  original.indexes[299] = 20; // Index for thread 299, position 0
+
+  // Write to file
+  original.write(temp_filename);
+
+  // Read into new index
+  libvroom::index restored = parser.init(100, 300);
+  restored.read(temp_filename);
+
+  EXPECT_EQ(restored.columns, 10);
+  EXPECT_EQ(restored.n_threads, 300);
+  EXPECT_EQ(restored.n_indexes[0], 2);
+  EXPECT_EQ(restored.n_indexes[1], 1);
+  EXPECT_EQ(restored.n_indexes[299], 1);
+  EXPECT_EQ(restored.indexes[0], 5);
+  EXPECT_EQ(restored.indexes[1], 10);
+}
+
+TEST_F(IndexClassTest, ReadLegacyV1Format) {
+  // Test backward compatibility with v1 format (uint8_t n_threads)
+  // Manually create a v1 format file
+  std::FILE *fp = std::fopen(temp_filename.c_str(), "wb");
+  ASSERT_NE(fp, nullptr);
+
+  // V1 format: columns (uint64_t), n_threads (uint8_t), n_indexes[], indexes[]
+  uint64_t columns = 5;
+  uint8_t n_threads_v1 = 2;
+  uint64_t n_indexes[2] = {2, 1};
+  uint64_t indexes[3] = {10, 20, 30};
+
+  std::fwrite(&columns, sizeof(uint64_t), 1, fp);
+  std::fwrite(&n_threads_v1, sizeof(uint8_t), 1, fp);
+  std::fwrite(n_indexes, sizeof(uint64_t), 2, fp);
+  std::fwrite(indexes, sizeof(uint64_t), 3, fp);
+  std::fclose(fp);
+
+  // Read using current version (should detect v1 format)
+  two_pass parser;
+  libvroom::index restored = parser.init(100, 2);
+  restored.read(temp_filename);
+
+  EXPECT_EQ(restored.columns, 5);
+  EXPECT_EQ(restored.n_threads, 2);
+  EXPECT_EQ(restored.n_indexes[0], 2);
+  EXPECT_EQ(restored.n_indexes[1], 1);
+  EXPECT_EQ(restored.indexes[0], 10);
+  EXPECT_EQ(restored.indexes[1], 20);
+  EXPECT_EQ(restored.indexes[2], 30);
 }
 
 // ============================================================================
@@ -140,94 +202,94 @@ TEST_F(IndexClassTest, DefaultConstructor) {
 
 class FirstPassTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(FirstPassTest, FirstPassNaive) {
-    std::string content = "a,b,c\n1,2,3\n4,5,6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n4,5,6\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
+  auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
 
-    // first_pass_naive finds the first newline
-    EXPECT_EQ(stats.first_even_nl, 5);  // Position of first '\n'
-    EXPECT_EQ(stats.first_odd_nl, null_pos);  // Not set by naive
-    EXPECT_EQ(stats.n_quotes, 0);  // Naive doesn't count quotes
+  // first_pass_naive finds the first newline
+  EXPECT_EQ(stats.first_even_nl, 5);       // Position of first '\n'
+  EXPECT_EQ(stats.first_odd_nl, null_pos); // Not set by naive
+  EXPECT_EQ(stats.n_quotes, 0);            // Naive doesn't count quotes
 }
 
 TEST_F(FirstPassTest, FirstPassNaiveNoNewline) {
-    std::string content = "a,b,c";  // No newline
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c"; // No newline
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
+  auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
 
-    // Should not find any newline
-    EXPECT_EQ(stats.first_even_nl, null_pos);
+  // Should not find any newline
+  EXPECT_EQ(stats.first_even_nl, null_pos);
 }
 
 TEST_F(FirstPassTest, FirstPassChunkWithQuotes) {
-    std::string content = "\"a\",b,c\n1,\"2\",3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\"a\",b,c\n1,\"2\",3\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
 
-    // Should find newlines and count quotes
-    EXPECT_NE(stats.first_even_nl, null_pos);
-    EXPECT_EQ(stats.n_quotes, 4);  // 4 quote characters
+  // Should find newlines and count quotes
+  EXPECT_NE(stats.first_even_nl, null_pos);
+  EXPECT_EQ(stats.n_quotes, 4); // 4 quote characters
 }
 
 TEST_F(FirstPassTest, FirstPassChunkOddQuotes) {
-    std::string content = "\"a,\nb,c\n";  // Unclosed quote spans newline
-    auto buf = makeBuffer(content);
+  std::string content = "\"a,\nb,c\n"; // Unclosed quote spans newline
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
 
-    // First newline at position 3 is at odd quote count (1)
-    EXPECT_EQ(stats.first_odd_nl, 3);
-    // Second newline at position 7 is at odd quote count (1)
-    EXPECT_EQ(stats.first_even_nl, null_pos);  // No even newline
+  // First newline at position 3 is at odd quote count (1)
+  EXPECT_EQ(stats.first_odd_nl, 3);
+  // Second newline at position 7 is at odd quote count (1)
+  EXPECT_EQ(stats.first_even_nl, null_pos); // No even newline
 }
 
 TEST_F(FirstPassTest, FirstPassSIMDShortBuffer) {
-    // Buffer shorter than 64 bytes to test scalar fallback
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  // Buffer shorter than 64 bytes to test scalar fallback
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_NE(stats.first_even_nl, null_pos);
-    EXPECT_EQ(stats.n_quotes, 0);
+  EXPECT_NE(stats.first_even_nl, null_pos);
+  EXPECT_EQ(stats.n_quotes, 0);
 }
 
 TEST_F(FirstPassTest, FirstPassSIMDLongBuffer) {
-    // Buffer larger than 64 bytes
-    std::string content;
-    for (int i = 0; i < 20; i++) {
-        content += "field1,field2,field3\n";
-    }
-    auto buf = makeBuffer(content);
+  // Buffer larger than 64 bytes
+  std::string content;
+  for (int i = 0; i < 20; i++) {
+    content += "field1,field2,field3\n";
+  }
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_NE(stats.first_even_nl, null_pos);
+  EXPECT_NE(stats.first_even_nl, null_pos);
 }
 
 TEST_F(FirstPassTest, FirstPassSIMDWithQuotes) {
-    // Buffer with quotes, larger than 64 bytes
-    std::string content;
-    for (int i = 0; i < 5; i++) {
-        content += "\"quoted\",\"field\",normal\n";
-    }
-    auto buf = makeBuffer(content);
+  // Buffer with quotes, larger than 64 bytes
+  std::string content;
+  for (int i = 0; i < 5; i++) {
+    content += "\"quoted\",\"field\",normal\n";
+  }
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_NE(stats.first_even_nl, null_pos);
-    EXPECT_GT(stats.n_quotes, 0);
+  EXPECT_NE(stats.first_even_nl, null_pos);
+  EXPECT_GT(stats.n_quotes, 0);
 }
 
 // ============================================================================
@@ -235,62 +297,63 @@ TEST_F(FirstPassTest, FirstPassSIMDWithQuotes) {
 // ============================================================================
 
 TEST_F(FirstPassTest, FirstPassNaiveWithCR) {
-    // Test CR-only line endings (old Mac style)
-    std::string content = "a,b,c\r1,2,3\r4,5,6\r";
-    auto buf = makeBuffer(content);
+  // Test CR-only line endings (old Mac style)
+  std::string content = "a,b,c\r1,2,3\r4,5,6\r";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
+  auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
 
-    // first_pass_naive should find the first CR as a line ending
-    EXPECT_EQ(stats.first_even_nl, 5);  // Position of first '\r'
+  // first_pass_naive should find the first CR as a line ending
+  EXPECT_EQ(stats.first_even_nl, 5); // Position of first '\r'
 }
 
 TEST_F(FirstPassTest, FirstPassNaiveWithCRLF) {
-    // Test CRLF line endings - CR should NOT be treated as line ending
-    std::string content = "a,b,c\r\n1,2,3\r\n";
-    auto buf = makeBuffer(content);
+  // Test CRLF line endings - CR should NOT be treated as line ending
+  std::string content = "a,b,c\r\n1,2,3\r\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
+  auto stats = two_pass::first_pass_naive(buf.data(), 0, content.size());
 
-    // Should find LF as line ending, not CR (CR followed by LF is not a line ending)
-    EXPECT_EQ(stats.first_even_nl, 6);  // Position of '\n' after '\r'
+  // Should find LF as line ending, not CR (CR followed by LF is not a line
+  // ending)
+  EXPECT_EQ(stats.first_even_nl, 6); // Position of '\n' after '\r'
 }
 
 TEST_F(FirstPassTest, FirstPassChunkWithCR) {
-    // Test CR-only line endings with quotes
-    std::string content = "\"a\",b,c\r1,\"2\",3\r";
-    auto buf = makeBuffer(content);
+  // Test CR-only line endings with quotes
+  std::string content = "\"a\",b,c\r1,\"2\",3\r";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
 
-    // Should find CR as newline and count quotes
-    EXPECT_NE(stats.first_even_nl, null_pos);
-    EXPECT_EQ(stats.n_quotes, 4);  // 4 quote characters
+  // Should find CR as newline and count quotes
+  EXPECT_NE(stats.first_even_nl, null_pos);
+  EXPECT_EQ(stats.n_quotes, 4); // 4 quote characters
 }
 
 TEST_F(FirstPassTest, FirstPassChunkWithCRLF) {
-    // Test CRLF line endings - CR followed by LF should use LF as line ending
-    std::string content = "\"a\",b,c\r\n1,\"2\",3\r\n";
-    auto buf = makeBuffer(content);
+  // Test CRLF line endings - CR followed by LF should use LF as line ending
+  std::string content = "\"a\",b,c\r\n1,\"2\",3\r\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
 
-    // Should find LF as newline (position 8), not CR (position 7)
-    EXPECT_EQ(stats.first_even_nl, 8);
-    EXPECT_EQ(stats.n_quotes, 4);
+  // Should find LF as newline (position 8), not CR (position 7)
+  EXPECT_EQ(stats.first_even_nl, 8);
+  EXPECT_EQ(stats.n_quotes, 4);
 }
 
 TEST_F(FirstPassTest, FirstPassChunkCRInQuotes) {
-    // Test CR inside quoted field - should not be treated as line ending
-    std::string content = "\"a\rb\",c\r1,2,3\r";
-    auto buf = makeBuffer(content);
+  // Test CR inside quoted field - should not be treated as line ending
+  std::string content = "\"a\rb\",c\r1,2,3\r";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
 
-    // First newline outside quotes is at position 7 (after "c")
-    // The CR at position 2 is inside quotes
-    EXPECT_EQ(stats.first_even_nl, 7);
-    EXPECT_EQ(stats.n_quotes, 2);
+  // First newline outside quotes is at position 7 (after "c")
+  // The CR at position 2 is inside quotes
+  EXPECT_EQ(stats.first_even_nl, 7);
+  EXPECT_EQ(stats.n_quotes, 2);
 }
 
 // ============================================================================
@@ -299,84 +362,86 @@ TEST_F(FirstPassTest, FirstPassChunkCRInQuotes) {
 
 class QuotationStateTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(QuotationStateTest, AtStart) {
-    std::string content = "a,b,c";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c";
+  auto buf = makeBuffer(content);
 
-    auto state = two_pass::get_quotation_state(buf.data(), 0);
-    EXPECT_EQ(state, two_pass::UNQUOTED);
+  auto state = two_pass::get_quotation_state(buf.data(), 0);
+  EXPECT_EQ(state, two_pass::UNQUOTED);
 }
 
 TEST_F(QuotationStateTest, UnquotedContext) {
-    std::string content = "abc,def,ghi";
-    auto buf = makeBuffer(content);
+  std::string content = "abc,def,ghi";
+  auto buf = makeBuffer(content);
 
-    auto state = two_pass::get_quotation_state(buf.data(), 5, ',', '"');
-    // Position 5 is 'e' in 'def', preceded by comma - should determine context
-    EXPECT_TRUE(state == two_pass::UNQUOTED || state == two_pass::AMBIGUOUS);
+  auto state = two_pass::get_quotation_state(buf.data(), 5, ',', '"');
+  // Position 5 is 'e' in 'def', preceded by comma - should determine context
+  EXPECT_TRUE(state == two_pass::UNQUOTED || state == two_pass::AMBIGUOUS);
 }
 
 TEST_F(QuotationStateTest, QuotedContext) {
-    std::string content = "a,\"hello world\",c";
-    auto buf = makeBuffer(content);
+  std::string content = "a,\"hello world\",c";
+  auto buf = makeBuffer(content);
 
-    // Position 8 is inside "hello world" - should be in quoted context
-    auto state = two_pass::get_quotation_state(buf.data(), 8, ',', '"');
+  // Position 8 is inside "hello world" - should be in quoted context
+  auto state = two_pass::get_quotation_state(buf.data(), 8, ',', '"');
 
-    // The function looks backward to determine if we're in quotes
-    // Inside "hello world", should detect quoted state
-    EXPECT_TRUE(state == two_pass::QUOTED || state == two_pass::AMBIGUOUS);
+  // The function looks backward to determine if we're in quotes
+  // Inside "hello world", should detect quoted state
+  EXPECT_TRUE(state == two_pass::QUOTED || state == two_pass::AMBIGUOUS);
 }
 
 TEST_F(QuotationStateTest, QuoteOtherPattern) {
-    // Test q-o pattern (quote followed by "other" character)
-    // Looking backwards from position 3 ('c'):
-    // - Position 3: 'c' (other)
-    // - Position 2: 'b' (other)
-    // - Position 1: 'a' (other)
-    // - Position 0: '"' (quote)
-    // At position 0: quote followed by 'a' is o-q pattern from end perspective
-    // So looking back we see other-quote, which means UNQUOTED
-    std::string content = "\"abc";
-    auto buf = makeBuffer(content);
+  // Test q-o pattern (quote followed by "other" character)
+  // Looking backwards from position 3 ('c'):
+  // - Position 3: 'c' (other)
+  // - Position 2: 'b' (other)
+  // - Position 1: 'a' (other)
+  // - Position 0: '"' (quote)
+  // At position 0: quote followed by 'a' is o-q pattern from end perspective
+  // So looking back we see other-quote, which means UNQUOTED
+  std::string content = "\"abc";
+  auto buf = makeBuffer(content);
 
-    auto state = two_pass::get_quotation_state(buf.data(), 3, ',', '"');
-    // Position 3 is 'c', function scans backward
-    // The algorithm looks for quote patterns to determine state
-    // Since we're after a quote at position 0 with 'a' after it, we're in quoted context
-    // But the actual implementation may differ - let's accept whatever it returns
-    EXPECT_TRUE(state == two_pass::QUOTED || state == two_pass::UNQUOTED || state == two_pass::AMBIGUOUS);
+  auto state = two_pass::get_quotation_state(buf.data(), 3, ',', '"');
+  // Position 3 is 'c', function scans backward
+  // The algorithm looks for quote patterns to determine state
+  // Since we're after a quote at position 0 with 'a' after it, we're in quoted
+  // context But the actual implementation may differ - let's accept whatever it
+  // returns
+  EXPECT_TRUE(state == two_pass::QUOTED || state == two_pass::UNQUOTED ||
+              state == two_pass::AMBIGUOUS);
 }
 
 TEST_F(QuotationStateTest, OtherQuotePattern) {
-    // Test o-q pattern (other followed by quote)
-    std::string content = "ab\"c";
-    auto buf = makeBuffer(content);
+  // Test o-q pattern (other followed by quote)
+  std::string content = "ab\"c";
+  auto buf = makeBuffer(content);
 
-    auto state = two_pass::get_quotation_state(buf.data(), 3, ',', '"');
-    // Position 3 is 'c', looking back sees 'b' then quote - unquoted
-    EXPECT_EQ(state, two_pass::UNQUOTED);
+  auto state = two_pass::get_quotation_state(buf.data(), 3, ',', '"');
+  // Position 3 is 'c', looking back sees 'b' then quote - unquoted
+  EXPECT_EQ(state, two_pass::UNQUOTED);
 }
 
 TEST_F(QuotationStateTest, LongContextAmbiguous) {
-    // Create content longer than SPECULATION_SIZE (64KB) to force AMBIGUOUS
-    // In practice this is expensive, so we test the logic differently
-    std::string content;
-    content.resize(100);
-    std::fill(content.begin(), content.end(), 'x');
+  // Create content longer than SPECULATION_SIZE (64KB) to force AMBIGUOUS
+  // In practice this is expensive, so we test the logic differently
+  std::string content;
+  content.resize(100);
+  std::fill(content.begin(), content.end(), 'x');
 
-    auto buf = makeBuffer(content);
+  auto buf = makeBuffer(content);
 
-    // With no quotes at all and position 50, should be ambiguous or unquoted
-    auto state = two_pass::get_quotation_state(buf.data(), 50, ',', '"');
-    EXPECT_TRUE(state == two_pass::AMBIGUOUS || state == two_pass::UNQUOTED);
+  // With no quotes at all and position 50, should be ambiguous or unquoted
+  auto state = two_pass::get_quotation_state(buf.data(), 50, ',', '"');
+  EXPECT_TRUE(state == two_pass::AMBIGUOUS || state == two_pass::UNQUOTED);
 }
 
 // ============================================================================
@@ -385,94 +450,95 @@ TEST_F(QuotationStateTest, LongContextAmbiguous) {
 
 class ParseBranchlessTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(ParseBranchlessTest, SimpleCSV) {
-    std::string content = "a,b,c\n1,2,3\n4,5,6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n4,5,6\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse_branchless(buf.data(), idx, content.size());
+  bool success = parser.parse_branchless(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
-    EXPECT_GT(idx.n_indexes[0], 0);
+  EXPECT_TRUE(success);
+  EXPECT_GT(idx.n_indexes[0], 0);
 }
 
 TEST_F(ParseBranchlessTest, QuotedFields) {
-    std::string content = "\"a\",\"b\",\"c\"\n\"1\",\"2\",\"3\"\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\"a\",\"b\",\"c\"\n\"1\",\"2\",\"3\"\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse_branchless(buf.data(), idx, content.size());
+  bool success = parser.parse_branchless(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(ParseBranchlessTest, MultiThreaded) {
-    // Create large content for multi-threading
-    std::string content;
-    for (int i = 0; i < 1000; i++) {
-        content += "field1,field2,field3\n";
-    }
-    auto buf = makeBuffer(content);
+  // Create large content for multi-threading
+  std::string content;
+  for (int i = 0; i < 1000; i++) {
+    content += "field1,field2,field3\n";
+  }
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
 
-    bool success = parser.parse_branchless(buf.data(), idx, content.size());
+  bool success = parser.parse_branchless(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(ParseBranchlessTest, ZeroThreadsFallsBack) {
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 0);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 0);
 
-    // n_threads=0 should be handled (falls back to 1)
-    bool success = parser.parse_branchless(buf.data(), idx, content.size());
+  // n_threads=0 should be handled (falls back to 1)
+  bool success = parser.parse_branchless(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(ParseBranchlessTest, SmallChunkFallback) {
-    // Very small content with multiple threads should fall back
-    std::string content = "a,b\n";
-    auto buf = makeBuffer(content);
+  // Very small content with multiple threads should fall back
+  std::string content = "a,b\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    // Allocate with enough space; parser will update n_threads to 1
-    libvroom::index idx = parser.init(content.size() + 64, 8);  // Too many threads for tiny file
+  two_pass parser;
+  // Allocate with enough space; parser will update n_threads to 1
+  libvroom::index idx =
+      parser.init(content.size() + 64, 8); // Too many threads for tiny file
 
-    bool success = parser.parse_branchless(buf.data(), idx, content.size());
+  bool success = parser.parse_branchless(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
-    // Should have fallen back to single thread
-    EXPECT_EQ(idx.n_threads, 1);
+  EXPECT_TRUE(success);
+  // Should have fallen back to single thread
+  EXPECT_EQ(idx.n_threads, 1);
 }
 
 TEST_F(ParseBranchlessTest, CustomDialect) {
-    std::string content = "a;b;c\n1;2;3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a;b;c\n1;2;3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse_branchless(buf.data(), idx, content.size(),
-                                           Dialect::semicolon());
+  bool success = parser.parse_branchless(buf.data(), idx, content.size(),
+                                         Dialect::semicolon());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // ============================================================================
@@ -481,87 +547,90 @@ TEST_F(ParseBranchlessTest, CustomDialect) {
 
 class ParseAutoTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(ParseAutoTest, DetectCSV) {
-    std::string content = "a,b,c\n1,2,3\n4,5,6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n4,5,6\n";
+  auto buf = makeBuffer(content);
 
-    auto result = two_pass::detect_dialect(buf.data(), content.size());
+  auto result = two_pass::detect_dialect(buf.data(), content.size());
 
-    EXPECT_TRUE(result.success());
-    EXPECT_EQ(result.dialect.delimiter, ',');
+  EXPECT_TRUE(result.success());
+  EXPECT_EQ(result.dialect.delimiter, ',');
 }
 
 TEST_F(ParseAutoTest, DetectTSV) {
-    std::string content = "a\tb\tc\n1\t2\t3\n4\t5\t6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a\tb\tc\n1\t2\t3\n4\t5\t6\n";
+  auto buf = makeBuffer(content);
 
-    auto result = two_pass::detect_dialect(buf.data(), content.size());
+  auto result = two_pass::detect_dialect(buf.data(), content.size());
 
-    EXPECT_TRUE(result.success());
-    EXPECT_EQ(result.dialect.delimiter, '\t');
+  EXPECT_TRUE(result.success());
+  EXPECT_EQ(result.dialect.delimiter, '\t');
 }
 
 TEST_F(ParseAutoTest, DetectSemicolon) {
-    std::string content = "a;b;c\n1;2;3\n4;5;6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a;b;c\n1;2;3\n4;5;6\n";
+  auto buf = makeBuffer(content);
 
-    auto result = two_pass::detect_dialect(buf.data(), content.size());
+  auto result = two_pass::detect_dialect(buf.data(), content.size());
 
-    EXPECT_TRUE(result.success());
-    EXPECT_EQ(result.dialect.delimiter, ';');
+  EXPECT_TRUE(result.success());
+  EXPECT_EQ(result.dialect.delimiter, ';');
 }
 
 TEST_F(ParseAutoTest, ParseAutoCSV) {
-    std::string content = "a,b,c\n1,2,3\n4,5,6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n4,5,6\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    DetectionResult detected;
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  DetectionResult detected;
 
-    bool success = parser.parse_auto(buf.data(), idx, content.size(), errors, &detected);
+  bool success =
+      parser.parse_auto(buf.data(), idx, content.size(), errors, &detected);
 
-    EXPECT_TRUE(success);
-    EXPECT_TRUE(detected.success());
-    EXPECT_EQ(detected.dialect.delimiter, ',');
+  EXPECT_TRUE(success);
+  EXPECT_TRUE(detected.success());
+  EXPECT_EQ(detected.dialect.delimiter, ',');
 }
 
 TEST_F(ParseAutoTest, ParseAutoTSV) {
-    std::string content = "a\tb\tc\n1\t2\t3\n4\t5\t6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a\tb\tc\n1\t2\t3\n4\t5\t6\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    DetectionResult detected;
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  DetectionResult detected;
 
-    bool success = parser.parse_auto(buf.data(), idx, content.size(), errors, &detected);
+  bool success =
+      parser.parse_auto(buf.data(), idx, content.size(), errors, &detected);
 
-    EXPECT_TRUE(success);
-    EXPECT_TRUE(detected.success());
-    EXPECT_EQ(detected.dialect.delimiter, '\t');
+  EXPECT_TRUE(success);
+  EXPECT_TRUE(detected.success());
+  EXPECT_EQ(detected.dialect.delimiter, '\t');
 }
 
 TEST_F(ParseAutoTest, ParseAutoNullDetectedResult) {
-    // Test with nullptr for detected result
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  // Test with nullptr for detected result
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_auto(buf.data(), idx, content.size(), errors, nullptr);
+  bool success =
+      parser.parse_auto(buf.data(), idx, content.size(), errors, nullptr);
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // ============================================================================
@@ -570,106 +639,107 @@ TEST_F(ParseAutoTest, ParseAutoNullDetectedResult) {
 
 class EdgeCaseTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(EdgeCaseTest, ZeroThreadsSpeculate) {
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 0);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 0);
 
-    bool success = parser.parse_speculate(buf.data(), idx, content.size());
+  bool success = parser.parse_speculate(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(EdgeCaseTest, ZeroThreadsTwoPass) {
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 0);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 0);
 
-    bool success = parser.parse_two_pass(buf.data(), idx, content.size());
+  bool success = parser.parse_two_pass(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(EdgeCaseTest, ZeroThreadsTwoPassWithErrors) {
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 0);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 0);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_two_pass_with_errors(buf.data(), idx, content.size(), errors);
+  bool success = parser.parse_two_pass_with_errors(buf.data(), idx,
+                                                   content.size(), errors);
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(EdgeCaseTest, EmptyInputTwoPassWithErrors) {
-    std::vector<uint8_t> buf(LIBVROOM_PADDING, 0);
+  std::vector<uint8_t> buf(LIBVROOM_PADDING, 0);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(0, 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(0, 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_two_pass_with_errors(buf.data(), idx, 0, errors);
+  bool success = parser.parse_two_pass_with_errors(buf.data(), idx, 0, errors);
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(EdgeCaseTest, VerySmallChunksMultiThreaded) {
-    // File too small for multi-threading
-    std::string content = "a\n";
-    auto buf = makeBuffer(content);
+  // File too small for multi-threading
+  std::string content = "a\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 16);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 16);
 
-    bool success = parser.parse_speculate(buf.data(), idx, content.size());
+  bool success = parser.parse_speculate(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
-    // Should fall back to single thread
-    EXPECT_EQ(idx.n_threads, 1);
+  EXPECT_TRUE(success);
+  // Should fall back to single thread
+  EXPECT_EQ(idx.n_threads, 1);
 }
 
 TEST_F(EdgeCaseTest, ChunkBoundaryExactly64Bytes) {
-    // Create content that's exactly 64 bytes
-    std::string content(64, 'x');
-    content[63] = '\n';
-    auto buf = makeBuffer(content);
+  // Create content that's exactly 64 bytes
+  std::string content(64, 'x');
+  content[63] = '\n';
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size());
+  bool success = parser.parse(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(EdgeCaseTest, ChunkBoundaryExactly128Bytes) {
-    // Create content that's exactly 128 bytes (2 SIMD blocks)
-    std::string content;
-    for (int i = 0; i < 8; i++) {
-        content += "1234567890123456";  // 16 bytes each
-    }
-    content[127] = '\n';
-    auto buf = makeBuffer(content);
+  // Create content that's exactly 128 bytes (2 SIMD blocks)
+  std::string content;
+  for (int i = 0; i < 8; i++) {
+    content += "1234567890123456"; // 16 bytes each
+  }
+  content[127] = '\n';
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size());
+  bool success = parser.parse(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // ============================================================================
@@ -677,130 +747,120 @@ TEST_F(EdgeCaseTest, ChunkBoundaryExactly128Bytes) {
 // ============================================================================
 
 TEST(HelperFunctionTest, GetContextNormal) {
-    std::string content = "abcdefghijklmnopqrstuvwxyz";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 10, 5);
+  std::string content = "abcdefghijklmnopqrstuvwxyz";
+  auto ctx = two_pass::get_context(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size(), 10, 5);
 
-    // Context around position 10 with 5 chars before/after
-    EXPECT_FALSE(ctx.empty());
-    EXPECT_LE(ctx.size(), 11);  // 5 + 1 + 5
+  // Context around position 10 with 5 chars before/after
+  EXPECT_FALSE(ctx.empty());
+  EXPECT_LE(ctx.size(), 11); // 5 + 1 + 5
 }
 
 TEST(HelperFunctionTest, GetContextNearStart) {
-    std::string content = "abcdefghij";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 2, 5);
+  std::string content = "abcdefghij";
+  auto ctx = two_pass::get_context(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size(), 2, 5);
 
-    EXPECT_FALSE(ctx.empty());
-    EXPECT_TRUE(ctx.find('a') != std::string::npos);
+  EXPECT_FALSE(ctx.empty());
+  EXPECT_TRUE(ctx.find('a') != std::string::npos);
 }
 
 TEST(HelperFunctionTest, GetContextNearEnd) {
-    std::string content = "abcdefghij";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 8, 5);
+  std::string content = "abcdefghij";
+  auto ctx = two_pass::get_context(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size(), 8, 5);
 
-    EXPECT_FALSE(ctx.empty());
-    EXPECT_TRUE(ctx.find('j') != std::string::npos);
+  EXPECT_FALSE(ctx.empty());
+  EXPECT_TRUE(ctx.find('j') != std::string::npos);
 }
 
 TEST(HelperFunctionTest, GetContextWithNewlines) {
-    std::string content = "abc\ndef\n";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 4, 5);
+  std::string content = "abc\ndef\n";
+  auto ctx = two_pass::get_context(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size(), 4, 5);
 
-    // Newlines should be escaped as \n
-    EXPECT_TRUE(ctx.find("\\n") != std::string::npos);
+  // Newlines should be escaped as \n
+  EXPECT_TRUE(ctx.find("\\n") != std::string::npos);
 }
 
 TEST(HelperFunctionTest, GetContextWithCarriageReturn) {
-    std::string content = "abc\r\ndef";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 4, 5);
+  std::string content = "abc\r\ndef";
+  auto ctx = two_pass::get_context(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size(), 4, 5);
 
-    // Carriage returns should be escaped as \r
-    EXPECT_TRUE(ctx.find("\\r") != std::string::npos);
+  // Carriage returns should be escaped as \r
+  EXPECT_TRUE(ctx.find("\\r") != std::string::npos);
 }
 
 TEST(HelperFunctionTest, GetContextEmpty) {
-    auto ctx = two_pass::get_context(nullptr, 0, 0, 5);
-    EXPECT_TRUE(ctx.empty());
+  auto ctx = two_pass::get_context(nullptr, 0, 0, 5);
+  EXPECT_TRUE(ctx.empty());
 }
 
 TEST(HelperFunctionTest, GetContextPosOutOfBounds) {
-    std::string content = "abcde";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 100, 5);
+  std::string content = "abcde";
+  auto ctx =
+      two_pass::get_context(reinterpret_cast<const uint8_t *>(content.data()),
+                            content.size(), 100, 5);
 
-    // Should handle gracefully
-    EXPECT_FALSE(ctx.empty());
+  // Should handle gracefully
+  EXPECT_FALSE(ctx.empty());
 }
 
 TEST(HelperFunctionTest, GetLineColumnSimple) {
-    std::string content = "abc\ndef\nghi";
-    size_t line, col;
+  std::string content = "abc\ndef\nghi";
+  size_t line, col;
 
-    two_pass::get_line_column(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 0, line, col);
-    EXPECT_EQ(line, 1);
-    EXPECT_EQ(col, 1);
+  two_pass::get_line_column(reinterpret_cast<const uint8_t *>(content.data()),
+                            content.size(), 0, line, col);
+  EXPECT_EQ(line, 1);
+  EXPECT_EQ(col, 1);
 }
 
 TEST(HelperFunctionTest, GetLineColumnSecondLine) {
-    std::string content = "abc\ndef\nghi";
-    size_t line, col;
+  std::string content = "abc\ndef\nghi";
+  size_t line, col;
 
-    // Position 5 is 'e' on second line
-    two_pass::get_line_column(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 5, line, col);
-    EXPECT_EQ(line, 2);
-    EXPECT_EQ(col, 2);
+  // Position 5 is 'e' on second line
+  two_pass::get_line_column(reinterpret_cast<const uint8_t *>(content.data()),
+                            content.size(), 5, line, col);
+  EXPECT_EQ(line, 2);
+  EXPECT_EQ(col, 2);
 }
 
 TEST(HelperFunctionTest, GetLineColumnThirdLine) {
-    std::string content = "abc\ndef\nghi";
-    size_t line, col;
+  std::string content = "abc\ndef\nghi";
+  size_t line, col;
 
-    // Position 8 is 'g' on third line
-    two_pass::get_line_column(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 8, line, col);
-    EXPECT_EQ(line, 3);
-    EXPECT_EQ(col, 1);
+  // Position 8 is 'g' on third line
+  two_pass::get_line_column(reinterpret_cast<const uint8_t *>(content.data()),
+                            content.size(), 8, line, col);
+  EXPECT_EQ(line, 3);
+  EXPECT_EQ(col, 1);
 }
 
 TEST(HelperFunctionTest, GetLineColumnWithCRLF) {
-    std::string content = "ab\r\ncd";
-    size_t line, col;
+  std::string content = "ab\r\ncd";
+  size_t line, col;
 
-    // Position 4 is 'c' on second line
-    two_pass::get_line_column(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 4, line, col);
-    EXPECT_EQ(line, 2);
-    // CR doesn't count as column increment
-    EXPECT_EQ(col, 1);
+  // Position 4 is 'c' on second line
+  two_pass::get_line_column(reinterpret_cast<const uint8_t *>(content.data()),
+                            content.size(), 4, line, col);
+  EXPECT_EQ(line, 2);
+  // CR doesn't count as column increment
+  EXPECT_EQ(col, 1);
 }
 
 TEST(HelperFunctionTest, GetLineColumnOutOfBounds) {
-    std::string content = "abc";
-    size_t line, col;
+  std::string content = "abc";
+  size_t line, col;
 
-    two_pass::get_line_column(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 100, line, col);
+  two_pass::get_line_column(reinterpret_cast<const uint8_t *>(content.data()),
+                            content.size(), 100, line, col);
 
-    // Should handle gracefully, counting all content
-    EXPECT_EQ(line, 1);
-    EXPECT_EQ(col, 4);  // After all 3 chars
+  // Should handle gracefully, counting all content
+  EXPECT_EQ(line, 1);
+  EXPECT_EQ(col, 4); // After all 3 chars
 }
 
 // ============================================================================
@@ -808,75 +868,76 @@ TEST(HelperFunctionTest, GetLineColumnOutOfBounds) {
 // ============================================================================
 
 TEST(StateMachineTest, QuotedState) {
-    // Test all transitions for quoted_state
-    auto r1 = two_pass::quoted_state(two_pass::RECORD_START);
-    EXPECT_EQ(r1.state, two_pass::QUOTED_FIELD);
-    EXPECT_EQ(r1.error, ErrorCode::NONE);
+  // Test all transitions for quoted_state
+  auto r1 = two_pass::quoted_state(two_pass::RECORD_START);
+  EXPECT_EQ(r1.state, two_pass::QUOTED_FIELD);
+  EXPECT_EQ(r1.error, ErrorCode::NONE);
 
-    auto r2 = two_pass::quoted_state(two_pass::FIELD_START);
-    EXPECT_EQ(r2.state, two_pass::QUOTED_FIELD);
+  auto r2 = two_pass::quoted_state(two_pass::FIELD_START);
+  EXPECT_EQ(r2.state, two_pass::QUOTED_FIELD);
 
-    auto r3 = two_pass::quoted_state(two_pass::UNQUOTED_FIELD);
-    EXPECT_EQ(r3.state, two_pass::UNQUOTED_FIELD);
-    EXPECT_EQ(r3.error, ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
+  auto r3 = two_pass::quoted_state(two_pass::UNQUOTED_FIELD);
+  EXPECT_EQ(r3.state, two_pass::UNQUOTED_FIELD);
+  EXPECT_EQ(r3.error, ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
 
-    auto r4 = two_pass::quoted_state(two_pass::QUOTED_FIELD);
-    EXPECT_EQ(r4.state, two_pass::QUOTED_END);
+  auto r4 = two_pass::quoted_state(two_pass::QUOTED_FIELD);
+  EXPECT_EQ(r4.state, two_pass::QUOTED_END);
 
-    auto r5 = two_pass::quoted_state(two_pass::QUOTED_END);
-    EXPECT_EQ(r5.state, two_pass::QUOTED_FIELD);  // Escaped quote
+  auto r5 = two_pass::quoted_state(two_pass::QUOTED_END);
+  EXPECT_EQ(r5.state, two_pass::QUOTED_FIELD); // Escaped quote
 }
 
 TEST(StateMachineTest, CommaState) {
-    auto r1 = two_pass::comma_state(two_pass::RECORD_START);
-    EXPECT_EQ(r1.state, two_pass::FIELD_START);
+  auto r1 = two_pass::comma_state(two_pass::RECORD_START);
+  EXPECT_EQ(r1.state, two_pass::FIELD_START);
 
-    auto r2 = two_pass::comma_state(two_pass::FIELD_START);
-    EXPECT_EQ(r2.state, two_pass::FIELD_START);
+  auto r2 = two_pass::comma_state(two_pass::FIELD_START);
+  EXPECT_EQ(r2.state, two_pass::FIELD_START);
 
-    auto r3 = two_pass::comma_state(two_pass::UNQUOTED_FIELD);
-    EXPECT_EQ(r3.state, two_pass::FIELD_START);
+  auto r3 = two_pass::comma_state(two_pass::UNQUOTED_FIELD);
+  EXPECT_EQ(r3.state, two_pass::FIELD_START);
 
-    auto r4 = two_pass::comma_state(two_pass::QUOTED_FIELD);
-    EXPECT_EQ(r4.state, two_pass::QUOTED_FIELD);  // Comma inside quotes
+  auto r4 = two_pass::comma_state(two_pass::QUOTED_FIELD);
+  EXPECT_EQ(r4.state, two_pass::QUOTED_FIELD); // Comma inside quotes
 
-    auto r5 = two_pass::comma_state(two_pass::QUOTED_END);
-    EXPECT_EQ(r5.state, two_pass::FIELD_START);
+  auto r5 = two_pass::comma_state(two_pass::QUOTED_END);
+  EXPECT_EQ(r5.state, two_pass::FIELD_START);
 }
 
 TEST(StateMachineTest, NewlineState) {
-    auto r1 = two_pass::newline_state(two_pass::RECORD_START);
-    EXPECT_EQ(r1.state, two_pass::RECORD_START);
+  auto r1 = two_pass::newline_state(two_pass::RECORD_START);
+  EXPECT_EQ(r1.state, two_pass::RECORD_START);
 
-    auto r2 = two_pass::newline_state(two_pass::FIELD_START);
-    EXPECT_EQ(r2.state, two_pass::RECORD_START);
+  auto r2 = two_pass::newline_state(two_pass::FIELD_START);
+  EXPECT_EQ(r2.state, two_pass::RECORD_START);
 
-    auto r3 = two_pass::newline_state(two_pass::UNQUOTED_FIELD);
-    EXPECT_EQ(r3.state, two_pass::RECORD_START);
+  auto r3 = two_pass::newline_state(two_pass::UNQUOTED_FIELD);
+  EXPECT_EQ(r3.state, two_pass::RECORD_START);
 
-    auto r4 = two_pass::newline_state(two_pass::QUOTED_FIELD);
-    EXPECT_EQ(r4.state, two_pass::QUOTED_FIELD);  // Newline inside quotes
+  auto r4 = two_pass::newline_state(two_pass::QUOTED_FIELD);
+  EXPECT_EQ(r4.state, two_pass::QUOTED_FIELD); // Newline inside quotes
 
-    auto r5 = two_pass::newline_state(two_pass::QUOTED_END);
-    EXPECT_EQ(r5.state, two_pass::RECORD_START);
+  auto r5 = two_pass::newline_state(two_pass::QUOTED_END);
+  EXPECT_EQ(r5.state, two_pass::RECORD_START);
 }
 
 TEST(StateMachineTest, OtherState) {
-    auto r1 = two_pass::other_state(two_pass::RECORD_START);
-    EXPECT_EQ(r1.state, two_pass::UNQUOTED_FIELD);
+  auto r1 = two_pass::other_state(two_pass::RECORD_START);
+  EXPECT_EQ(r1.state, two_pass::UNQUOTED_FIELD);
 
-    auto r2 = two_pass::other_state(two_pass::FIELD_START);
-    EXPECT_EQ(r2.state, two_pass::UNQUOTED_FIELD);
+  auto r2 = two_pass::other_state(two_pass::FIELD_START);
+  EXPECT_EQ(r2.state, two_pass::UNQUOTED_FIELD);
 
-    auto r3 = two_pass::other_state(two_pass::UNQUOTED_FIELD);
-    EXPECT_EQ(r3.state, two_pass::UNQUOTED_FIELD);
+  auto r3 = two_pass::other_state(two_pass::UNQUOTED_FIELD);
+  EXPECT_EQ(r3.state, two_pass::UNQUOTED_FIELD);
 
-    auto r4 = two_pass::other_state(two_pass::QUOTED_FIELD);
-    EXPECT_EQ(r4.state, two_pass::QUOTED_FIELD);
+  auto r4 = two_pass::other_state(two_pass::QUOTED_FIELD);
+  EXPECT_EQ(r4.state, two_pass::QUOTED_FIELD);
 
-    auto r5 = two_pass::other_state(two_pass::QUOTED_END);
-    EXPECT_EQ(r5.state, two_pass::UNQUOTED_FIELD);
-    EXPECT_EQ(r5.error, ErrorCode::INVALID_QUOTE_ESCAPE);  // Invalid char after quote
+  auto r5 = two_pass::other_state(two_pass::QUOTED_END);
+  EXPECT_EQ(r5.state, two_pass::UNQUOTED_FIELD);
+  EXPECT_EQ(r5.error,
+            ErrorCode::INVALID_QUOTE_ESCAPE); // Invalid char after quote
 }
 
 // ============================================================================
@@ -884,22 +945,22 @@ TEST(StateMachineTest, OtherState) {
 // ============================================================================
 
 TEST(IsOtherTest, Basic) {
-    EXPECT_FALSE(two_pass::is_other(','));
-    EXPECT_FALSE(two_pass::is_other('\n'));
-    EXPECT_FALSE(two_pass::is_other('"'));
-    EXPECT_TRUE(two_pass::is_other('a'));
-    EXPECT_TRUE(two_pass::is_other('1'));
-    EXPECT_TRUE(two_pass::is_other(' '));
+  EXPECT_FALSE(two_pass::is_other(','));
+  EXPECT_FALSE(two_pass::is_other('\n'));
+  EXPECT_FALSE(two_pass::is_other('"'));
+  EXPECT_TRUE(two_pass::is_other('a'));
+  EXPECT_TRUE(two_pass::is_other('1'));
+  EXPECT_TRUE(two_pass::is_other(' '));
 }
 
 TEST(IsOtherTest, CustomDelimiter) {
-    EXPECT_FALSE(two_pass::is_other(';', ';', '"'));
-    EXPECT_TRUE(two_pass::is_other(',', ';', '"'));
+  EXPECT_FALSE(two_pass::is_other(';', ';', '"'));
+  EXPECT_TRUE(two_pass::is_other(',', ';', '"'));
 }
 
 TEST(IsOtherTest, CustomQuote) {
-    EXPECT_FALSE(two_pass::is_other('\'', ',', '\''));
-    EXPECT_TRUE(two_pass::is_other('"', ',', '\''));
+  EXPECT_FALSE(two_pass::is_other('\'', ',', '\''));
+  EXPECT_TRUE(two_pass::is_other('"', ',', '\''));
 }
 
 // ============================================================================
@@ -908,55 +969,59 @@ TEST(IsOtherTest, CustomQuote) {
 
 class FirstPassSpeculateTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(FirstPassSpeculateTest, UnquotedContext) {
-    std::string content = "abc,def\nghi,jkl\n";
-    auto buf = makeBuffer(content);
+  std::string content = "abc,def\nghi,jkl\n";
+  auto buf = makeBuffer(content);
 
-    // Start speculating from position 0
-    auto stats = two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
+  // Start speculating from position 0
+  auto stats =
+      two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
 
-    // Should find the first newline
-    EXPECT_EQ(stats.first_even_nl, 7);
+  // Should find the first newline
+  EXPECT_EQ(stats.first_even_nl, 7);
 }
 
 TEST_F(FirstPassSpeculateTest, NoNewline) {
-    std::string content = "abc,def,ghi";
-    auto buf = makeBuffer(content);
+  std::string content = "abc,def,ghi";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
+  auto stats =
+      two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
 
-    // No newline in content
-    EXPECT_EQ(stats.first_even_nl, null_pos);
-    EXPECT_EQ(stats.first_odd_nl, null_pos);
+  // No newline in content
+  EXPECT_EQ(stats.first_even_nl, null_pos);
+  EXPECT_EQ(stats.first_odd_nl, null_pos);
 }
 
 TEST_F(FirstPassSpeculateTest, WithCRLineEnding) {
-    // Test CR-only line endings
-    std::string content = "abc,def\rghi,jkl\r";
-    auto buf = makeBuffer(content);
+  // Test CR-only line endings
+  std::string content = "abc,def\rghi,jkl\r";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
+  auto stats =
+      two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
 
-    // Should find the first CR as newline
-    EXPECT_EQ(stats.first_even_nl, 7);
+  // Should find the first CR as newline
+  EXPECT_EQ(stats.first_even_nl, 7);
 }
 
 TEST_F(FirstPassSpeculateTest, WithCRLFLineEnding) {
-    // Test CRLF line endings - CR followed by LF should use LF
-    std::string content = "abc,def\r\nghi,jkl\r\n";
-    auto buf = makeBuffer(content);
+  // Test CRLF line endings - CR followed by LF should use LF
+  std::string content = "abc,def\r\nghi,jkl\r\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
+  auto stats =
+      two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
 
-    // Should skip CR and find LF at position 8 as newline
-    EXPECT_EQ(stats.first_even_nl, 8);
+  // Should skip CR and find LF at position 8 as newline
+  EXPECT_EQ(stats.first_even_nl, 8);
 }
 
 // ============================================================================
@@ -965,39 +1030,39 @@ TEST_F(FirstPassSpeculateTest, WithCRLFLineEnding) {
 
 class ParseValidateTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(ParseValidateTest, ValidCSV) {
-    std::string content = "a,b,c\n1,2,3\n4,5,6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n4,5,6\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_validate(buf.data(), idx, content.size(), errors);
+  bool success = parser.parse_validate(buf.data(), idx, content.size(), errors);
 
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 TEST_F(ParseValidateTest, WithDialect) {
-    std::string content = "a;b;c\n1;2;3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a;b;c\n1;2;3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_validate(buf.data(), idx, content.size(), errors,
-                                         Dialect::semicolon());
+  bool success = parser.parse_validate(buf.data(), idx, content.size(), errors,
+                                       Dialect::semicolon());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // ============================================================================
@@ -1006,40 +1071,40 @@ TEST_F(ParseValidateTest, WithDialect) {
 
 class MultiThreadedFallbackTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(MultiThreadedFallbackTest, SpeculateFallsBackOnNullPos) {
-    // Create content where multi-threaded chunking would fail to find valid split points
-    // This happens when chunks are too small to contain newlines
-    std::string content = "abcdef\n";  // Very short content
-    auto buf = makeBuffer(content);
+  // Create content where multi-threaded chunking would fail to find valid split
+  // points This happens when chunks are too small to contain newlines
+  std::string content = "abcdef\n"; // Very short content
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);  // Try to use 4 threads
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4); // Try to use 4 threads
 
-    bool success = parser.parse_speculate(buf.data(), idx, content.size());
+  bool success = parser.parse_speculate(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
-    // Should fall back to single thread due to small chunk size
-    EXPECT_EQ(idx.n_threads, 1);
+  EXPECT_TRUE(success);
+  // Should fall back to single thread due to small chunk size
+  EXPECT_EQ(idx.n_threads, 1);
 }
 
 TEST_F(MultiThreadedFallbackTest, TwoPassFallsBackOnNullPos) {
-    std::string content = "abcdef\n";
-    auto buf = makeBuffer(content);
+  std::string content = "abcdef\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
 
-    bool success = parser.parse_two_pass(buf.data(), idx, content.size());
+  bool success = parser.parse_two_pass(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
-    EXPECT_EQ(idx.n_threads, 1);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(idx.n_threads, 1);
 }
 
 // ============================================================================
@@ -1048,60 +1113,61 @@ TEST_F(MultiThreadedFallbackTest, TwoPassFallsBackOnNullPos) {
 
 class DialectIntegrationTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(DialectIntegrationTest, ParseWithTSVDialect) {
-    std::string content = "a\tb\tc\n1\t2\t3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a\tb\tc\n1\t2\t3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size(), Dialect::tsv());
+  bool success = parser.parse(buf.data(), idx, content.size(), Dialect::tsv());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(DialectIntegrationTest, ParseWithSemicolonDialect) {
-    std::string content = "a;b;c\n1;2;3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a;b;c\n1;2;3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size(), Dialect::semicolon());
+  bool success =
+      parser.parse(buf.data(), idx, content.size(), Dialect::semicolon());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(DialectIntegrationTest, ParseWithPipeDialect) {
-    std::string content = "a|b|c\n1|2|3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a|b|c\n1|2|3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size(), Dialect::pipe());
+  bool success = parser.parse(buf.data(), idx, content.size(), Dialect::pipe());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(DialectIntegrationTest, ParseWithSingleQuoteDialect) {
-    std::string content = "'a','b','c'\n'1','2','3'\n";
-    auto buf = makeBuffer(content);
+  std::string content = "'a','b','c'\n'1','2','3'\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    Dialect dialect{',', '\'', '\'', true, Dialect::LineEnding::UNKNOWN};
-    bool success = parser.parse(buf.data(), idx, content.size(), dialect);
+  Dialect dialect{',', '\'', '\'', true, Dialect::LineEnding::UNKNOWN};
+  bool success = parser.parse(buf.data(), idx, content.size(), dialect);
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // ============================================================================
@@ -1110,96 +1176,100 @@ TEST_F(DialectIntegrationTest, ParseWithSingleQuoteDialect) {
 
 class SecondPassThrowingTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 TEST_F(SecondPassThrowingTest, ThrowsOnQuoteInUnquotedField) {
-    std::string content = "a,bad\"quote,c\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,bad\"quote,c\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    EXPECT_THROW({
+  EXPECT_THROW(
+      {
         two_pass::second_pass_chunk_throwing(buf.data(), 0, content.size(),
-                                              &idx, 0, ',', '"');
-    }, std::runtime_error);
+                                             &idx, 0, ',', '"');
+      },
+      std::runtime_error);
 }
 
 TEST_F(SecondPassThrowingTest, ThrowsOnInvalidQuoteEscape) {
-    std::string content = "\"test\"invalid,b\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\"test\"invalid,b\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    EXPECT_THROW({
+  EXPECT_THROW(
+      {
         two_pass::second_pass_chunk_throwing(buf.data(), 0, content.size(),
-                                              &idx, 0, ',', '"');
-    }, std::runtime_error);
+                                             &idx, 0, ',', '"');
+      },
+      std::runtime_error);
 }
 
 TEST_F(SecondPassThrowingTest, ValidCSVDoesNotThrow) {
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    EXPECT_NO_THROW({
-        two_pass::second_pass_chunk_throwing(buf.data(), 0, content.size(),
-                                              &idx, 0, ',', '"');
-    });
+  EXPECT_NO_THROW({
+    two_pass::second_pass_chunk_throwing(buf.data(), 0, content.size(), &idx, 0,
+                                         ',', '"');
+  });
 }
 
 TEST_F(SecondPassThrowingTest, CRLineEndingDoesNotThrow) {
-    // Test CR-only line endings
-    std::string content = "a,b,c\r1,2,3\r";
-    auto buf = makeBuffer(content);
+  // Test CR-only line endings
+  std::string content = "a,b,c\r1,2,3\r";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    EXPECT_NO_THROW({
-        auto n_indexes = two_pass::second_pass_chunk_throwing(buf.data(), 0, content.size(),
-                                              &idx, 0, ',', '"');
-        // Should have found indexes at each comma and CR
-        EXPECT_GT(n_indexes, 0);
-    });
+  EXPECT_NO_THROW({
+    auto n_indexes = two_pass::second_pass_chunk_throwing(
+        buf.data(), 0, content.size(), &idx, 0, ',', '"');
+    // Should have found indexes at each comma and CR
+    EXPECT_GT(n_indexes, 0);
+  });
 }
 
 TEST_F(SecondPassThrowingTest, CRLFLineEndingDoesNotThrow) {
-    // Test CRLF line endings - CR followed by LF
-    std::string content = "a,b,c\r\n1,2,3\r\n";
-    auto buf = makeBuffer(content);
+  // Test CRLF line endings - CR followed by LF
+  std::string content = "a,b,c\r\n1,2,3\r\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    EXPECT_NO_THROW({
-        auto n_indexes = two_pass::second_pass_chunk_throwing(buf.data(), 0, content.size(),
-                                              &idx, 0, ',', '"');
-        EXPECT_GT(n_indexes, 0);
-    });
+  EXPECT_NO_THROW({
+    auto n_indexes = two_pass::second_pass_chunk_throwing(
+        buf.data(), 0, content.size(), &idx, 0, ',', '"');
+    EXPECT_GT(n_indexes, 0);
+  });
 }
 
 TEST_F(SecondPassThrowingTest, CRInQuotedFieldDoesNotThrow) {
-    // Test CR inside quoted field - should not be treated as line ending
-    std::string content = "\"a\rb\",c\r1,2,3\r";
-    auto buf = makeBuffer(content);
+  // Test CR inside quoted field - should not be treated as line ending
+  std::string content = "\"a\rb\",c\r1,2,3\r";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    EXPECT_NO_THROW({
-        auto n_indexes = two_pass::second_pass_chunk_throwing(buf.data(), 0, content.size(),
-                                              &idx, 0, ',', '"');
-        EXPECT_GT(n_indexes, 0);
-    });
+  EXPECT_NO_THROW({
+    auto n_indexes = two_pass::second_pass_chunk_throwing(
+        buf.data(), 0, content.size(), &idx, 0, ',', '"');
+    EXPECT_GT(n_indexes, 0);
+  });
 }
 
 // ============================================================================
@@ -1208,215 +1278,229 @@ TEST_F(SecondPassThrowingTest, CRInQuotedFieldDoesNotThrow) {
 
 class StateMachineEdgeCaseTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test all valid state transitions in sequence
 TEST_F(StateMachineEdgeCaseTest, AllValidTransitions) {
-    // Create CSV that exercises all valid state transitions
-    // RECORD_START -> '"' -> QUOTED_FIELD -> '"' -> QUOTED_END -> ',' -> FIELD_START
-    // FIELD_START -> 'x' -> UNQUOTED_FIELD -> ',' -> FIELD_START -> '\n' -> RECORD_START
-    std::string content = "\"quoted\",unquoted\n";
-    auto buf = makeBuffer(content);
+  // Create CSV that exercises all valid state transitions
+  // RECORD_START -> '"' -> QUOTED_FIELD -> '"' -> QUOTED_END -> ',' ->
+  // FIELD_START FIELD_START -> 'x' -> UNQUOTED_FIELD -> ',' -> FIELD_START ->
+  // '\n' -> RECORD_START
+  std::string content = "\"quoted\",unquoted\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // Test escaped quote transition (QUOTED_END -> '"' -> QUOTED_FIELD)
 TEST_F(StateMachineEdgeCaseTest, EscapedQuoteTransition) {
-    std::string content = "\"he\"\"llo\"\n";  // Escaped quote inside quoted field
-    auto buf = makeBuffer(content);
+  std::string content = "\"he\"\"llo\"\n"; // Escaped quote inside quoted field
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // Test newline inside quoted field (should not end record)
 TEST_F(StateMachineEdgeCaseTest, NewlineInQuotedField) {
-    std::string content = "\"line1\nline2\",b\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\"line1\nline2\",b\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // Test comma inside quoted field (should not separate fields)
 TEST_F(StateMachineEdgeCaseTest, CommaInQuotedField) {
-    std::string content = "\"a,b,c\",d\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\"a,b,c\",d\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // Test quote error in unquoted field
 TEST_F(StateMachineEdgeCaseTest, QuoteErrorInUnquotedField) {
-    std::string content = "abc\"def,ghi\n";  // Quote in middle of unquoted field
-    auto buf = makeBuffer(content);
+  std::string content = "abc\"def,ghi\n"; // Quote in middle of unquoted field
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(errors.has_errors());
-    EXPECT_EQ(errors.errors()[0].code, ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(errors.has_errors());
+  EXPECT_EQ(errors.errors()[0].code, ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
 }
 
 // Test invalid character after closing quote
 TEST_F(StateMachineEdgeCaseTest, InvalidCharAfterClosingQuote) {
-    std::string content = "\"valid\"x,b\n";  // 'x' after closing quote is invalid
-    auto buf = makeBuffer(content);
+  std::string content = "\"valid\"x,b\n"; // 'x' after closing quote is invalid
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(errors.has_errors());
-    EXPECT_EQ(errors.errors()[0].code, ErrorCode::INVALID_QUOTE_ESCAPE);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(errors.has_errors());
+  EXPECT_EQ(errors.errors()[0].code, ErrorCode::INVALID_QUOTE_ESCAPE);
 }
 
 // Test empty fields at various positions
 TEST_F(StateMachineEdgeCaseTest, EmptyFieldsAtStart) {
-    std::string content = ",b,c\n";  // Empty first field
-    auto buf = makeBuffer(content);
+  std::string content = ",b,c\n"; // Empty first field
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 TEST_F(StateMachineEdgeCaseTest, EmptyFieldsAtEnd) {
-    std::string content = "a,b,\n";  // Empty last field
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,\n"; // Empty last field
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
 }
 
 TEST_F(StateMachineEdgeCaseTest, ConsecutiveEmptyFields) {
-    std::string content = "a,,,,b\n";  // Multiple consecutive empty fields
-    auto buf = makeBuffer(content);
+  std::string content = "a,,,,b\n"; // Multiple consecutive empty fields
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
 }
 
 // Test empty quoted fields
 TEST_F(StateMachineEdgeCaseTest, EmptyQuotedField) {
-    std::string content = "\"\",b,c\n";  // Empty quoted field
-    auto buf = makeBuffer(content);
+  std::string content = "\"\",b,c\n"; // Empty quoted field
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // Test null byte detection
 TEST_F(StateMachineEdgeCaseTest, NullByteDetection) {
-    // Create content with explicit null byte
-    std::vector<uint8_t> buf(32 + LIBVROOM_PADDING, 0);
-    const char* data = "a,b";
-    std::memcpy(buf.data(), data, 3);
-    buf[3] = '\0';  // Null byte
-    const char* rest = ",c\n";
-    std::memcpy(buf.data() + 4, rest, 3);
-    size_t content_len = 7;  // "a,b\0,c\n"
+  // Create content with explicit null byte
+  std::vector<uint8_t> buf(32 + LIBVROOM_PADDING, 0);
+  const char *data = "a,b";
+  std::memcpy(buf.data(), data, 3);
+  buf[3] = '\0'; // Null byte
+  const char *rest = ",c\n";
+  std::memcpy(buf.data() + 4, rest, 3);
+  size_t content_len = 7; // "a,b\0,c\n"
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content_len, 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content_len, 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content_len, errors);
-    EXPECT_TRUE(errors.has_errors());
-    EXPECT_EQ(errors.errors()[0].code, ErrorCode::NULL_BYTE);
+  bool success = parser.parse_with_errors(buf.data(), idx, content_len, errors);
+  EXPECT_TRUE(errors.has_errors());
+  EXPECT_EQ(errors.errors()[0].code, ErrorCode::NULL_BYTE);
 }
 
 // Test CR-only line endings with parse_with_errors (uses second_pass_chunk)
 TEST_F(StateMachineEdgeCaseTest, CRLineEndingsWithErrors) {
-    // Test CR-only line endings
-    std::string content = "a,b,c\r1,2,3\r4,5,6\r";
-    auto buf = makeBuffer(content);
+  // Test CR-only line endings
+  std::string content = "a,b,c\r1,2,3\r4,5,6\r";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // Test CRLF line endings with parse_with_errors
 TEST_F(StateMachineEdgeCaseTest, CRLFLineEndingsWithErrors) {
-    // Test CRLF line endings
-    std::string content = "a,b,c\r\n1,2,3\r\n4,5,6\r\n";
-    auto buf = makeBuffer(content);
+  // Test CRLF line endings
+  std::string content = "a,b,c\r\n1,2,3\r\n4,5,6\r\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // Test CR inside quoted field with parse_with_errors
 TEST_F(StateMachineEdgeCaseTest, CRInQuotedFieldWithErrors) {
-    // CR inside quoted field should not end the record
-    std::string content = "\"line1\rline2\",b\r";
-    auto buf = makeBuffer(content);
+  // CR inside quoted field should not end the record
+  std::string content = "\"line1\rline2\",b\r";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
-    EXPECT_TRUE(success);
-    EXPECT_FALSE(errors.has_errors());
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
 }
 
 // ============================================================================
@@ -1425,102 +1509,103 @@ TEST_F(StateMachineEdgeCaseTest, CRInQuotedFieldWithErrors) {
 
 class QuoteParityTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test first_pass_simd with no quotes (even quote count)
 TEST_F(QuoteParityTest, FirstPassSIMDNoQuotes) {
-    std::string content = "a,b,c\n1,2,3\n4,5,6\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n4,5,6\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_EQ(stats.n_quotes, 0);
-    EXPECT_NE(stats.first_even_nl, null_pos);  // Should find newline at even count
+  EXPECT_EQ(stats.n_quotes, 0);
+  EXPECT_NE(stats.first_even_nl, null_pos); // Should find newline at even count
 }
 
 // Test first_pass_simd with balanced quotes
 TEST_F(QuoteParityTest, FirstPassSIMDBalancedQuotes) {
-    std::string content = "\"a\",\"b\"\n\"c\",\"d\"\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\"a\",\"b\"\n\"c\",\"d\"\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_EQ(stats.n_quotes, 8);  // 4 pairs of quotes
-    EXPECT_NE(stats.first_even_nl, null_pos);  // Newlines at even quote count
+  EXPECT_EQ(stats.n_quotes, 8);             // 4 pairs of quotes
+  EXPECT_NE(stats.first_even_nl, null_pos); // Newlines at even quote count
 }
 
 // Test first_pass_simd with odd quote count at newline
 TEST_F(QuoteParityTest, FirstPassSIMDOddQuoteAtNewline) {
-    std::string content = "\"a\nb\",c\n";  // Newline inside quoted field
-    auto buf = makeBuffer(content);
+  std::string content = "\"a\nb\",c\n"; // Newline inside quoted field
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    // First newline is at odd quote count (inside quoted field)
-    EXPECT_EQ(stats.first_odd_nl, 2);  // Position of first \n
+  // First newline is at odd quote count (inside quoted field)
+  EXPECT_EQ(stats.first_odd_nl, 2); // Position of first \n
 }
 
 // Test first_pass_chunk with various quote patterns
 TEST_F(QuoteParityTest, FirstPassChunkMixedQuotes) {
-    std::string content = "unquoted,\"quoted\"\n\"quote\nspan\",end\n";
-    auto buf = makeBuffer(content);
+  std::string content = "unquoted,\"quoted\"\n\"quote\nspan\",end\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_chunk(buf.data(), 0, content.size(), '"');
 
-    EXPECT_GT(stats.n_quotes, 0);
+  EXPECT_GT(stats.n_quotes, 0);
 }
 
 // Test first_pass with quotes at chunk boundaries
 TEST_F(QuoteParityTest, QuotesAtChunkBoundary) {
-    // Create content where quotes appear near 64-byte boundaries
-    std::string content(64, 'x');  // 64 'x' characters
-    content[62] = '"';  // Quote near end of first chunk
-    content[63] = '\n';
-    content += "\"more\"\n";
-    auto buf = makeBuffer(content);
+  // Create content where quotes appear near 64-byte boundaries
+  std::string content(64, 'x'); // 64 'x' characters
+  content[62] = '"';            // Quote near end of first chunk
+  content[63] = '\n';
+  content += "\"more\"\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_GT(stats.n_quotes, 0);
+  EXPECT_GT(stats.n_quotes, 0);
 }
 
 // Test first_pass_simd with content exactly 64 bytes
 TEST_F(QuoteParityTest, Exactly64Bytes) {
-    std::string content(63, 'x');
-    content += '\n';  // Total 64 bytes
-    auto buf = makeBuffer(content);
+  std::string content(63, 'x');
+  content += '\n'; // Total 64 bytes
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_EQ(stats.first_even_nl, 63);
-    EXPECT_EQ(stats.n_quotes, 0);
+  EXPECT_EQ(stats.first_even_nl, 63);
+  EXPECT_EQ(stats.n_quotes, 0);
 }
 
-// Test first_pass_simd with content > 64 but < 128 bytes (one full + partial SIMD block)
+// Test first_pass_simd with content > 64 but < 128 bytes (one full + partial
+// SIMD block)
 TEST_F(QuoteParityTest, BetweenSIMDBlocks) {
-    std::string content(100, 'x');
-    content[50] = '\n';
-    content[99] = '\n';
-    auto buf = makeBuffer(content);
+  std::string content(100, 'x');
+  content[50] = '\n';
+  content[99] = '\n';
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '"');
 
-    EXPECT_EQ(stats.first_even_nl, 50);
+  EXPECT_EQ(stats.first_even_nl, 50);
 }
 
 // Test with custom quote character
 TEST_F(QuoteParityTest, CustomQuoteCharacter) {
-    std::string content = "'a','b'\n'c','d'\n";
-    auto buf = makeBuffer(content);
+  std::string content = "'a','b'\n'c','d'\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '\'');
+  auto stats = two_pass::first_pass_simd(buf.data(), 0, content.size(), '\'');
 
-    EXPECT_EQ(stats.n_quotes, 8);
+  EXPECT_EQ(stats.n_quotes, 8);
 }
 
 // ============================================================================
@@ -1529,128 +1614,129 @@ TEST_F(QuoteParityTest, CustomQuoteCharacter) {
 
 class MultiThreadedChunkTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test successful multi-threaded parsing
 TEST_F(MultiThreadedChunkTest, SuccessfulMultiThreadedParsing) {
-    // Create large content that will be split across multiple threads
-    std::string content;
-    for (int i = 0; i < 1000; i++) {
-        content += "field1,field2,field3\n";
-    }
-    auto buf = makeBuffer(content);
+  // Create large content that will be split across multiple threads
+  std::string content;
+  for (int i = 0; i < 1000; i++) {
+    content += "field1,field2,field3\n";
+  }
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    size_t num_threads = 4;
-    libvroom::index idx = parser.init(content.size(), num_threads);
+  two_pass parser;
+  size_t num_threads = 4;
+  libvroom::index idx = parser.init(content.size(), num_threads);
 
-    bool success = parser.parse(buf.data(), idx, content.size());
+  bool success = parser.parse(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // Test with quoted fields spanning potential chunk boundaries
 TEST_F(MultiThreadedChunkTest, QuotedFieldsSpanningChunks) {
-    std::string content;
-    for (int i = 0; i < 500; i++) {
-        content += "\"this is a quoted field with some content\",field2,field3\n";
-    }
-    auto buf = makeBuffer(content);
+  std::string content;
+  for (int i = 0; i < 500; i++) {
+    content += "\"this is a quoted field with some content\",field2,field3\n";
+  }
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
 
-    bool success = parser.parse_speculate(buf.data(), idx, content.size());
+  bool success = parser.parse_speculate(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // Test parse_two_pass with multi-threading
 TEST_F(MultiThreadedChunkTest, ParseTwoPassMultiThreaded) {
-    std::string content;
-    for (int i = 0; i < 1000; i++) {
-        content += "a,b,c,d,e\n";
-    }
-    auto buf = makeBuffer(content);
+  std::string content;
+  for (int i = 0; i < 1000; i++) {
+    content += "a,b,c,d,e\n";
+  }
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
 
-    bool success = parser.parse_two_pass(buf.data(), idx, content.size());
+  bool success = parser.parse_two_pass(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // Test parse_two_pass_with_errors multi-threaded
 TEST_F(MultiThreadedChunkTest, ParseTwoPassWithErrorsMultiThreaded) {
-    std::string content;
-    for (int i = 0; i < 500; i++) {
-        content += "field1,field2,field3\n";
-    }
-    auto buf = makeBuffer(content);
+  std::string content;
+  for (int i = 0; i < 500; i++) {
+    content += "field1,field2,field3\n";
+  }
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_two_pass_with_errors(buf.data(), idx, content.size(), errors);
+  bool success = parser.parse_two_pass_with_errors(buf.data(), idx,
+                                                   content.size(), errors);
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // Test with errors in different chunks
 TEST_F(MultiThreadedChunkTest, ErrorsInDifferentChunks) {
-    // Create content with errors that would appear in different chunks
-    std::string content;
-    for (int i = 0; i < 200; i++) {
-        content += "a,b,c\n";
-    }
-    content += "a,bad\"quote,c\n";  // Error in middle
-    for (int i = 0; i < 200; i++) {
-        content += "a,b,c\n";
-    }
-    auto buf = makeBuffer(content);
+  // Create content with errors that would appear in different chunks
+  std::string content;
+  for (int i = 0; i < 200; i++) {
+    content += "a,b,c\n";
+  }
+  content += "a,bad\"quote,c\n"; // Error in middle
+  for (int i = 0; i < 200; i++) {
+    content += "a,b,c\n";
+  }
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    parser.parse_two_pass_with_errors(buf.data(), idx, content.size(), errors);
+  parser.parse_two_pass_with_errors(buf.data(), idx, content.size(), errors);
 
-    EXPECT_TRUE(errors.has_errors());
+  EXPECT_TRUE(errors.has_errors());
 }
 
 // Test fallback to single thread when chunks are too small
 TEST_F(MultiThreadedChunkTest, FallbackOnSmallChunks) {
-    std::string content = "a,b\nc,d\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b\nc,d\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 16);  // Too many threads
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 16); // Too many threads
 
-    bool success = parser.parse_two_pass(buf.data(), idx, content.size());
+  bool success = parser.parse_two_pass(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
-    EXPECT_EQ(idx.n_threads, 1);  // Should fall back to single thread
+  EXPECT_TRUE(success);
+  EXPECT_EQ(idx.n_threads, 1); // Should fall back to single thread
 }
 
 // Test with file that has no valid split points
 TEST_F(MultiThreadedChunkTest, NoValidSplitPoints) {
-    // A single long quoted field with no newlines outside it
-    std::string content = "\"" + std::string(500, 'x') + "\"\n";
-    auto buf = makeBuffer(content);
+  // A single long quoted field with no newlines outside it
+  std::string content = "\"" + std::string(500, 'x') + "\"\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
 
-    bool success = parser.parse_speculate(buf.data(), idx, content.size());
+  bool success = parser.parse_speculate(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // ============================================================================
@@ -1659,133 +1745,133 @@ TEST_F(MultiThreadedChunkTest, NoValidSplitPoints) {
 
 class SIMDScalarFallbackTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test with content < 64 bytes (pure scalar)
 TEST_F(SIMDScalarFallbackTest, VerySmallFile) {
-    std::string content = "a\n";  // 2 bytes
-    auto buf = makeBuffer(content);
+  std::string content = "a\n"; // 2 bytes
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size());
+  bool success = parser.parse(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // Test with various sizes less than 64 bytes
 TEST_F(SIMDScalarFallbackTest, ScalarSizes) {
-    for (int size = 4; size < 64; size++) {  // Start from 4 to have valid CSV
-        std::string content(size - 1, 'x');
-        content += '\n';
-        auto buf = makeBuffer(content);
+  for (int size = 4; size < 64; size++) { // Start from 4 to have valid CSV
+    std::string content(size - 1, 'x');
+    content += '\n';
+    auto buf = makeBuffer(content);
 
-        two_pass parser;
-        // Allocate more space than content size for safety margin
-        libvroom::index idx = parser.init(content.size() + 64, 1);
+    two_pass parser;
+    // Allocate more space than content size for safety margin
+    libvroom::index idx = parser.init(content.size() + 64, 1);
 
-        bool success = parser.parse(buf.data(), idx, content.size());
-        EXPECT_TRUE(success) << "Failed for size " << size;
-    }
+    bool success = parser.parse(buf.data(), idx, content.size());
+    EXPECT_TRUE(success) << "Failed for size " << size;
+  }
 }
 
 // Test with exactly 64 bytes (one SIMD block)
 TEST_F(SIMDScalarFallbackTest, ExactlyOneSIMDBlock) {
-    std::string content(63, 'x');
-    content += '\n';
-    auto buf = makeBuffer(content);
+  std::string content(63, 'x');
+  content += '\n';
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size());
+  bool success = parser.parse(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 // Test with 64 * 2 bytes (two SIMD blocks)
 TEST_F(SIMDScalarFallbackTest, ExactlyTwoSIMDBlocks) {
-    std::string content(127, 'x');
+  std::string content(127, 'x');
+  content += '\n';
+  auto buf = makeBuffer(content);
+
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+
+  bool success = parser.parse(buf.data(), idx, content.size());
+
+  EXPECT_TRUE(success);
+}
+
+// Test with various remainder sizes (65-127 bytes)
+TEST_F(SIMDScalarFallbackTest, SIMDWithRemainders) {
+  for (int size = 65; size < 128; size++) {
+    std::string content(size - 1, 'x');
+    content += '\n';
+    auto buf = makeBuffer(content);
+
+    two_pass parser;
+    // Allocate more space for safety margin
+    libvroom::index idx = parser.init(content.size() + 64, 1);
+
+    bool success = parser.parse(buf.data(), idx, content.size());
+    EXPECT_TRUE(success) << "Failed for size " << size;
+  }
+}
+
+// Test with remainder that's exactly 1 byte
+TEST_F(SIMDScalarFallbackTest, SingleByteRemainder) {
+  std::string content(64, 'x');
+  content += '\n'; // 65 bytes total - 64 SIMD + 1 remainder
+  auto buf = makeBuffer(content);
+
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+
+  bool success = parser.parse(buf.data(), idx, content.size());
+
+  EXPECT_TRUE(success);
+}
+
+// Test with remainder that's 63 bytes
+TEST_F(SIMDScalarFallbackTest, MaxRemainder) {
+  std::string content(126, 'x');
+  content += '\n'; // 127 bytes - 64 SIMD + 63 remainder
+  auto buf = makeBuffer(content);
+
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+
+  bool success = parser.parse(buf.data(), idx, content.size());
+
+  EXPECT_TRUE(success);
+}
+
+// Test second_pass_simd directly with various lengths
+TEST_F(SIMDScalarFallbackTest, SecondPassSIMDVariousLengths) {
+  for (int size : {10, 32, 63, 64, 65, 100, 127, 128, 129, 200}) {
+    std::string content;
+    while (content.size() < static_cast<size_t>(size - 1)) {
+      content += "a,b,c\n";
+    }
+    content.resize(size - 1);
     content += '\n';
     auto buf = makeBuffer(content);
 
     two_pass parser;
     libvroom::index idx = parser.init(content.size(), 1);
 
-    bool success = parser.parse(buf.data(), idx, content.size());
+    auto n_indexes = two_pass::second_pass_simd(buf.data(), 0, content.size(),
+                                                &idx, 0, ',', '"');
 
-    EXPECT_TRUE(success);
-}
-
-// Test with various remainder sizes (65-127 bytes)
-TEST_F(SIMDScalarFallbackTest, SIMDWithRemainders) {
-    for (int size = 65; size < 128; size++) {
-        std::string content(size - 1, 'x');
-        content += '\n';
-        auto buf = makeBuffer(content);
-
-        two_pass parser;
-        // Allocate more space for safety margin
-        libvroom::index idx = parser.init(content.size() + 64, 1);
-
-        bool success = parser.parse(buf.data(), idx, content.size());
-        EXPECT_TRUE(success) << "Failed for size " << size;
-    }
-}
-
-// Test with remainder that's exactly 1 byte
-TEST_F(SIMDScalarFallbackTest, SingleByteRemainder) {
-    std::string content(64, 'x');
-    content += '\n';  // 65 bytes total - 64 SIMD + 1 remainder
-    auto buf = makeBuffer(content);
-
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-
-    bool success = parser.parse(buf.data(), idx, content.size());
-
-    EXPECT_TRUE(success);
-}
-
-// Test with remainder that's 63 bytes
-TEST_F(SIMDScalarFallbackTest, MaxRemainder) {
-    std::string content(126, 'x');
-    content += '\n';  // 127 bytes - 64 SIMD + 63 remainder
-    auto buf = makeBuffer(content);
-
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-
-    bool success = parser.parse(buf.data(), idx, content.size());
-
-    EXPECT_TRUE(success);
-}
-
-// Test second_pass_simd directly with various lengths
-TEST_F(SIMDScalarFallbackTest, SecondPassSIMDVariousLengths) {
-    for (int size : {10, 32, 63, 64, 65, 100, 127, 128, 129, 200}) {
-        std::string content;
-        while (content.size() < static_cast<size_t>(size - 1)) {
-            content += "a,b,c\n";
-        }
-        content.resize(size - 1);
-        content += '\n';
-        auto buf = makeBuffer(content);
-
-        two_pass parser;
-        libvroom::index idx = parser.init(content.size(), 1);
-
-        auto n_indexes = two_pass::second_pass_simd(
-            buf.data(), 0, content.size(), &idx, 0, ',', '"');
-
-        EXPECT_GE(n_indexes, 0) << "Failed for size " << size;
-    }
+    EXPECT_GE(n_indexes, 0) << "Failed for size " << size;
+  }
 }
 
 // ============================================================================
@@ -1794,171 +1880,179 @@ TEST_F(SIMDScalarFallbackTest, SecondPassSIMDVariousLengths) {
 
 class ErrorHandlingEdgeCaseTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test unclosed quote at end of file
 TEST_F(ErrorHandlingEdgeCaseTest, UnclosedQuoteAtEnd) {
-    std::string content = "a,b,\"unclosed";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,\"unclosed";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    EXPECT_TRUE(errors.has_errors());
-    // Should have UNCLOSED_QUOTE error
-    bool found_unclosed = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::UNCLOSED_QUOTE) {
-            found_unclosed = true;
-            break;
-        }
+  EXPECT_TRUE(errors.has_errors());
+  // Should have UNCLOSED_QUOTE error
+  bool found_unclosed = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::UNCLOSED_QUOTE) {
+      found_unclosed = true;
+      break;
     }
-    EXPECT_TRUE(found_unclosed);
+  }
+  EXPECT_TRUE(found_unclosed);
 }
 
 // Test empty header detection
 TEST_F(ErrorHandlingEdgeCaseTest, EmptyHeaderLine) {
-    std::string content = "\na,b,c\n";  // Empty first line
-    auto buf = makeBuffer(content);
+  std::string content = "\na,b,c\n"; // Empty first line
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    EXPECT_TRUE(errors.has_errors());
-    bool found_empty_header = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::EMPTY_HEADER) {
-            found_empty_header = true;
-            break;
-        }
+  EXPECT_TRUE(errors.has_errors());
+  bool found_empty_header = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::EMPTY_HEADER) {
+      found_empty_header = true;
+      break;
     }
-    EXPECT_TRUE(found_empty_header);
+  }
+  EXPECT_TRUE(found_empty_header);
 }
 
 // Test duplicate column names
 TEST_F(ErrorHandlingEdgeCaseTest, DuplicateColumns) {
-    std::string content = "a,b,a\n1,2,3\n";  // 'a' appears twice
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,a\n1,2,3\n"; // 'a' appears twice
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    bool found_duplicate = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::DUPLICATE_COLUMN_NAMES) {
-            found_duplicate = true;
-            break;
-        }
+  bool found_duplicate = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::DUPLICATE_COLUMN_NAMES) {
+      found_duplicate = true;
+      break;
     }
-    EXPECT_TRUE(found_duplicate);
+  }
+  EXPECT_TRUE(found_duplicate);
 }
 
 // Test inconsistent field counts
 TEST_F(ErrorHandlingEdgeCaseTest, InconsistentFieldCount) {
-    std::string content = "a,b,c\n1,2\n3,4,5\n";  // Second row has 2 fields, not 3
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2\n3,4,5\n"; // Second row has 2 fields, not 3
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    bool found_inconsistent = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::INCONSISTENT_FIELD_COUNT) {
-            found_inconsistent = true;
-            break;
-        }
+  bool found_inconsistent = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::INCONSISTENT_FIELD_COUNT) {
+      found_inconsistent = true;
+      break;
     }
-    EXPECT_TRUE(found_inconsistent);
+  }
+  EXPECT_TRUE(found_inconsistent);
 }
 
 // Test mixed line endings
 TEST_F(ErrorHandlingEdgeCaseTest, MixedLineEndings) {
-    std::string content = "a,b,c\r\n1,2,3\n4,5,6\r";  // CRLF, LF, CR mixed
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\r\n1,2,3\n4,5,6\r"; // CRLF, LF, CR mixed
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    bool found_mixed = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
-            found_mixed = true;
-            break;
-        }
+  bool found_mixed = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
+      found_mixed = true;
+      break;
     }
-    EXPECT_TRUE(found_mixed);
+  }
+  EXPECT_TRUE(found_mixed);
 }
 
 // Test STRICT mode stops on first error
 TEST_F(ErrorHandlingEdgeCaseTest, StrictModeStopsEarly) {
-    std::string content = "a,bad\"quote,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,bad\"quote,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::STRICT);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::STRICT);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    // STRICT mode should have stopped and collected at least one error
-    EXPECT_TRUE(errors.has_errors());
-    EXPECT_EQ(errors.error_count(), 1);  // Should stop after first error
+  // STRICT mode should have stopped and collected at least one error
+  EXPECT_TRUE(errors.has_errors());
+  EXPECT_EQ(errors.error_count(), 1); // Should stop after first error
 }
 
 // Test BEST_EFFORT mode
 TEST_F(ErrorHandlingEdgeCaseTest, BestEffortMode) {
-    std::string content = "a,bad\"quote,c\nanother\"error,b,c\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,bad\"quote,c\nanother\"error,b,c\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::BEST_EFFORT);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::BEST_EFFORT);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    // Best effort should continue despite errors
-    EXPECT_TRUE(success);
+  // Best effort should continue despite errors
+  EXPECT_TRUE(success);
 }
 
 // Test check_field_counts with no trailing newline
 TEST_F(ErrorHandlingEdgeCaseTest, NoTrailingNewlineFieldCount) {
-    std::string content = "a,b,c\n1,2";  // Last row has 2 fields, no trailing \n
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2"; // Last row has 2 fields, no trailing \n
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 1);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 1);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool success = parser.parse_with_errors(buf.data(), idx, content.size(), errors);
+  bool success =
+      parser.parse_with_errors(buf.data(), idx, content.size(), errors);
 
-    bool found_inconsistent = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::INCONSISTENT_FIELD_COUNT) {
-            found_inconsistent = true;
-            break;
-        }
+  bool found_inconsistent = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::INCONSISTENT_FIELD_COUNT) {
+      found_inconsistent = true;
+      break;
     }
-    EXPECT_TRUE(found_inconsistent);
+  }
+  EXPECT_TRUE(found_inconsistent);
 }
 
 // ============================================================================
@@ -1967,51 +2061,52 @@ TEST_F(ErrorHandlingEdgeCaseTest, NoTrailingNewlineFieldCount) {
 
 class QuotationStateEdgeCaseTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test get_quotation_state at position 0
 TEST_F(QuotationStateEdgeCaseTest, StateAtPosition0) {
-    std::string content = "abc";
-    auto buf = makeBuffer(content);
+  std::string content = "abc";
+  auto buf = makeBuffer(content);
 
-    auto state = two_pass::get_quotation_state(buf.data(), 0, ',', '"');
-    EXPECT_EQ(state, two_pass::UNQUOTED);  // Start is always unquoted
+  auto state = two_pass::get_quotation_state(buf.data(), 0, ',', '"');
+  EXPECT_EQ(state, two_pass::UNQUOTED); // Start is always unquoted
 }
 
 // Test get_quotation_state with quote right before position
 TEST_F(QuotationStateEdgeCaseTest, QuoteImmediatelyBefore) {
-    std::string content = "\"abc";
-    auto buf = makeBuffer(content);
+  std::string content = "\"abc";
+  auto buf = makeBuffer(content);
 
-    auto state = two_pass::get_quotation_state(buf.data(), 1, ',', '"');
-    // After opening quote, should be in quoted context
-    EXPECT_TRUE(state == two_pass::QUOTED || state == two_pass::AMBIGUOUS);
+  auto state = two_pass::get_quotation_state(buf.data(), 1, ',', '"');
+  // After opening quote, should be in quoted context
+  EXPECT_TRUE(state == two_pass::QUOTED || state == two_pass::AMBIGUOUS);
 }
 
 // Test with multiple quotes before position
 TEST_F(QuotationStateEdgeCaseTest, MultipleQuotesBefore) {
-    std::string content = "\"a\"b\"c";
-    auto buf = makeBuffer(content);
+  std::string content = "\"a\"b\"c";
+  auto buf = makeBuffer(content);
 
-    auto state = two_pass::get_quotation_state(buf.data(), 5, ',', '"');
-    // Odd number of quotes = quoted, even = unquoted
-    EXPECT_TRUE(state != two_pass::QUOTED || state != two_pass::UNQUOTED || state == two_pass::AMBIGUOUS);
+  auto state = two_pass::get_quotation_state(buf.data(), 5, ',', '"');
+  // Odd number of quotes = quoted, even = unquoted
+  EXPECT_TRUE(state != two_pass::QUOTED || state != two_pass::UNQUOTED ||
+              state == two_pass::AMBIGUOUS);
 }
 
 // Test with delimiter in content
 TEST_F(QuotationStateEdgeCaseTest, DelimiterContext) {
-    std::string content = "a,b,c";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c";
+  auto buf = makeBuffer(content);
 
-    // Position after a comma
-    auto state = two_pass::get_quotation_state(buf.data(), 2, ',', '"');
-    // After delimiter in unquoted content, should be unquoted or ambiguous
-    EXPECT_TRUE(state == two_pass::UNQUOTED || state == two_pass::AMBIGUOUS);
+  // Position after a comma
+  auto state = two_pass::get_quotation_state(buf.data(), 2, ',', '"');
+  // After delimiter in unquoted content, should be unquoted or ambiguous
+  EXPECT_TRUE(state == two_pass::UNQUOTED || state == two_pass::AMBIGUOUS);
 }
 
 // ============================================================================
@@ -2020,38 +2115,36 @@ TEST_F(QuotationStateEdgeCaseTest, DelimiterContext) {
 
 class IndexEdgeCaseTest : public ::testing::Test {
 protected:
-    std::string temp_filename;
+  std::string temp_filename;
 
-    void SetUp() override {
-        temp_filename = "test_index_edge.bin";
-    }
+  void SetUp() override { temp_filename = "test_index_edge.bin"; }
 
-    void TearDown() override {
-        if (fs::exists(temp_filename)) {
-            fs::remove(temp_filename);
-        }
+  void TearDown() override {
+    if (fs::exists(temp_filename)) {
+      fs::remove(temp_filename);
     }
+  }
 };
 
 // Test destructor with null pointers
 TEST_F(IndexEdgeCaseTest, DestructorWithNullPointers) {
-    libvroom::index idx;
-    // Default constructor leaves pointers as nullptr
-    EXPECT_EQ(idx.indexes, nullptr);
-    EXPECT_EQ(idx.n_indexes, nullptr);
-    // Destructor should handle null pointers safely
-    // (this will be tested by just letting idx go out of scope)
+  libvroom::index idx;
+  // Default constructor leaves pointers as nullptr
+  EXPECT_EQ(idx.indexes, nullptr);
+  EXPECT_EQ(idx.n_indexes, nullptr);
+  // Destructor should handle null pointers safely
+  // (this will be tested by just letting idx go out of scope)
 }
 
 // Test move from already-moved object
 TEST_F(IndexEdgeCaseTest, MoveFromMovedObject) {
-    two_pass parser;
-    libvroom::index original = parser.init(100, 2);
-    libvroom::index first_move(std::move(original));
-    libvroom::index second_move(std::move(original));  // original is now empty
+  two_pass parser;
+  libvroom::index original = parser.init(100, 2);
+  libvroom::index first_move(std::move(original));
+  libvroom::index second_move(std::move(original)); // original is now empty
 
-    EXPECT_EQ(second_move.indexes, nullptr);
-    EXPECT_EQ(second_move.n_indexes, nullptr);
+  EXPECT_EQ(second_move.indexes, nullptr);
+  EXPECT_EQ(second_move.n_indexes, nullptr);
 }
 
 // ============================================================================
@@ -2059,44 +2152,43 @@ TEST_F(IndexEdgeCaseTest, MoveFromMovedObject) {
 // ============================================================================
 
 TEST(GetContextEdgeCaseTest, ZeroContextSize) {
-    std::string content = "abcdefghij";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 5, 0);
+  std::string content = "abcdefghij";
+  auto ctx = two_pass::get_context(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size(), 5, 0);
 
-    EXPECT_TRUE(ctx.empty() || ctx.size() <= 1);
+  EXPECT_TRUE(ctx.empty() || ctx.size() <= 1);
 }
 
 TEST(GetContextEdgeCaseTest, LargeContextSize) {
-    std::string content = "abc";
-    auto ctx = two_pass::get_context(
-        reinterpret_cast<const uint8_t*>(content.data()),
-        content.size(), 1, 100);  // Context larger than content
+  std::string content = "abc";
+  auto ctx = two_pass::get_context(
+      reinterpret_cast<const uint8_t *>(content.data()), content.size(), 1,
+      100); // Context larger than content
 
-    EXPECT_FALSE(ctx.empty());
-    EXPECT_LE(ctx.size(), content.size());
+  EXPECT_FALSE(ctx.empty());
+  EXPECT_LE(ctx.size(), content.size());
 }
 
 TEST(GetContextEdgeCaseTest, WithNullByte) {
-    // Construct buffer with explicit null byte
-    uint8_t data[10] = {'a', 'b', '\0', 'c', 'd', '\0'};
-    size_t len = 5;
+  // Construct buffer with explicit null byte
+  uint8_t data[10] = {'a', 'b', '\0', 'c', 'd', '\0'};
+  size_t len = 5;
 
-    auto ctx = two_pass::get_context(data, len, 2, 3);
+  auto ctx = two_pass::get_context(data, len, 2, 3);
 
-    // Null bytes should be escaped as \0
-    EXPECT_NE(ctx.find("\\0"), std::string::npos);
+  // Null bytes should be escaped as \0
+  EXPECT_NE(ctx.find("\\0"), std::string::npos);
 }
 
 TEST(GetContextEdgeCaseTest, WithNonPrintable) {
-    // Construct buffer with explicit non-printable characters
-    uint8_t data[10] = {'a', 'b', 0x01, 0x02, 'c', 'd', '\0'};
-    size_t len = 6;
+  // Construct buffer with explicit non-printable characters
+  uint8_t data[10] = {'a', 'b', 0x01, 0x02, 'c', 'd', '\0'};
+  size_t len = 6;
 
-    auto ctx = two_pass::get_context(data, len, 3, 3);
+  auto ctx = two_pass::get_context(data, len, 3, 3);
 
-    // Non-printable should be shown as ?
-    EXPECT_NE(ctx.find("?"), std::string::npos);
+  // Non-printable should be shown as ?
+  EXPECT_NE(ctx.find("?"), std::string::npos);
 }
 
 // ============================================================================
@@ -2105,126 +2197,128 @@ TEST(GetContextEdgeCaseTest, WithNonPrintable) {
 
 class CheckFunctionsTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test check_duplicate_columns with quoted column names
 TEST_F(CheckFunctionsTest, DuplicateQuotedColumns) {
-    std::string content = "\"a\",\"b\",\"a\"\n1,2,3\n";  // Quoted duplicate
-    auto buf = makeBuffer(content);
+  std::string content = "\"a\",\"b\",\"a\"\n1,2,3\n"; // Quoted duplicate
+  auto buf = makeBuffer(content);
 
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    two_pass::check_duplicate_columns(buf.data(), content.size(), errors, ',', '"');
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass::check_duplicate_columns(buf.data(), content.size(), errors, ',',
+                                    '"');
 
-    bool found = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::DUPLICATE_COLUMN_NAMES) {
-            found = true;
-            break;
-        }
+  bool found = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::DUPLICATE_COLUMN_NAMES) {
+      found = true;
+      break;
     }
-    EXPECT_TRUE(found);
+  }
+  EXPECT_TRUE(found);
 }
 
 // Test check_empty_header with empty buffer
 TEST_F(CheckFunctionsTest, EmptyBufferHeader) {
-    std::vector<uint8_t> buf(LIBVROOM_PADDING, 0);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  std::vector<uint8_t> buf(LIBVROOM_PADDING, 0);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    bool result = two_pass::check_empty_header(buf.data(), 0, errors);
-    EXPECT_TRUE(result);  // Empty is "OK" (no error added)
+  bool result = two_pass::check_empty_header(buf.data(), 0, errors);
+  EXPECT_TRUE(result); // Empty is "OK" (no error added)
 }
 
 // Test check_empty_header with CR at start
 TEST_F(CheckFunctionsTest, CRAtStart) {
-    std::string content = "\ra,b,c\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\ra,b,c\n";
+  auto buf = makeBuffer(content);
 
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    bool result = two_pass::check_empty_header(buf.data(), content.size(), errors);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  bool result =
+      two_pass::check_empty_header(buf.data(), content.size(), errors);
 
-    EXPECT_FALSE(result);  // Should detect empty header
+  EXPECT_FALSE(result); // Should detect empty header
 }
 
 // Test check_line_endings with only CRLF
 TEST_F(CheckFunctionsTest, OnlyCRLF) {
-    std::string content = "a,b,c\r\n1,2,3\r\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\r\n1,2,3\r\n";
+  auto buf = makeBuffer(content);
 
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    two_pass::check_line_endings(buf.data(), content.size(), errors);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass::check_line_endings(buf.data(), content.size(), errors);
 
-    // Should not have mixed line endings error
-    bool found_mixed = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
-            found_mixed = true;
-            break;
-        }
+  // Should not have mixed line endings error
+  bool found_mixed = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
+      found_mixed = true;
+      break;
     }
-    EXPECT_FALSE(found_mixed);
+  }
+  EXPECT_FALSE(found_mixed);
 }
 
 // Test check_line_endings with only LF
 TEST_F(CheckFunctionsTest, OnlyLF) {
-    std::string content = "a,b,c\n1,2,3\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n1,2,3\n";
+  auto buf = makeBuffer(content);
 
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    two_pass::check_line_endings(buf.data(), content.size(), errors);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass::check_line_endings(buf.data(), content.size(), errors);
 
-    bool found_mixed = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
-            found_mixed = true;
-            break;
-        }
+  bool found_mixed = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
+      found_mixed = true;
+      break;
     }
-    EXPECT_FALSE(found_mixed);
+  }
+  EXPECT_FALSE(found_mixed);
 }
 
 // Test check_line_endings with only CR (old Mac style)
 TEST_F(CheckFunctionsTest, OnlyCR) {
-    std::string content = "a,b,c\r1,2,3\r";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\r1,2,3\r";
+  auto buf = makeBuffer(content);
 
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    two_pass::check_line_endings(buf.data(), content.size(), errors);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass::check_line_endings(buf.data(), content.size(), errors);
 
-    bool found_mixed = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
-            found_mixed = true;
-            break;
-        }
+  bool found_mixed = false;
+  for (const auto &err : errors.errors()) {
+    if (err.code == ErrorCode::MIXED_LINE_ENDINGS) {
+      found_mixed = true;
+      break;
     }
-    EXPECT_FALSE(found_mixed);
+  }
+  EXPECT_FALSE(found_mixed);
 }
 
 // Test check_field_counts with empty buffer
 TEST_F(CheckFunctionsTest, FieldCountEmptyBuffer) {
-    std::vector<uint8_t> buf(LIBVROOM_PADDING, 0);
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
+  std::vector<uint8_t> buf(LIBVROOM_PADDING, 0);
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
 
-    two_pass::check_field_counts(buf.data(), 0, errors, ',', '"');
+  two_pass::check_field_counts(buf.data(), 0, errors, ',', '"');
 
-    EXPECT_EQ(errors.error_count(), 0);
+  EXPECT_EQ(errors.error_count(), 0);
 }
 
 // Test check_field_counts with quoted fields containing newlines
 TEST_F(CheckFunctionsTest, FieldCountQuotedNewlines) {
-    std::string content = "a,b,c\n\"1\n2\",3,4\n5,6,7\n";
-    auto buf = makeBuffer(content);
+  std::string content = "a,b,c\n\"1\n2\",3,4\n5,6,7\n";
+  auto buf = makeBuffer(content);
 
-    ErrorCollector errors(ErrorMode::PERMISSIVE);
-    two_pass::check_field_counts(buf.data(), content.size(), errors, ',', '"');
+  ErrorCollector errors(ErrorMode::PERMISSIVE);
+  two_pass::check_field_counts(buf.data(), content.size(), errors, ',', '"');
 
-    // The newline inside quotes should be ignored for field counting
-    // So all rows should have 3 fields (but the check may not be perfect)
+  // The newline inside quotes should be ignored for field counting
+  // So all rows should have 3 fields (but the check may not be perfect)
 }
 
 // ============================================================================
@@ -2233,54 +2327,57 @@ TEST_F(CheckFunctionsTest, FieldCountQuotedNewlines) {
 
 class SpeculateEdgeCaseTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test speculate with quoted context (entering in quoted state)
 TEST_F(SpeculateEdgeCaseTest, StartInQuotedContext) {
-    // This simulates starting in the middle of a quoted field
-    std::string content = "hello\",world\n";
-    auto buf = makeBuffer(content);
+  // This simulates starting in the middle of a quoted field
+  std::string content = "hello\",world\n";
+  auto buf = makeBuffer(content);
 
-    // Create a larger context where this would appear after a quote
-    std::string full = "\"";
-    full += content;
-    auto fullBuf = makeBuffer(full);
+  // Create a larger context where this would appear after a quote
+  std::string full = "\"";
+  full += content;
+  auto fullBuf = makeBuffer(full);
 
-    // Speculate from position 1 (after opening quote)
-    auto stats = two_pass::first_pass_speculate(fullBuf.data(), 1, full.size(), ',', '"');
+  // Speculate from position 1 (after opening quote)
+  auto stats =
+      two_pass::first_pass_speculate(fullBuf.data(), 1, full.size(), ',', '"');
 
-    // The function should try to determine quote context
+  // The function should try to determine quote context
 }
 
 // Test speculate with AMBIGUOUS initial state
 TEST_F(SpeculateEdgeCaseTest, AmbiguousContext) {
-    // Create content where quote state is ambiguous
-    std::string content;
-    content.resize(200);
-    std::fill(content.begin(), content.end(), 'x');
-    content[100] = '\n';
-    content[199] = '\n';
-    auto buf = makeBuffer(content);
+  // Create content where quote state is ambiguous
+  std::string content;
+  content.resize(200);
+  std::fill(content.begin(), content.end(), 'x');
+  content[100] = '\n';
+  content[199] = '\n';
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_speculate(buf.data(), 50, content.size(), ',', '"');
+  auto stats =
+      two_pass::first_pass_speculate(buf.data(), 50, content.size(), ',', '"');
 
-    // Should still find a newline
-    EXPECT_NE(stats.first_even_nl, null_pos);
+  // Should still find a newline
+  EXPECT_NE(stats.first_even_nl, null_pos);
 }
 
 // Test speculate with quote toggling
 TEST_F(SpeculateEdgeCaseTest, QuoteToggling) {
-    std::string content = "\"a\"b\"c\"\n";
-    auto buf = makeBuffer(content);
+  std::string content = "\"a\"b\"c\"\n";
+  auto buf = makeBuffer(content);
 
-    auto stats = two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
+  auto stats =
+      two_pass::first_pass_speculate(buf.data(), 0, content.size(), ',', '"');
 
-    // Should handle quote toggling correctly
+  // Should handle quote toggling correctly
 }
 
 // ============================================================================
@@ -2289,45 +2386,45 @@ TEST_F(SpeculateEdgeCaseTest, QuoteToggling) {
 
 class BranchlessMultiThreadedTest : public ::testing::Test {
 protected:
-    std::vector<uint8_t> makeBuffer(const std::string& content) {
-        std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
-        std::memcpy(buf.data(), content.data(), content.size());
-        return buf;
-    }
+  std::vector<uint8_t> makeBuffer(const std::string &content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    std::memcpy(buf.data(), content.data(), content.size());
+    return buf;
+  }
 };
 
 // Test branchless with null_pos fallback
 TEST_F(BranchlessMultiThreadedTest, NullPosFallback) {
-    // Very small file that would cause null_pos during chunking
-    std::string content = "ab\n";
-    auto buf = makeBuffer(content);
+  // Very small file that would cause null_pos during chunking
+  std::string content = "ab\n";
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 8);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 8);
 
-    bool success = parser.parse_branchless(buf.data(), idx, content.size());
+  bool success = parser.parse_branchless(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
-    EXPECT_EQ(idx.n_threads, 1);  // Should fall back
+  EXPECT_TRUE(success);
+  EXPECT_EQ(idx.n_threads, 1); // Should fall back
 }
 
 // Test branchless multi-threaded with large file
 TEST_F(BranchlessMultiThreadedTest, LargeFileMultiThreaded) {
-    std::string content;
-    for (int i = 0; i < 5000; i++) {
-        content += "a,b,c,d,e,f,g\n";
-    }
-    auto buf = makeBuffer(content);
+  std::string content;
+  for (int i = 0; i < 5000; i++) {
+    content += "a,b,c,d,e,f,g\n";
+  }
+  auto buf = makeBuffer(content);
 
-    two_pass parser;
-    libvroom::index idx = parser.init(content.size(), 4);
+  two_pass parser;
+  libvroom::index idx = parser.init(content.size(), 4);
 
-    bool success = parser.parse_branchless(buf.data(), idx, content.size());
+  bool success = parser.parse_branchless(buf.data(), idx, content.size());
 
-    EXPECT_TRUE(success);
+  EXPECT_TRUE(success);
 }
 
 int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Summary
- Change `n_threads` from `uint8_t` to `uint16_t` in the `index` struct to support systems with more than 255 cores
- Add versioned index file format (v2) with backward compatibility for reading legacy v1 format files
- Increase `MAX_THREADS` limit from 255 to 1024 in CLI
- Update all loop variables iterating over `n_threads` to `uint16_t` across the codebase

## Motivation
Systems with more than 255 cores (e.g., high-performance computing clusters, large cloud instances) could not fully utilize all available cores for parallel CSV parsing due to the `uint8_t` thread count limitation.

## Breaking Change
Index files saved with the new v2 format cannot be read by older versions of libvroom. However, the new code can still read legacy v1 format files, maintaining backward compatibility for reading.

## Test plan
- [x] Updated CLI tests to validate new thread limits (1024 max, >1024 invalid)
- [x] Added `WriteAndReadLargeThreadCount` test for serialization with 300 threads
- [x] Added `ReadLegacyV1Format` test to verify backward compatibility
- [x] Added `CountManyThreads` CLI test to verify parsing works with 500 threads
- [x] All 1664 tests pass locally

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)