### PR TITLE
test: Remove temporary debug output from SampleManyRows test

### DIFF
--- a/test/cli_test.cpp
+++ b/test/cli_test.cpp
@@ -1089,12 +1089,6 @@ TEST_F(CliTest, SampleManyRows) {
     data_rows++;
   if (result.output.find("20,2000,T") != std::string::npos)
     data_rows++;
-  // Debug output to help diagnose flaky test failures
-  if (data_rows != 5) {
-    std::cerr << "SampleManyRows DEBUG: exit_code=" << result.exit_code
-              << " output_size=" << result.output.size() << " data_rows=" << data_rows << "\n";
-    std::cerr << "SampleManyRows DEBUG: full output:\n[[[" << result.output << "]]]\n";
-  }
   EXPECT_EQ(data_rows, 5); // We requested 5 rows
 }
 


### PR DESCRIPTION
## Summary
- Removes temporary debug output from `CliTest.SampleManyRows` test
- The debug output was added in PR #295 to diagnose intermittent test failures
- The root cause is now documented in issue #297, so this diagnostic code is no longer needed

Fixes #298

## Test plan
- [x] All tests pass locally (1845 tests)
- [x] No functional changes - only removes debug stderr output

🤖 Generated with [Claude Code](https://claude.com/claude-code)