### PR TITLE
Remove deprecated APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ vroom info data.csv               # Get file info (rows, columns, dialect)
 libvroom::FileBuffer buffer = libvroom::load_file("data.csv");
 libvroom::Parser parser;
 libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-auto result = parser.parse_auto(buffer.data(), buffer.size(), errors);
+auto result = parser.parse(buffer.data(), buffer.size(), {.errors = &errors});
 // result.num_columns(), result.dialect.delimiter, etc.
 ```
 

--- a/benchmark/basic_benchmarks.cpp
+++ b/benchmark/basic_benchmarks.cpp
@@ -115,7 +115,7 @@ static void BM_IndexCreation(benchmark::State& state) {
   size_t file_size = static_cast<size_t>(state.range(0));
   int n_threads = static_cast<int>(state.range(1));
 
-  libvroom::two_pass tp;
+  libvroom::TwoPass tp;
 
   for (auto _ : state) {
     auto result = tp.init(file_size, n_threads);

--- a/benchmark/external_parser_benchmarks.cpp
+++ b/benchmark/external_parser_benchmarks.cpp
@@ -40,14 +40,10 @@
 //
 // =============================================================================
 
-// Benchmarks intentionally test deprecated two_pass methods for performance
-// comparison
-#include "two_pass.h"
-LIBVROOM_SUPPRESS_DEPRECATION_START
-
 #include "common_defs.h"
 #include "io_util.h"
 #include "mem_util.h"
+#include "two_pass.h"
 
 #include <benchmark/benchmark.h>
 #include <cstring>
@@ -195,7 +191,7 @@ private:
 #endif
 
 extern std::map<std::string, std::basic_string_view<uint8_t>> test_data;
-extern libvroom::two_pass* global_parser;
+extern libvroom::TwoPass* global_parser;
 
 // ============================================================================
 // Test Data Generation
@@ -305,10 +301,10 @@ static const std::string& get_or_generate_quoted_data(size_t size) {
 
 static size_t parse_libvroom(const uint8_t* data, size_t len) {
   if (!global_parser) {
-    global_parser = new libvroom::two_pass();
+    global_parser = new libvroom::TwoPass();
   }
 
-  libvroom::index result = global_parser->init(len, 1);
+  libvroom::ParseIndex result = global_parser->init(len, 1);
   global_parser->parse(data, result, len);
 
   // Return total field count as work indicator

--- a/docs/error-handling.qmd
+++ b/docs/error-handling.qmd
@@ -93,7 +93,7 @@ Bob,25,NYC,USA
 
 void parse_with_errors(const uint8_t* buf, size_t len) {
     // Create parser and error collector
-    libvroom::two_pass parser;
+    libvroom::TwoPass parser;
     auto idx = parser.init(len, 1);
     libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
 
@@ -144,7 +144,7 @@ if (errors.at_error_limit()) {
 When parsing with multiple threads, each thread collects errors locally. After parsing, errors are merged and sorted by byte offset:
 
 ```cpp
-libvroom::two_pass parser;
+libvroom::TwoPass parser;
 auto idx = parser.init(len, 4);  // 4 threads
 libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
 

--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -265,7 +265,7 @@ int main() {
     libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
 
     // Parse with automatic dialect detection
-    auto result = parser.parse_auto(buffer.data(), buffer.size(), errors);
+    auto result = parser.parse(buffer.data(), buffer.size(), {.errors = &errors});
 
     if (result.success()) {
         std::cout << "Columns: " << result.num_columns() << "\n";

--- a/docs/integration-guide.qmd
+++ b/docs/integration-guide.qmd
@@ -199,7 +199,7 @@ int main(int argc, char* argv[]) {
     libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
 
     // Parse with automatic dialect detection
-    auto result = parser.parse_auto(buffer.data(), buffer.size(), errors);
+    auto result = parser.parse(buffer.data(), buffer.size(), {.errors = &errors});
 
     if (result.success()) {
         std::cout << "Parsed successfully!\n";

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -64,14 +64,14 @@ auto result = parser.parse(buf, len, ParseOptions::branchless());
 
 | Class | Description |
 |-------|-------------|
-| @ref libvroom::index | Result structure containing parsed field positions. |
+| @ref libvroom::ParseIndex | Result structure containing parsed field positions. |
 | @ref libvroom::ErrorCollector | Collects and manages parse errors. |
 
 ### Internal Classes (Deprecated for Direct Use)
 
 | Class | Description |
 |-------|-------------|
-| @ref libvroom::two_pass | Low-level parser implementation. Use `Parser` instead. |
+| @ref libvroom::TwoPass | Low-level parser implementation. Use `Parser` instead. |
 
 ### Dialect Detection
 
@@ -109,16 +109,16 @@ libvroom supports multiple CSV dialects beyond standard comma-separated:
 
 ```cpp
 // Standard CSV (comma, double-quote)
-auto result = parser.parse(data, len, libvroom::Dialect::csv());
+auto result = parser.parse(data, len, {.dialect = libvroom::Dialect::csv()});
 
 // Tab-separated values
-auto result = parser.parse(data, len, libvroom::Dialect::tsv());
+auto result = parser.parse(data, len, {.dialect = libvroom::Dialect::tsv()});
 
 // Semicolon-separated (European style)
-auto result = parser.parse(data, len, libvroom::Dialect::semicolon());
+auto result = parser.parse(data, len, {.dialect = libvroom::Dialect::semicolon()});
 
 // Pipe-separated
-auto result = parser.parse(data, len, libvroom::Dialect::pipe());
+auto result = parser.parse(data, len, {.dialect = libvroom::Dialect::pipe()});
 
 // Custom dialect
 libvroom::Dialect custom;

--- a/fuzz/fuzz_csv_parser.cpp
+++ b/fuzz/fuzz_csv_parser.cpp
@@ -3,46 +3,52 @@
  * @brief LibFuzzer target for fuzz testing the CSV parser.
  */
 
-#include <cstdint>
+#include "error.h"
+#include "mem_util.h"
+#include "two_pass.h"
+
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 
-#include "two_pass.h"
-#include "error.h"
-#include "mem_util.h"
-
 struct AlignedDeleter {
-    void operator()(uint8_t* ptr) const { if (ptr) aligned_free(ptr); }
+  void operator()(uint8_t* ptr) const {
+    if (ptr)
+      aligned_free(ptr);
+  }
 };
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-    if (size == 0) return 0;
-    // 64KB limit: Large enough to test SIMD chunking (64-byte lanes) and
-    // multi-record parsing, small enough for fast fuzzing iterations
-    constexpr size_t MAX_INPUT_SIZE = 64 * 1024;
-    if (size > MAX_INPUT_SIZE) size = MAX_INPUT_SIZE;
-
-    // Use immediate RAII to prevent leaks if an exception occurs
-    std::unique_ptr<uint8_t, AlignedDeleter> guard(
-        static_cast<uint8_t*>(aligned_malloc(64, size + 64)));
-    if (!guard) return 0;
-    uint8_t* buf = guard.get();
-    std::memcpy(buf, data, size);
-    std::memset(buf + size, 0, 64);
-
-    libvroom::two_pass parser;
-
-    { // Single-threaded parsing
-        libvroom::index idx = parser.init(size, 1);
-        parser.parse(buf, idx, size);
-    }
-
-    { // Error collection mode
-        libvroom::index idx = parser.init(size, 1);
-        libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-        parser.parse_with_errors(buf, idx, size, errors);
-    }
-
+  if (size == 0)
     return 0;
+  // 64KB limit: Large enough to test SIMD chunking (64-byte lanes) and
+  // multi-record parsing, small enough for fast fuzzing iterations
+  constexpr size_t MAX_INPUT_SIZE = 64 * 1024;
+  if (size > MAX_INPUT_SIZE)
+    size = MAX_INPUT_SIZE;
+
+  // Use immediate RAII to prevent leaks if an exception occurs
+  std::unique_ptr<uint8_t, AlignedDeleter> guard(
+      static_cast<uint8_t*>(aligned_malloc(64, size + 64)));
+  if (!guard)
+    return 0;
+  uint8_t* buf = guard.get();
+  std::memcpy(buf, data, size);
+  std::memset(buf + size, 0, 64);
+
+  libvroom::TwoPass parser;
+
+  { // Single-threaded parsing
+    libvroom::ParseIndex idx = parser.init(size, 1);
+    parser.parse(buf, idx, size);
+  }
+
+  { // Error collection mode
+    libvroom::ParseIndex idx = parser.init(size, 1);
+    libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
+    parser.parse_with_errors(buf, idx, size, errors);
+  }
+
+  return 0;
 }

--- a/fuzz/fuzz_parse_auto.cpp
+++ b/fuzz/fuzz_parse_auto.cpp
@@ -3,46 +3,52 @@
  * @brief LibFuzzer target for fuzz testing parse_auto.
  */
 
-#include <cstdint>
+#include "dialect.h"
+#include "error.h"
+#include "mem_util.h"
+#include "two_pass.h"
+
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 
-#include "two_pass.h"
-#include "error.h"
-#include "dialect.h"
-#include "mem_util.h"
-
 struct AlignedDeleter {
-    void operator()(uint8_t* ptr) const { if (ptr) aligned_free(ptr); }
+  void operator()(uint8_t* ptr) const {
+    if (ptr)
+      aligned_free(ptr);
+  }
 };
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-    if (size == 0) return 0;
-    // 64KB limit: Matches fuzz_csv_parser since parse_auto exercises both
-    // dialect detection and full parsing paths
-    constexpr size_t MAX_INPUT_SIZE = 64 * 1024;
-    if (size > MAX_INPUT_SIZE) size = MAX_INPUT_SIZE;
-
-    // Use immediate RAII to prevent leaks if an exception occurs
-    std::unique_ptr<uint8_t, AlignedDeleter> guard(
-        static_cast<uint8_t*>(aligned_malloc(64, size + 64)));
-    if (!guard) return 0;
-    uint8_t* buf = guard.get();
-    std::memcpy(buf, data, size);
-    std::memset(buf + size, 0, 64);
-
-    libvroom::two_pass parser;
-    libvroom::index idx = parser.init(size, 1);
-    libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-    libvroom::DetectionResult detected;
-    bool success = parser.parse_auto(buf, idx, size, errors, &detected);
-
-    // Use the results to exercise different code paths
-    if (success && detected.success()) {
-        (void)idx.n_indexes;
-        (void)detected.detected_columns;
-    }
-
+  if (size == 0)
     return 0;
+  // 64KB limit: Matches fuzz_csv_parser since parse_auto exercises both
+  // dialect detection and full parsing paths
+  constexpr size_t MAX_INPUT_SIZE = 64 * 1024;
+  if (size > MAX_INPUT_SIZE)
+    size = MAX_INPUT_SIZE;
+
+  // Use immediate RAII to prevent leaks if an exception occurs
+  std::unique_ptr<uint8_t, AlignedDeleter> guard(
+      static_cast<uint8_t*>(aligned_malloc(64, size + 64)));
+  if (!guard)
+    return 0;
+  uint8_t* buf = guard.get();
+  std::memcpy(buf, data, size);
+  std::memset(buf + size, 0, 64);
+
+  libvroom::TwoPass parser;
+  libvroom::ParseIndex idx = parser.init(size, 1);
+  libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
+  libvroom::DetectionResult detected;
+  bool success = parser.parse_auto(buf, idx, size, errors, &detected);
+
+  // Use the results to exercise different code paths
+  if (success && detected.success()) {
+    (void)idx.n_indexes;
+    (void)detected.detected_columns;
+  }
+
+  return 0;
 }

--- a/include/error.h
+++ b/include/error.h
@@ -3,9 +3,9 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 /**
  * @file error.h
@@ -35,36 +35,36 @@ namespace libvroom {
  * - General errors (FILE_TOO_LARGE, IO_ERROR, INTERNAL_ERROR)
  */
 enum class ErrorCode {
-    NONE = 0,                    ///< No error
+  NONE = 0, ///< No error
 
-    // Quote-related errors (all implemented)
-    UNCLOSED_QUOTE,              ///< Quoted field not closed before EOF
-    INVALID_QUOTE_ESCAPE,        ///< Invalid quote escape sequence (e.g., "abc"def)
-    QUOTE_IN_UNQUOTED_FIELD,     ///< Quote appears in middle of unquoted field
+  // Quote-related errors (all implemented)
+  UNCLOSED_QUOTE,          ///< Quoted field not closed before EOF
+  INVALID_QUOTE_ESCAPE,    ///< Invalid quote escape sequence (e.g., "abc"def)
+  QUOTE_IN_UNQUOTED_FIELD, ///< Quote appears in middle of unquoted field
 
-    // Field structure errors
-    INCONSISTENT_FIELD_COUNT,    ///< Row has different number of fields than header
-    FIELD_TOO_LARGE,             ///< Field exceeds maximum size limit
+  // Field structure errors
+  INCONSISTENT_FIELD_COUNT, ///< Row has different number of fields than header
+  FIELD_TOO_LARGE,          ///< Field exceeds maximum size limit
 
-    // Line ending errors
-    MIXED_LINE_ENDINGS,          ///< File uses inconsistent line endings (warning)
+  // Line ending errors
+  MIXED_LINE_ENDINGS, ///< File uses inconsistent line endings (warning)
 
-    // Character encoding errors
-    INVALID_UTF8,                ///< Invalid UTF-8 byte sequence detected
-    NULL_BYTE,                   ///< Unexpected null byte in data
+  // Character encoding errors
+  INVALID_UTF8, ///< Invalid UTF-8 byte sequence detected
+  NULL_BYTE,    ///< Unexpected null byte in data
 
-    // Structure errors (all implemented)
-    EMPTY_HEADER,                ///< Header row is empty
-    DUPLICATE_COLUMN_NAMES,      ///< Header contains duplicate column names
+  // Structure errors (all implemented)
+  EMPTY_HEADER,           ///< Header row is empty
+  DUPLICATE_COLUMN_NAMES, ///< Header contains duplicate column names
 
-    // Separator errors
-    AMBIGUOUS_SEPARATOR,         ///< Cannot determine separator reliably (used in dialect detection)
+  // Separator errors
+  AMBIGUOUS_SEPARATOR, ///< Cannot determine separator reliably (used in dialect detection)
 
-    // General errors
-    FILE_TOO_LARGE,              ///< File exceeds maximum size limit
-    INDEX_ALLOCATION_OVERFLOW,   ///< Index allocation would overflow
-    IO_ERROR,                    ///< File I/O error (e.g., read failure)
-    INTERNAL_ERROR               ///< Internal parser error
+  // General errors
+  FILE_TOO_LARGE,            ///< File exceeds maximum size limit
+  INDEX_ALLOCATION_OVERFLOW, ///< Index allocation would overflow
+  IO_ERROR,                  ///< File I/O error (e.g., read failure)
+  INTERNAL_ERROR             ///< Internal parser error
 };
 
 /**
@@ -74,7 +74,7 @@ enum class ErrorCode {
  * denial-of-service attacks via maliciously crafted CSV files with
  * extremely large fields.
  */
-constexpr size_t DEFAULT_MAX_FIELD_SIZE = 16 * 1024 * 1024;  // 16 MB
+constexpr size_t DEFAULT_MAX_FIELD_SIZE = 16 * 1024 * 1024; // 16 MB
 
 /**
  * @brief Default limit for total file size (4 GB).
@@ -83,7 +83,7 @@ constexpr size_t DEFAULT_MAX_FIELD_SIZE = 16 * 1024 * 1024;  // 16 MB
  * prevents out-of-memory conditions when allocating index buffers.
  * For larger files, consider using the streaming API.
  */
-constexpr size_t DEFAULT_MAX_FILE_SIZE = 4ULL * 1024 * 1024 * 1024;  // 4 GB
+constexpr size_t DEFAULT_MAX_FILE_SIZE = 4ULL * 1024 * 1024 * 1024; // 4 GB
 
 /**
  * @brief Severity levels for parse errors.
@@ -92,9 +92,9 @@ constexpr size_t DEFAULT_MAX_FILE_SIZE = 4ULL * 1024 * 1024 * 1024;  // 4 GB
  * can continue after encountering it.
  */
 enum class ErrorSeverity {
-    WARNING,    ///< Non-fatal issue, parser continues (e.g., mixed line endings)
-    ERROR,      ///< Recoverable error, can skip affected row (e.g., inconsistent field count)
-    FATAL       ///< Unrecoverable error, parsing must stop (e.g., unclosed quote at EOF)
+  WARNING, ///< Non-fatal issue, parser continues (e.g., mixed line endings)
+  ERROR,   ///< Recoverable error, can skip affected row (e.g., inconsistent field count)
+  FATAL    ///< Unrecoverable error, parsing must stop (e.g., unclosed quote at EOF)
 };
 
 /**
@@ -112,40 +112,40 @@ enum class ErrorSeverity {
  * @endcode
  */
 struct ParseError {
-    ErrorCode code;           ///< The type of error that occurred
-    ErrorSeverity severity;   ///< Severity level of the error
+  ErrorCode code;         ///< The type of error that occurred
+  ErrorSeverity severity; ///< Severity level of the error
 
-    // Location information
-    size_t line;              ///< Line number where error occurred (1-indexed)
-    size_t column;            ///< Column number where error occurred (1-indexed)
-    size_t byte_offset;       ///< Byte offset from start of file
+  // Location information
+  size_t line;        ///< Line number where error occurred (1-indexed)
+  size_t column;      ///< Column number where error occurred (1-indexed)
+  size_t byte_offset; ///< Byte offset from start of file
 
-    // Context
-    std::string message;      ///< Human-readable error description
-    std::string context;      ///< Snippet of data around the error location
+  // Context
+  std::string message; ///< Human-readable error description
+  std::string context; ///< Snippet of data around the error location
 
-    /**
-     * @brief Construct a ParseError with full details.
-     *
-     * @param c Error code identifying the type of error
-     * @param s Severity level of the error
-     * @param l Line number (1-indexed) where the error occurred
-     * @param col Column number (1-indexed) where the error occurred
-     * @param offset Byte offset from the start of the file
-     * @param msg Human-readable error message
-     * @param ctx Optional context snippet showing data around the error
-     */
-    ParseError(ErrorCode c, ErrorSeverity s, size_t l, size_t col,
-               size_t offset, const std::string& msg, const std::string& ctx = "")
-        : code(c), severity(s), line(l), column(col),
-          byte_offset(offset), message(msg), context(ctx) {}
+  /**
+   * @brief Construct a ParseError with full details.
+   *
+   * @param c Error code identifying the type of error
+   * @param s Severity level of the error
+   * @param l Line number (1-indexed) where the error occurred
+   * @param col Column number (1-indexed) where the error occurred
+   * @param offset Byte offset from the start of the file
+   * @param msg Human-readable error message
+   * @param ctx Optional context snippet showing data around the error
+   */
+  ParseError(ErrorCode c, ErrorSeverity s, size_t l, size_t col, size_t offset,
+             const std::string& msg, const std::string& ctx = "")
+      : code(c), severity(s), line(l), column(col), byte_offset(offset), message(msg),
+        context(ctx) {}
 
-    /**
-     * @brief Convert the error to a human-readable string.
-     *
-     * @return Formatted string with severity, location, and message.
-     */
-    std::string to_string() const;
+  /**
+   * @brief Convert the error to a human-readable string.
+   *
+   * @return Formatted string with severity, location, and message.
+   */
+  std::string to_string() const;
 };
 
 /**
@@ -169,9 +169,9 @@ struct ParseError {
  * @endcode
  */
 enum class ErrorMode {
-    STRICT,      ///< Stop parsing on first error encountered
-    PERMISSIVE,  ///< Try to recover from errors, collect and report all
-    BEST_EFFORT  ///< Ignore errors completely, parse what we can
+  STRICT,     ///< Stop parsing on first error encountered
+  PERMISSIVE, ///< Try to recover from errors, collect and report all
+  BEST_EFFORT ///< Ignore errors completely, parse what we can
 };
 
 /**
@@ -192,7 +192,7 @@ enum class ErrorMode {
  * libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
  *
  * // Parse CSV with error collection
- * libvroom::two_pass parser;
+ * libvroom::TwoPass parser;
  * auto idx = parser.init(data_len, 1);
  * parser.parse_with_errors(data, idx, data_len, errors);
  *
@@ -207,181 +207,183 @@ enum class ErrorMode {
  */
 class ErrorCollector {
 public:
-    /** @brief Default maximum number of errors to collect (prevents OOM attacks) */
-    static constexpr size_t DEFAULT_MAX_ERRORS = 10000;
+  /** @brief Default maximum number of errors to collect (prevents OOM attacks) */
+  static constexpr size_t DEFAULT_MAX_ERRORS = 10000;
 
-    /**
-     * @brief Construct an ErrorCollector with specified mode and limits.
-     *
-     * @param mode Error handling mode (STRICT, PERMISSIVE, or BEST_EFFORT)
-     * @param max_errors Maximum errors to collect (default: 10000)
-     */
-    explicit ErrorCollector(ErrorMode mode = ErrorMode::STRICT,
-                           size_t max_errors = DEFAULT_MAX_ERRORS)
-        : mode_(mode), max_errors_(max_errors), has_fatal_(false) {}
+  /**
+   * @brief Construct an ErrorCollector with specified mode and limits.
+   *
+   * @param mode Error handling mode (STRICT, PERMISSIVE, or BEST_EFFORT)
+   * @param max_errors Maximum errors to collect (default: 10000)
+   */
+  explicit ErrorCollector(ErrorMode mode = ErrorMode::STRICT,
+                          size_t max_errors = DEFAULT_MAX_ERRORS)
+      : mode_(mode), max_errors_(max_errors), has_fatal_(false) {}
 
-    /**
-     * @brief Add an error to the collection.
-     *
-     * Errors are only added if the collection has not reached max_errors_.
-     * If a FATAL error is added, has_fatal_ is set to true.
-     *
-     * @param error The ParseError to add
-     */
-    void add_error(const ParseError& error) {
-        if (errors_.size() >= max_errors_) return;
-        errors_.push_back(error);
-        if (error.severity == ErrorSeverity::FATAL) {
-            has_fatal_ = true;
-        }
+  /**
+   * @brief Add an error to the collection.
+   *
+   * Errors are only added if the collection has not reached max_errors_.
+   * If a FATAL error is added, has_fatal_ is set to true.
+   *
+   * @param error The ParseError to add
+   */
+  void add_error(const ParseError& error) {
+    if (errors_.size() >= max_errors_)
+      return;
+    errors_.push_back(error);
+    if (error.severity == ErrorSeverity::FATAL) {
+      has_fatal_ = true;
     }
+  }
 
-    /**
-     * @brief Check if the error limit has been reached.
-     *
-     * @return true if max_errors_ limit has been reached
-     */
-    bool at_error_limit() const { return errors_.size() >= max_errors_; }
+  /**
+   * @brief Check if the error limit has been reached.
+   *
+   * @return true if max_errors_ limit has been reached
+   */
+  bool at_error_limit() const { return errors_.size() >= max_errors_; }
 
-    /**
-     * @brief Add an error with individual parameters (convenience overload).
-     *
-     * @param code Error code identifying the type of error
-     * @param severity Severity level of the error
-     * @param line Line number (1-indexed) where the error occurred
-     * @param column Column number (1-indexed) where the error occurred
-     * @param offset Byte offset from the start of the file
-     * @param message Human-readable error message
-     * @param context Optional context snippet showing data around the error
-     */
-    void add_error(ErrorCode code, ErrorSeverity severity, size_t line,
-                   size_t column, size_t offset, const std::string& message,
-                   const std::string& context = "") {
-        add_error(ParseError(code, severity, line, column, offset, message, context));
+  /**
+   * @brief Add an error with individual parameters (convenience overload).
+   *
+   * @param code Error code identifying the type of error
+   * @param severity Severity level of the error
+   * @param line Line number (1-indexed) where the error occurred
+   * @param column Column number (1-indexed) where the error occurred
+   * @param offset Byte offset from the start of the file
+   * @param message Human-readable error message
+   * @param context Optional context snippet showing data around the error
+   */
+  void add_error(ErrorCode code, ErrorSeverity severity, size_t line, size_t column, size_t offset,
+                 const std::string& message, const std::string& context = "") {
+    add_error(ParseError(code, severity, line, column, offset, message, context));
+  }
+
+  /**
+   * @brief Check if parsing should stop based on current errors and mode.
+   *
+   * Returns true in the following cases:
+   * - STRICT mode and any error has been recorded
+   * - Any FATAL error has been recorded (regardless of mode)
+   *
+   * @return true if parsing should stop
+   */
+  bool should_stop() const {
+    if (mode_ == ErrorMode::STRICT && !errors_.empty())
+      return true;
+    if (has_fatal_)
+      return true;
+    return false;
+  }
+
+  /**
+   * @brief Check if any errors have been recorded.
+   * @return true if at least one error has been recorded
+   */
+  bool has_errors() const { return !errors_.empty(); }
+
+  /**
+   * @brief Check if any fatal errors have been recorded.
+   * @return true if at least one FATAL error has been recorded
+   */
+  bool has_fatal_errors() const { return has_fatal_; }
+
+  /**
+   * @brief Get the number of recorded errors.
+   * @return Number of errors in the collection
+   */
+  size_t error_count() const { return errors_.size(); }
+
+  /**
+   * @brief Get read-only access to all recorded errors.
+   * @return Const reference to the vector of ParseError objects
+   */
+  const std::vector<ParseError>& errors() const { return errors_; }
+
+  /**
+   * @brief Get a summary string of all errors.
+   * @return Human-readable summary of error counts by type
+   */
+  std::string summary() const;
+
+  /**
+   * @brief Clear all recorded errors and reset fatal flag.
+   */
+  void clear() {
+    errors_.clear();
+    has_fatal_ = false;
+  }
+
+  /**
+   * @brief Get the current error handling mode.
+   * @return Current ErrorMode
+   */
+  ErrorMode mode() const { return mode_; }
+
+  /**
+   * @brief Change the error handling mode.
+   * @param mode New ErrorMode to use
+   */
+  void set_mode(ErrorMode mode) { mode_ = mode; }
+
+  /**
+   * @brief Merge errors from another collector.
+   *
+   * Used for multi-threaded parsing where each thread has its own collector.
+   * Respects max_errors_ limit when merging.
+   *
+   * @param other The ErrorCollector to merge from
+   */
+  void merge_from(const ErrorCollector& other) {
+    if (other.errors_.empty())
+      return;
+
+    // Respect max_errors_ limit when merging
+    size_t available = max_errors_ > errors_.size() ? max_errors_ - errors_.size() : 0;
+    size_t to_copy = std::min(available, other.errors_.size());
+
+    errors_.reserve(errors_.size() + to_copy);
+    for (size_t i = 0; i < to_copy; ++i) {
+      errors_.push_back(other.errors_[i]);
     }
-
-    /**
-     * @brief Check if parsing should stop based on current errors and mode.
-     *
-     * Returns true in the following cases:
-     * - STRICT mode and any error has been recorded
-     * - Any FATAL error has been recorded (regardless of mode)
-     *
-     * @return true if parsing should stop
-     */
-    bool should_stop() const {
-        if (mode_ == ErrorMode::STRICT && !errors_.empty()) return true;
-        if (has_fatal_) return true;
-        return false;
+    if (other.has_fatal_) {
+      has_fatal_ = true;
     }
+  }
 
-    /**
-     * @brief Check if any errors have been recorded.
-     * @return true if at least one error has been recorded
-     */
-    bool has_errors() const { return !errors_.empty(); }
+  /**
+   * @brief Sort errors by byte offset.
+   *
+   * Call this after merging errors from multiple threads to ensure
+   * errors are in logical file order.
+   */
+  void sort_by_offset() {
+    std::sort(errors_.begin(), errors_.end(), [](const ParseError& a, const ParseError& b) {
+      return a.byte_offset < b.byte_offset;
+    });
+  }
 
-    /**
-     * @brief Check if any fatal errors have been recorded.
-     * @return true if at least one FATAL error has been recorded
-     */
-    bool has_fatal_errors() const { return has_fatal_; }
-
-    /**
-     * @brief Get the number of recorded errors.
-     * @return Number of errors in the collection
-     */
-    size_t error_count() const { return errors_.size(); }
-
-    /**
-     * @brief Get read-only access to all recorded errors.
-     * @return Const reference to the vector of ParseError objects
-     */
-    const std::vector<ParseError>& errors() const { return errors_; }
-
-    /**
-     * @brief Get a summary string of all errors.
-     * @return Human-readable summary of error counts by type
-     */
-    std::string summary() const;
-
-    /**
-     * @brief Clear all recorded errors and reset fatal flag.
-     */
-    void clear() {
-        errors_.clear();
-        has_fatal_ = false;
+  /**
+   * @brief Merge multiple collectors and sort by byte offset.
+   *
+   * Convenience method for multi-threaded parsing that merges all
+   * thread-local collectors and sorts the result.
+   *
+   * @param collectors Vector of ErrorCollectors to merge from
+   */
+  void merge_sorted(std::vector<ErrorCollector>& collectors) {
+    for (auto& collector : collectors) {
+      merge_from(collector);
     }
-
-    /**
-     * @brief Get the current error handling mode.
-     * @return Current ErrorMode
-     */
-    ErrorMode mode() const { return mode_; }
-
-    /**
-     * @brief Change the error handling mode.
-     * @param mode New ErrorMode to use
-     */
-    void set_mode(ErrorMode mode) { mode_ = mode; }
-
-    /**
-     * @brief Merge errors from another collector.
-     *
-     * Used for multi-threaded parsing where each thread has its own collector.
-     * Respects max_errors_ limit when merging.
-     *
-     * @param other The ErrorCollector to merge from
-     */
-    void merge_from(const ErrorCollector& other) {
-        if (other.errors_.empty()) return;
-
-        // Respect max_errors_ limit when merging
-        size_t available = max_errors_ > errors_.size() ? max_errors_ - errors_.size() : 0;
-        size_t to_copy = std::min(available, other.errors_.size());
-
-        errors_.reserve(errors_.size() + to_copy);
-        for (size_t i = 0; i < to_copy; ++i) {
-            errors_.push_back(other.errors_[i]);
-        }
-        if (other.has_fatal_) {
-            has_fatal_ = true;
-        }
-    }
-
-    /**
-     * @brief Sort errors by byte offset.
-     *
-     * Call this after merging errors from multiple threads to ensure
-     * errors are in logical file order.
-     */
-    void sort_by_offset() {
-        std::sort(errors_.begin(), errors_.end(),
-            [](const ParseError& a, const ParseError& b) {
-                return a.byte_offset < b.byte_offset;
-            });
-    }
-
-    /**
-     * @brief Merge multiple collectors and sort by byte offset.
-     *
-     * Convenience method for multi-threaded parsing that merges all
-     * thread-local collectors and sorts the result.
-     *
-     * @param collectors Vector of ErrorCollectors to merge from
-     */
-    void merge_sorted(std::vector<ErrorCollector>& collectors) {
-        for (auto& collector : collectors) {
-            merge_from(collector);
-        }
-        sort_by_offset();
-    }
+    sort_by_offset();
+  }
 
 private:
-    ErrorMode mode_;
-    size_t max_errors_;
-    std::vector<ParseError> errors_;
-    bool has_fatal_;
+  ErrorMode mode_;
+  size_t max_errors_;
+  std::vector<ParseError> errors_;
+  bool has_fatal_;
 };
 
 /**
@@ -404,40 +406,41 @@ private:
  */
 class ParseException : public std::runtime_error {
 public:
-    /**
-     * @brief Construct exception from a single error.
-     * @param error The ParseError that caused the exception
-     */
-    explicit ParseException(const ParseError& error)
-        : std::runtime_error(error.message), errors_{error} {}
+  /**
+   * @brief Construct exception from a single error.
+   * @param error The ParseError that caused the exception
+   */
+  explicit ParseException(const ParseError& error)
+      : std::runtime_error(error.message), errors_{error} {}
 
-    /**
-     * @brief Construct exception from multiple errors.
-     * @param errors Vector of ParseError objects
-     */
-    explicit ParseException(const std::vector<ParseError>& errors)
-        : std::runtime_error(format_errors(errors)), errors_(errors) {}
+  /**
+   * @brief Construct exception from multiple errors.
+   * @param errors Vector of ParseError objects
+   */
+  explicit ParseException(const std::vector<ParseError>& errors)
+      : std::runtime_error(format_errors(errors)), errors_(errors) {}
 
-    /**
-     * @brief Get the first (primary) error.
-     * @return Reference to the first ParseError
-     * @throws std::logic_error if no errors are present
-     */
-    const ParseError& error() const {
-        if (errors_.empty()) throw std::logic_error("No errors in ParseException");
-        return errors_[0];
-    }
+  /**
+   * @brief Get the first (primary) error.
+   * @return Reference to the first ParseError
+   * @throws std::logic_error if no errors are present
+   */
+  const ParseError& error() const {
+    if (errors_.empty())
+      throw std::logic_error("No errors in ParseException");
+    return errors_[0];
+  }
 
-    /**
-     * @brief Get all errors that contributed to this exception.
-     * @return Const reference to the vector of ParseError objects
-     */
-    const std::vector<ParseError>& errors() const { return errors_; }
+  /**
+   * @brief Get all errors that contributed to this exception.
+   * @return Const reference to the vector of ParseError objects
+   */
+  const std::vector<ParseError>& errors() const { return errors_; }
 
 private:
-    std::vector<ParseError> errors_;
+  std::vector<ParseError> errors_;
 
-    static std::string format_errors(const std::vector<ParseError>& errors);
+  static std::string format_errors(const std::vector<ParseError>& errors);
 };
 
 /**

--- a/include/streaming.h
+++ b/include/streaming.h
@@ -42,29 +42,18 @@
 #ifndef LIBVROOM_STREAMING_H
 #define LIBVROOM_STREAMING_H
 
-#include <cstdint>
+#include "dialect.h"
+#include "error.h"
+
 #include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
-#include <vector>
-#include <fstream>
 #include <unordered_map>
-
-#include "dialect.h"
-#include "error.h"
-
-// Deprecation macro for cross-compiler support (guarded to avoid redefinition)
-#ifndef LIBVROOM_DEPRECATED
-    #if defined(__GNUC__) || defined(__clang__)
-        #define LIBVROOM_DEPRECATED(msg) __attribute__((deprecated(msg)))
-    #elif defined(_MSC_VER)
-        #define LIBVROOM_DEPRECATED(msg) __declspec(deprecated(msg))
-    #else
-        #define LIBVROOM_DEPRECATED(msg)
-    #endif
-#endif
+#include <vector>
 
 namespace libvroom {
 
@@ -72,11 +61,11 @@ namespace libvroom {
  * @brief Status codes returned by streaming operations.
  */
 enum class StreamStatus {
-    OK,              ///< Operation succeeded
-    ROW_READY,       ///< A complete row is available (pull model)
-    END_OF_DATA,     ///< No more data to process
-    NEED_MORE_DATA,  ///< Parser needs more input data
-    ERROR            ///< Parse error occurred
+  OK,             ///< Operation succeeded
+  ROW_READY,      ///< A complete row is available (pull model)
+  END_OF_DATA,    ///< No more data to process
+  NEED_MORE_DATA, ///< Parser needs more input data
+  ERROR           ///< Parse error occurred
 };
 
 /**
@@ -87,26 +76,26 @@ enum class StreamStatus {
  * or the parser is reset.
  */
 struct Field {
-    std::string_view data;  ///< View into the buffer (zero-copy)
-    bool is_quoted;         ///< Whether the field was quoted in the source
-    size_t field_index;     ///< Column index (0-based)
+  std::string_view data; ///< View into the buffer (zero-copy)
+  bool is_quoted;        ///< Whether the field was quoted in the source
+  size_t field_index;    ///< Column index (0-based)
 
-    /// Returns true if the field is empty
-    bool empty() const { return data.empty(); }
+  /// Returns true if the field is empty
+  bool empty() const { return data.empty(); }
 
-    /// Returns the field content as a string (allocates memory)
-    std::string str() const { return std::string(data); }
+  /// Returns the field content as a string (allocates memory)
+  std::string str() const { return std::string(data); }
 
-    /**
-     * @brief Returns the field with quotes and escapes removed.
-     *
-     * For quoted fields, removes surrounding quotes and handles escape sequences
-     * (e.g., "" becomes "). For unquoted fields, returns the data as-is.
-     *
-     * @param quote_char The quote character used (default: ")
-     * @return Unescaped field content (allocates memory)
-     */
-    std::string unescaped(char quote_char = '"') const;
+  /**
+   * @brief Returns the field with quotes and escapes removed.
+   *
+   * For quoted fields, removes surrounding quotes and handles escape sequences
+   * (e.g., "" becomes "). For unquoted fields, returns the data as-is.
+   *
+   * @param quote_char The quote character used (default: ")
+   * @return Unescaped field content (allocates memory)
+   */
+  std::string unescaped(char quote_char = '"') const;
 };
 
 /**
@@ -117,69 +106,69 @@ struct Field {
  */
 class Row {
 public:
-    /// Default constructor (empty row)
-    Row() = default;
+  /// Default constructor (empty row)
+  Row() = default;
 
-    /// Number of fields in this row
-    size_t field_count() const { return fields_.size(); }
+  /// Number of fields in this row
+  size_t field_count() const { return fields_.size(); }
 
-    /// Check if row is empty
-    bool empty() const { return fields_.empty(); }
+  /// Check if row is empty
+  bool empty() const { return fields_.empty(); }
 
-    /// Access field by index (0-based), no bounds checking
-    const Field& operator[](size_t index) const { return fields_[index]; }
+  /// Access field by index (0-based), no bounds checking
+  const Field& operator[](size_t index) const { return fields_[index]; }
 
-    /// Access field by index with bounds checking
-    const Field& at(size_t index) const;
+  /// Access field by index with bounds checking
+  const Field& at(size_t index) const;
 
-    /// Access field by column name (requires header parsing)
-    /// @throws std::out_of_range if column name not found
-    const Field& operator[](const std::string& name) const;
+  /// Access field by column name (requires header parsing)
+  /// @throws std::out_of_range if column name not found
+  const Field& operator[](const std::string& name) const;
 
-    /// Current row number (1-based, counts from start of file/stream)
-    size_t row_number() const { return row_number_; }
+  /// Current row number (1-based, counts from start of file/stream)
+  size_t row_number() const { return row_number_; }
 
-    /// Byte offset where this row starts in the source
-    size_t byte_offset() const { return byte_offset_; }
+  /// Byte offset where this row starts in the source
+  size_t byte_offset() const { return byte_offset_; }
 
-    /// Iterator support for range-based for
-    using iterator = std::vector<Field>::const_iterator;
-    iterator begin() const { return fields_.begin(); }
-    iterator end() const { return fields_.end(); }
+  /// Iterator support for range-based for
+  using iterator = std::vector<Field>::const_iterator;
+  iterator begin() const { return fields_.begin(); }
+  iterator end() const { return fields_.end(); }
 
 private:
-    friend class StreamParser;
-    friend class StreamReader;
+  friend class StreamParser;
+  friend class StreamReader;
 
-    std::vector<Field> fields_;
-    std::vector<std::string> field_storage_;  // Owns the field string data
-    size_t row_number_ = 0;
-    size_t byte_offset_ = 0;
+  std::vector<Field> fields_;
+  std::vector<std::string> field_storage_; // Owns the field string data
+  size_t row_number_ = 0;
+  size_t byte_offset_ = 0;
 
-    // Column name lookup (set by StreamParser if header parsing enabled)
-    const std::unordered_map<std::string, size_t>* column_map_ = nullptr;
+  // Column name lookup (set by StreamParser if header parsing enabled)
+  const std::unordered_map<std::string, size_t>* column_map_ = nullptr;
 
-    void clear() {
-        fields_.clear();
-        field_storage_.clear();
-        row_number_ = 0;
-        byte_offset_ = 0;
-    }
+  void clear() {
+    fields_.clear();
+    field_storage_.clear();
+    row_number_ = 0;
+    byte_offset_ = 0;
+  }
 };
 
 /**
  * @brief Configuration for the streaming parser.
  */
 struct StreamConfig {
-    Dialect dialect = Dialect::csv();           ///< CSV dialect settings
-    ErrorMode error_mode = ErrorMode::PERMISSIVE;  ///< Error handling mode
+  Dialect dialect = Dialect::csv();             ///< CSV dialect settings
+  ErrorMode error_mode = ErrorMode::PERMISSIVE; ///< Error handling mode
 
-    size_t chunk_size = 64 * 1024;              ///< Default chunk size for file reading (64KB)
-    size_t max_field_size = 16 * 1024 * 1024;   ///< Maximum field size (16MB, for safety)
-    size_t initial_field_capacity = 64;         ///< Initial capacity for fields vector
+  size_t chunk_size = 64 * 1024;            ///< Default chunk size for file reading (64KB)
+  size_t max_field_size = 16 * 1024 * 1024; ///< Maximum field size (16MB, for safety)
+  size_t initial_field_capacity = 64;       ///< Initial capacity for fields vector
 
-    bool parse_header = true;                   ///< Parse first row as header
-    bool skip_empty_rows = false;               ///< Skip rows with no fields
+  bool parse_header = true;     ///< Parse first row as header
+  bool skip_empty_rows = false; ///< Skip rows with no fields
 };
 
 /**
@@ -235,139 +224,134 @@ using ErrorCallback = std::function<bool(const ParseError& error)>;
  */
 class StreamParser {
 public:
-    /**
-     * @brief Construct a streaming parser with the given configuration.
-     * @param config Parser configuration
-     */
-    explicit StreamParser(const StreamConfig& config = StreamConfig());
+  /**
+   * @brief Construct a streaming parser with the given configuration.
+   * @param config Parser configuration
+   */
+  explicit StreamParser(const StreamConfig& config = StreamConfig());
 
-    /// Destructor
-    ~StreamParser();
+  /// Destructor
+  ~StreamParser();
 
-    // Non-copyable, moveable
-    StreamParser(const StreamParser&) = delete;
-    StreamParser& operator=(const StreamParser&) = delete;
-    StreamParser(StreamParser&&) noexcept;
-    StreamParser& operator=(StreamParser&&) noexcept;
+  // Non-copyable, moveable
+  StreamParser(const StreamParser&) = delete;
+  StreamParser& operator=(const StreamParser&) = delete;
+  StreamParser(StreamParser&&) noexcept;
+  StreamParser& operator=(StreamParser&&) noexcept;
 
-    //--- Configuration ---//
+  //--- Configuration ---//
 
-    /// Get the current configuration (read-only)
-    const StreamConfig& config() const;
+  /// Get the current configuration (read-only)
+  const StreamConfig& config() const;
 
-    //--- Push Model Operations ---//
+  //--- Push Model Operations ---//
 
-    /**
-     * @brief Set the row callback handler (push model).
-     *
-     * The callback is invoked for each complete row found during parsing.
-     * Return true from the callback to continue parsing, false to stop.
-     *
-     * @param callback Function to call for each row
-     */
-    void set_row_handler(RowCallback callback);
+  /**
+   * @brief Set the row callback handler (push model).
+   *
+   * The callback is invoked for each complete row found during parsing.
+   * Return true from the callback to continue parsing, false to stop.
+   *
+   * @param callback Function to call for each row
+   */
+  void set_row_handler(RowCallback callback);
 
-    /**
-     * @brief Set the error callback handler.
-     *
-     * The callback is invoked when parse errors occur. Return true to
-     * continue parsing, false to stop.
-     *
-     * @param callback Function to call for each error
-     */
-    void set_error_handler(ErrorCallback callback);
+  /**
+   * @brief Set the error callback handler.
+   *
+   * The callback is invoked when parse errors occur. Return true to
+   * continue parsing, false to stop.
+   *
+   * @param callback Function to call for each error
+   */
+  void set_error_handler(ErrorCallback callback);
 
-    /**
-     * @brief Feed a chunk of data to the parser (push model).
-     *
-     * The parser will invoke the row callback for each complete row found.
-     * Partial rows at chunk boundaries are buffered internally.
-     *
-     * @param data Pointer to chunk data
-     * @param size Size of chunk in bytes
-     * @return StreamStatus::OK if processed successfully
-     */
-    StreamStatus parse_chunk(const uint8_t* data, size_t size);
+  /**
+   * @brief Feed a chunk of data to the parser (push model).
+   *
+   * The parser will invoke the row callback for each complete row found.
+   * Partial rows at chunk boundaries are buffered internally.
+   *
+   * @param data Pointer to chunk data
+   * @param size Size of chunk in bytes
+   * @return StreamStatus::OK if processed successfully
+   */
+  StreamStatus parse_chunk(const uint8_t* data, size_t size);
 
-    /// Convenience overload for char* data
-    StreamStatus parse_chunk(const char* data, size_t size) {
-        return parse_chunk(reinterpret_cast<const uint8_t*>(data), size);
-    }
+  /// Convenience overload for char* data
+  StreamStatus parse_chunk(const char* data, size_t size) {
+    return parse_chunk(reinterpret_cast<const uint8_t*>(data), size);
+  }
 
-    /// Convenience overload for string_view
-    StreamStatus parse_chunk(std::string_view data) {
-        return parse_chunk(reinterpret_cast<const uint8_t*>(data.data()), data.size());
-    }
+  /// Convenience overload for string_view
+  StreamStatus parse_chunk(std::string_view data) {
+    return parse_chunk(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+  }
 
-    /**
-     * @brief Signal end of input and process any remaining data.
-     *
-     * Must be called after all chunks have been fed to process
-     * any partial row at the end of the file.
-     *
-     * @return StreamStatus::END_OF_DATA on success, StreamStatus::ERROR if errors occurred
-     */
-    StreamStatus finish();
+  /**
+   * @brief Signal end of input and process any remaining data.
+   *
+   * Must be called after all chunks have been fed to process
+   * any partial row at the end of the file.
+   *
+   * @return StreamStatus::END_OF_DATA on success, StreamStatus::ERROR if errors occurred
+   */
+  StreamStatus finish();
 
-    /**
-     * @brief Reset parser state for reuse with new input.
-     *
-     * Clears all internal buffers and state, allowing the parser
-     * to be reused for a new file or stream.
-     */
-    void reset();
+  /**
+   * @brief Reset parser state for reuse with new input.
+   *
+   * Clears all internal buffers and state, allowing the parser
+   * to be reused for a new file or stream.
+   */
+  void reset();
 
-    //--- Pull Model Operations ---//
+  //--- Pull Model Operations ---//
 
-    /**
-     * @brief Attempt to parse and return the next row (pull model).
-     *
-     * This method extracts the next complete row from the buffered data.
-     * If no complete row is available, returns NEED_MORE_DATA.
-     *
-     * @return StreamStatus::ROW_READY if a row is available,
-     *         StreamStatus::NEED_MORE_DATA if more input needed,
-     *         StreamStatus::END_OF_DATA if finish() was called and no more rows,
-     *         StreamStatus::ERROR if a parse error occurred
-     */
-    StreamStatus next_row();
+  /**
+   * @brief Attempt to parse and return the next row (pull model).
+   *
+   * This method extracts the next complete row from the buffered data.
+   * If no complete row is available, returns NEED_MORE_DATA.
+   *
+   * @return StreamStatus::ROW_READY if a row is available,
+   *         StreamStatus::NEED_MORE_DATA if more input needed,
+   *         StreamStatus::END_OF_DATA if finish() was called and no more rows,
+   *         StreamStatus::ERROR if a parse error occurred
+   */
+  StreamStatus next_row();
 
-    /**
-     * @brief Get the current row (valid after next_row() returns ROW_READY).
-     *
-     * @return Reference to the current row
-     * @note The returned reference is invalidated by the next call to next_row()
-     */
-    const Row& current_row() const;
+  /**
+   * @brief Get the current row (valid after next_row() returns ROW_READY).
+   *
+   * @return Reference to the current row
+   * @note The returned reference is invalidated by the next call to next_row()
+   */
+  const Row& current_row() const;
 
-    //--- State Queries ---//
+  //--- State Queries ---//
 
-    /// Get header column names (if parse_header enabled)
-    const std::vector<std::string>& header() const;
+  /// Get header column names (if parse_header enabled)
+  const std::vector<std::string>& header() const;
 
-    /// Get column index by name (-1 if not found)
-    int column_index(const std::string& name) const;
+  /// Get column index by name (-1 if not found)
+  int column_index(const std::string& name) const;
 
-    /// Number of rows processed so far (excluding header if parse_header enabled)
-    size_t rows_processed() const;
+  /// Number of rows processed so far (excluding header if parse_header enabled)
+  size_t rows_processed() const;
 
-    /// Total bytes processed so far
-    size_t bytes_processed() const;
+  /// Total bytes processed so far
+  size_t bytes_processed() const;
 
-    /// Get error collector for inspecting accumulated errors
-    const ErrorCollector& error_collector() const;
+  /// Get error collector for inspecting accumulated errors
+  const ErrorCollector& error_collector() const;
 
-    /// @brief Backward-compatible alias for error_collector().
-    /// @deprecated Use error_collector() instead to avoid confusion with ErrorCollector::errors().
-    LIBVROOM_DEPRECATED("Use error_collector() instead")
-    const ErrorCollector& errors() const { return error_collector(); }
-
-    /// Check if the parser has finished (finish() was called)
-    bool is_finished() const;
+  /// Check if the parser has finished (finish() was called)
+  bool is_finished() const;
 
 private:
-    struct Impl;
-    std::unique_ptr<Impl> impl_;
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
 /**
@@ -378,30 +362,30 @@ private:
  */
 class StreamRowIterator {
 public:
-    using iterator_category = std::input_iterator_tag;
-    using value_type = Row;
-    using difference_type = std::ptrdiff_t;
-    using pointer = const Row*;
-    using reference = const Row&;
+  using iterator_category = std::input_iterator_tag;
+  using value_type = Row;
+  using difference_type = std::ptrdiff_t;
+  using pointer = const Row*;
+  using reference = const Row&;
 
-    /// Create end iterator
-    StreamRowIterator();
+  /// Create end iterator
+  StreamRowIterator();
 
-    /// Create iterator from StreamReader
-    explicit StreamRowIterator(class StreamReader* reader);
+  /// Create iterator from StreamReader
+  explicit StreamRowIterator(class StreamReader* reader);
 
-    reference operator*() const;
-    pointer operator->() const;
+  reference operator*() const;
+  pointer operator->() const;
 
-    StreamRowIterator& operator++();
-    StreamRowIterator operator++(int);
+  StreamRowIterator& operator++();
+  StreamRowIterator operator++(int);
 
-    bool operator==(const StreamRowIterator& other) const;
-    bool operator!=(const StreamRowIterator& other) const;
+  bool operator==(const StreamRowIterator& other) const;
+  bool operator!=(const StreamRowIterator& other) const;
 
 private:
-    class StreamReader* reader_ = nullptr;
-    bool at_end_ = true;
+  class StreamReader* reader_ = nullptr;
+  bool at_end_ = true;
 };
 
 /**
@@ -429,87 +413,80 @@ private:
  */
 class StreamReader {
 public:
-    /**
-     * @brief Construct a reader for the given file.
-     *
-     * @param filename Path to the CSV file
-     * @param config Parser configuration
-     * @throws std::runtime_error if file cannot be opened
-     */
-    explicit StreamReader(const std::string& filename,
-                         const StreamConfig& config = StreamConfig());
+  /**
+   * @brief Construct a reader for the given file.
+   *
+   * @param filename Path to the CSV file
+   * @param config Parser configuration
+   * @throws std::runtime_error if file cannot be opened
+   */
+  explicit StreamReader(const std::string& filename, const StreamConfig& config = StreamConfig());
 
-    /**
-     * @brief Construct a reader from an input stream.
-     *
-     * @param input Input stream to read from
-     * @param config Parser configuration
-     */
-    explicit StreamReader(std::istream& input,
-                         const StreamConfig& config = StreamConfig());
+  /**
+   * @brief Construct a reader from an input stream.
+   *
+   * @param input Input stream to read from
+   * @param config Parser configuration
+   */
+  explicit StreamReader(std::istream& input, const StreamConfig& config = StreamConfig());
 
-    /// Destructor
-    ~StreamReader();
+  /// Destructor
+  ~StreamReader();
 
-    // Non-copyable
-    StreamReader(const StreamReader&) = delete;
-    StreamReader& operator=(const StreamReader&) = delete;
+  // Non-copyable
+  StreamReader(const StreamReader&) = delete;
+  StreamReader& operator=(const StreamReader&) = delete;
 
-    // Moveable
-    StreamReader(StreamReader&&) noexcept;
-    StreamReader& operator=(StreamReader&&) noexcept;
+  // Moveable
+  StreamReader(StreamReader&&) noexcept;
+  StreamReader& operator=(StreamReader&&) noexcept;
 
-    /// Access configuration (read-only after construction)
-    const StreamConfig& config() const;
+  /// Access configuration (read-only after construction)
+  const StreamConfig& config() const;
 
-    /**
-     * @brief Read next row from the file.
-     *
-     * @return true if a row was read, false at end of file or on error
-     */
-    bool next_row();
+  /**
+   * @brief Read next row from the file.
+   *
+   * @return true if a row was read, false at end of file or on error
+   */
+  bool next_row();
 
-    /**
-     * @brief Get current row (valid after next_row() returns true).
-     *
-     * @return Reference to the current row
-     */
-    const Row& row() const;
+  /**
+   * @brief Get current row (valid after next_row() returns true).
+   *
+   * @return Reference to the current row
+   */
+  const Row& row() const;
 
-    /// Get header column names (if parse_header enabled)
-    const std::vector<std::string>& header() const;
+  /// Get header column names (if parse_header enabled)
+  const std::vector<std::string>& header() const;
 
-    /// Get column index by name (-1 if not found)
-    int column_index(const std::string& name) const;
+  /// Get column index by name (-1 if not found)
+  int column_index(const std::string& name) const;
 
-    /// Get error collector for inspecting errors
-    const ErrorCollector& error_collector() const;
+  /// Get error collector for inspecting errors
+  const ErrorCollector& error_collector() const;
 
-    /// @brief Backward-compatible alias for error_collector().
-    /// @deprecated Use error_collector() instead to avoid confusion with ErrorCollector::errors().
-    LIBVROOM_DEPRECATED("Use error_collector() instead")
-    const ErrorCollector& errors() const { return error_collector(); }
+  /// Number of rows read (excluding header)
+  size_t rows_read() const;
 
-    /// Number of rows read (excluding header)
-    size_t rows_read() const;
+  /// Total bytes read from file
+  size_t bytes_read() const;
 
-    /// Total bytes read from file
-    size_t bytes_read() const;
+  /// Check if end of file has been reached
+  bool eof() const;
 
-    /// Check if end of file has been reached
-    bool eof() const;
-
-    /// Iterator support for range-based for
-    StreamRowIterator begin();
-    StreamRowIterator end();
+  /// Iterator support for range-based for
+  StreamRowIterator begin();
+  StreamRowIterator end();
 
 private:
-    struct Impl;
-    std::unique_ptr<Impl> impl_;
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 
-    friend class StreamRowIterator;
+  friend class StreamRowIterator;
 };
 
-}  // namespace libvroom
+} // namespace libvroom
 
-#endif  // LIBVROOM_STREAMING_H
+#endif // LIBVROOM_STREAMING_H

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -46,7 +46,7 @@
  *
  * @see libvroom::Parser for the unified public API
  * @see libvroom::ParseOptions for configuration options
- * @see libvroom::index for the result structure containing field positions
+ * @see libvroom::ParseIndex for the result structure containing field positions
  */
 
 #include "branchless_state_machine.h"
@@ -63,30 +63,6 @@
 #include <unistd.h> // for getopt
 #include <unordered_set>
 #include <vector>
-
-// Deprecation macro for cross-compiler support
-#if defined(__GNUC__) || defined(__clang__)
-#define LIBVROOM_DEPRECATED(msg) __attribute__((deprecated(msg)))
-#elif defined(_MSC_VER)
-#define LIBVROOM_DEPRECATED(msg) __declspec(deprecated(msg))
-#else
-#define LIBVROOM_DEPRECATED(msg)
-#endif
-
-// Macro to suppress deprecation warnings for internal use
-// (Parser class needs to call deprecated methods)
-#ifdef __GNUC__
-#define LIBVROOM_SUPPRESS_DEPRECATION_START                                                        \
-  _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define LIBVROOM_SUPPRESS_DEPRECATION_END _Pragma("GCC diagnostic pop")
-#elif defined(_MSC_VER)
-#define LIBVROOM_SUPPRESS_DEPRECATION_START                                                        \
-  __pragma(warning(push)) __pragma(warning(disable : 4996))
-#define LIBVROOM_SUPPRESS_DEPRECATION_END __pragma(warning(pop))
-#else
-#define LIBVROOM_SUPPRESS_DEPRECATION_START
-#define LIBVROOM_SUPPRESS_DEPRECATION_END
-#endif
 
 namespace libvroom {
 
@@ -238,15 +214,10 @@ private:
   friend class TwoPass;
 };
 
-/// @brief Backward-compatible alias for ParseIndex.
-/// @deprecated Use ParseIndex instead. This alias will be removed in a future
-/// version.
-using index [[deprecated("Use ParseIndex instead")]] = ParseIndex;
-
 /**
  * @brief High-performance CSV parser using a speculative two-pass algorithm.
  *
- * The two_pass class implements a multi-threaded CSV parsing algorithm that
+ * The TwoPass class implements a multi-threaded CSV parsing algorithm that
  * achieves high performance through SIMD operations and speculative parallel
  * processing. The algorithm is based on research by Chang et al. (SIGMOD 2019)
  * combined with SIMD techniques from Langdale & Lemire (simdjson).
@@ -275,8 +246,8 @@ using index [[deprecated("Use ParseIndex instead")]] = ParseIndex;
  * auto [buffer, length] = libvroom::load_file("data.csv");
  *
  * // Create parser and initialize index
- * libvroom::two_pass parser;
- * libvroom::index idx = parser.init(length, 4);  // 4 threads
+ * libvroom::TwoPass parser;
+ * libvroom::ParseIndex idx = parser.init(length, 4);  // 4 threads
  *
  * // Parse without error collection (throws on error)
  * parser.parse(buffer, idx, length);
@@ -616,34 +587,19 @@ public:
 
   /**
    * @brief Parse using speculative multi-threading with dialect support.
-   *
-   * @deprecated Use Parser::parse() with ParseOptions{.algorithm =
-   * ParseAlgorithm::SPECULATIVE} instead. This method will be made private in a
-   * future version.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::SPECULATIVE instead")
   bool parse_speculate(const uint8_t* buf, ParseIndex& out, size_t len,
                        const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse using two-pass algorithm with dialect support.
-   *
-   * @deprecated Use Parser::parse() with ParseOptions{.algorithm =
-   * ParseAlgorithm::TWO_PASS} instead. This method will be made private in a
-   * future version.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with ParseAlgorithm::TWO_PASS instead")
   bool parse_two_pass(const uint8_t* buf, ParseIndex& out, size_t len,
                       const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer and build the field index.
-   *
-   * @deprecated Use Parser::parse() from libvroom.h instead. The Parser class
-   *             provides a simpler, unified API with automatic index
-   * management.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() from libvroom.h instead")
   bool parse(const uint8_t* buf, ParseIndex& out, size_t len,
              const Dialect& dialect = Dialect::csv());
 
@@ -674,21 +630,13 @@ public:
 
   /**
    * @brief Parse a CSV buffer using branchless state machine (optimized).
-   *
-   * @deprecated Use Parser::parse() with ParseOptions::branchless() instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with ParseOptions::branchless() instead")
   bool parse_branchless(const uint8_t* buf, ParseIndex& out, size_t len,
                         const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with automatic dialect detection.
-   *
-   * @deprecated Use Parser::parse() with default ParseOptions (auto-detects
-   * dialect).
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.errors = &errors} instead "
-                      "(auto-detects dialect)")
   bool parse_auto(const uint8_t* buf, ParseIndex& out, size_t len, ErrorCollector& errors,
                   DetectionResult* detected = nullptr,
                   const DetectionOptions& detection_options = DetectionOptions());
@@ -718,21 +666,13 @@ public:
 
   /**
    * @brief Parse a CSV buffer with error collection using multi-threading.
-   *
-   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors}
-   * instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_two_pass_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
                                   ErrorCollector& errors, const Dialect& dialect = Dialect::csv());
 
   /**
    * @brief Parse a CSV buffer with detailed error collection (single-threaded).
-   *
-   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors}
-   * instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_with_errors(const uint8_t* buf, ParseIndex& out, size_t len, ErrorCollector& errors,
                          const Dialect& dialect = Dialect::csv());
 
@@ -756,11 +696,7 @@ public:
 
   /**
    * @brief Perform full CSV validation with comprehensive error checking.
-   *
-   * @deprecated Use Parser::parse() with {.dialect = ..., .errors = &errors}
-   * instead.
    */
-  LIBVROOM_DEPRECATED("Use Parser::parse() with {.dialect = ..., .errors = &errors} instead")
   bool parse_validate(const uint8_t* buf, ParseIndex& out, size_t len, ErrorCollector& errors,
                       const Dialect& dialect = Dialect::csv());
 
@@ -774,11 +710,6 @@ public:
    */
   ParseIndex init_safe(size_t len, size_t n_threads, ErrorCollector* errors = nullptr);
 };
-
-/// @brief Backward-compatible alias for TwoPass.
-/// @deprecated Use TwoPass instead. This alias will be removed in a future
-/// version.
-using two_pass [[deprecated("Use TwoPass instead")]] = TwoPass;
 
 } // namespace libvroom
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -49,7 +49,7 @@ constexpr size_t MIN_PARALLEL_SIZE = 1024 * 1024;  // Minimum size for parallel 
  */
 class CsvIterator {
 public:
-  CsvIterator(const uint8_t* buf, const libvroom::index& idx) : buf_(buf), idx_(idx) {
+  CsvIterator(const uint8_t* buf, const libvroom::ParseIndex& idx) : buf_(buf), idx_(idx) {
     // Merge indexes from all threads into sorted order
     mergeIndexes();
   }
@@ -145,7 +145,7 @@ private:
   }
 
   const uint8_t* buf_;
-  const libvroom::index& idx_;
+  const libvroom::ParseIndex& idx_;
   std::vector<uint64_t> merged_indexes_;
 };
 
@@ -210,9 +210,9 @@ static bool isStdinInput(const char* filename) {
 
 /// Result of loading and parsing a file
 struct ParseResult {
-  LoadResult load_result; ///< The loaded data (RAII-managed)
-  libvroom::index idx;    ///< The parsed index
-  bool success{false};    ///< Whether parsing was successful
+  LoadResult load_result;   ///< The loaded data (RAII-managed)
+  libvroom::ParseIndex idx; ///< The parsed index
+  bool success{false};      ///< Whether parsing was successful
 };
 
 // Parse a file or stdin - returns ParseResult with RAII-managed data

--- a/src/libvroom_c.cpp
+++ b/src/libvroom_c.cpp
@@ -33,7 +33,7 @@ struct libvroom_index {
   // Default constructor - index will be populated by Parser::parse()
   libvroom_index(size_t threads) : idx(), num_threads(threads) {}
 
-  // Note: No explicit destructor needed - libvroom::index has its own destructor
+  // Note: No explicit destructor needed - libvroom::ParseIndex has its own destructor
   // that handles cleanup of n_indexes and indexes arrays
 };
 

--- a/src/two_pass.cpp
+++ b/src/two_pass.cpp
@@ -455,8 +455,6 @@ uint64_t TwoPass::second_pass_chunk_throwing(const uint8_t* buf, size_t start, s
 // TwoPass orchestration methods
 //-----------------------------------------------------------------------------
 
-LIBVROOM_SUPPRESS_DEPRECATION_START
-
 bool TwoPass::parse_speculate(const uint8_t* buf, ParseIndex& out, size_t len,
                               const Dialect& dialect) {
   char delim = dialect.delimiter;
@@ -588,8 +586,6 @@ bool TwoPass::parse(const uint8_t* buf, ParseIndex& out, size_t len, const Diale
   return parse_speculate(buf, out, len, dialect);
 }
 
-LIBVROOM_SUPPRESS_DEPRECATION_END
-
 TwoPass::branchless_chunk_result TwoPass::second_pass_branchless_chunk_with_errors(
     const BranchlessStateMachine& sm, const uint8_t* buf, size_t start, size_t end, ParseIndex* out,
     size_t thread_id, size_t total_len, ErrorMode mode) {
@@ -711,8 +707,6 @@ bool TwoPass::parse_branchless_with_errors(const uint8_t* buf, ParseIndex& out, 
   return !errors.has_fatal_errors();
 }
 
-LIBVROOM_SUPPRESS_DEPRECATION_START
-
 bool TwoPass::parse_branchless(const uint8_t* buf, ParseIndex& out, size_t len,
                                const Dialect& dialect) {
   BranchlessStateMachine sm(dialect.delimiter, dialect.quote_char, dialect.escape_char,
@@ -811,8 +805,6 @@ bool TwoPass::parse_auto(const uint8_t* buf, ParseIndex& out, size_t len, ErrorC
   return parse_two_pass_with_errors(buf, out, len, errors, dialect);
 }
 
-LIBVROOM_SUPPRESS_DEPRECATION_END
-
 DetectionResult TwoPass::detect_dialect(const uint8_t* buf, size_t len,
                                         const DetectionOptions& options) {
   DialectDetector detector(options);
@@ -830,8 +822,6 @@ TwoPass::chunk_result TwoPass::second_pass_chunk_with_errors(const uint8_t* buf,
                                        delimiter, quote_char);
   return result;
 }
-
-LIBVROOM_SUPPRESS_DEPRECATION_START
 
 bool TwoPass::parse_two_pass_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
                                          ErrorCollector& errors, const Dialect& dialect) {
@@ -982,8 +972,6 @@ bool TwoPass::parse_validate(const uint8_t* buf, ParseIndex& out, size_t len,
 
   return !errors.has_fatal_errors();
 }
-
-LIBVROOM_SUPPRESS_DEPRECATION_END
 
 //-----------------------------------------------------------------------------
 // TwoPass validation functions

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -54,7 +54,8 @@ TEST_F(SimplifiedAPITest, ParserWithErrors) {
   libvroom::FileBuffer buffer(data, len);
   libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
   libvroom::Parser parser;
-  auto result = parser.parse_with_errors(buffer.data(), buffer.size(), errors);
+  auto result = parser.parse(buffer.data(), buffer.size(),
+                             {.dialect = libvroom::Dialect::csv(), .errors = &errors});
   EXPECT_TRUE(result.success());
   EXPECT_TRUE(errors.has_errors());
 }
@@ -64,14 +65,15 @@ TEST_F(SimplifiedAPITest, ParserDialects) {
     auto [data, len] = make_buffer("a\tb\tc\n1\t2\t3\n");
     libvroom::FileBuffer buffer(data, len);
     libvroom::Parser parser;
-    auto result = parser.parse(buffer.data(), buffer.size(), libvroom::Dialect::tsv());
+    auto result = parser.parse(buffer.data(), buffer.size(), {.dialect = libvroom::Dialect::tsv()});
     EXPECT_TRUE(result.success());
   }
   {
     auto [data, len] = make_buffer("a;b;c\n1;2;3\n");
     libvroom::FileBuffer buffer(data, len);
     libvroom::Parser parser;
-    auto result = parser.parse(buffer.data(), buffer.size(), libvroom::Dialect::semicolon());
+    auto result =
+        parser.parse(buffer.data(), buffer.size(), {.dialect = libvroom::Dialect::semicolon()});
     EXPECT_TRUE(result.success());
   }
 }
@@ -89,7 +91,7 @@ TEST_F(SimplifiedAPITest, ParserAutoDetection) {
   libvroom::FileBuffer buffer(data, len);
   libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
   libvroom::Parser parser;
-  auto result = parser.parse_auto(buffer.data(), buffer.size(), errors);
+  auto result = parser.parse(buffer.data(), buffer.size(), {.errors = &errors});
   EXPECT_TRUE(result.success());
   EXPECT_EQ(result.dialect.delimiter, ';');
 }
@@ -110,7 +112,7 @@ TEST_F(SimplifiedAPITest, CustomDialect) {
   custom.delimiter = ':';
   custom.quote_char = '\'';
   libvroom::Parser parser;
-  auto result = parser.parse(buffer.data(), buffer.size(), custom);
+  auto result = parser.parse(buffer.data(), buffer.size(), {.dialect = custom});
   EXPECT_TRUE(result.success());
 }
 
@@ -270,7 +272,8 @@ TEST_F(UnifiedAPITest, LegacyParseWithDialect) {
   libvroom::FileBuffer buffer(data, len);
   libvroom::Parser parser;
 
-  auto result = parser.parse(buffer.data(), buffer.size(), libvroom::Dialect::semicolon());
+  auto result =
+      parser.parse(buffer.data(), buffer.size(), {.dialect = libvroom::Dialect::semicolon()});
   EXPECT_TRUE(result.success());
   EXPECT_EQ(result.dialect.delimiter, ';');
 }
@@ -282,7 +285,8 @@ TEST_F(UnifiedAPITest, LegacyParseWithErrors) {
   libvroom::Parser parser;
 
   libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-  auto result = parser.parse_with_errors(buffer.data(), buffer.size(), errors);
+  auto result = parser.parse(buffer.data(), buffer.size(),
+                             {.dialect = libvroom::Dialect::csv(), .errors = &errors});
   EXPECT_TRUE(result.success());
   EXPECT_TRUE(errors.has_errors());
 }
@@ -294,7 +298,7 @@ TEST_F(UnifiedAPITest, LegacyParseAuto) {
   libvroom::Parser parser;
 
   libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-  auto result = parser.parse_auto(buffer.data(), buffer.size(), errors);
+  auto result = parser.parse(buffer.data(), buffer.size(), {.errors = &errors});
   EXPECT_TRUE(result.success());
   EXPECT_EQ(result.dialect.delimiter, ';');
 }
@@ -1143,7 +1147,7 @@ TEST_F(RowColumnIterationTest, TSVIteration) {
   libvroom::FileBuffer buffer(data, len);
   libvroom::Parser parser;
 
-  auto result = parser.parse(buffer.data(), buffer.size(), libvroom::Dialect::tsv());
+  auto result = parser.parse(buffer.data(), buffer.size(), {.dialect = libvroom::Dialect::tsv()});
   EXPECT_TRUE(result.success());
   EXPECT_EQ(result.num_rows(), 2);
 
@@ -1156,7 +1160,8 @@ TEST_F(RowColumnIterationTest, SemicolonIteration) {
   libvroom::FileBuffer buffer(data, len);
   libvroom::Parser parser;
 
-  auto result = parser.parse(buffer.data(), buffer.size(), libvroom::Dialect::semicolon());
+  auto result =
+      parser.parse(buffer.data(), buffer.size(), {.dialect = libvroom::Dialect::semicolon()});
   EXPECT_TRUE(result.success());
   EXPECT_EQ(result.num_rows(), 2);
 
@@ -1533,9 +1538,7 @@ TEST_F(IndexMemoryTest, WithParsing) {
   libvroom::TwoPass parser;
   libvroom::ParseIndex idx = parser.init(buffer.size(), 1);
 
-  LIBVROOM_SUPPRESS_DEPRECATION_START
   bool success = parser.parse(buffer.data(), idx, buffer.size());
-  LIBVROOM_SUPPRESS_DEPRECATION_END
 
   EXPECT_TRUE(success);
   EXPECT_GT(idx.n_indexes[0], 0);
@@ -1550,9 +1553,7 @@ TEST_F(IndexMemoryTest, WithMultiThreadedParsing) {
   libvroom::TwoPass parser;
   libvroom::ParseIndex idx = parser.init(buffer.size(), 4);
 
-  LIBVROOM_SUPPRESS_DEPRECATION_START
   bool success = parser.parse(buffer.data(), idx, buffer.size());
-  LIBVROOM_SUPPRESS_DEPRECATION_END
 
   EXPECT_TRUE(success);
   // Memory automatically freed when idx and buffer go out of scope

--- a/test/concurrency_test.cpp
+++ b/test/concurrency_test.cpp
@@ -12,13 +12,12 @@
  *   ./build/concurrency_test
  */
 
-#include <gtest/gtest.h>
-#include <libvroom.h>
-
 #include <atomic>
 #include <chrono>
 #include <cstring>
 #include <future>
+#include <gtest/gtest.h>
+#include <libvroom.h>
 #include <random>
 #include <string>
 #include <thread>
@@ -26,37 +25,39 @@
 
 // Helper function to create padded buffer from string
 static std::pair<uint8_t*, size_t> make_buffer(const std::string& content) {
-    size_t len = content.size();
-    uint8_t* buf = allocate_padded_buffer(len, 64);
-    std::memcpy(buf, content.data(), len);
-    return {buf, len};
+  size_t len = content.size();
+  uint8_t* buf = allocate_padded_buffer(len, 64);
+  std::memcpy(buf, content.data(), len);
+  return {buf, len};
 }
 
 // Generate CSV data with specified rows and columns
 static std::string generate_csv(size_t rows, size_t cols, bool with_quotes = false) {
-    std::string csv;
-    csv.reserve(rows * cols * 10);  // Rough estimate
+  std::string csv;
+  csv.reserve(rows * cols * 10); // Rough estimate
 
-    // Header
+  // Header
+  for (size_t c = 0; c < cols; ++c) {
+    if (c > 0)
+      csv += ',';
+    csv += "col" + std::to_string(c);
+  }
+  csv += '\n';
+
+  // Data rows
+  for (size_t r = 0; r < rows; ++r) {
     for (size_t c = 0; c < cols; ++c) {
-        if (c > 0) csv += ',';
-        csv += "col" + std::to_string(c);
+      if (c > 0)
+        csv += ',';
+      if (with_quotes && (r % 2 == 0)) {
+        csv += "\"value" + std::to_string(r) + "_" + std::to_string(c) + "\"";
+      } else {
+        csv += "value" + std::to_string(r) + "_" + std::to_string(c);
+      }
     }
     csv += '\n';
-
-    // Data rows
-    for (size_t r = 0; r < rows; ++r) {
-        for (size_t c = 0; c < cols; ++c) {
-            if (c > 0) csv += ',';
-            if (with_quotes && (r % 2 == 0)) {
-                csv += "\"value" + std::to_string(r) + "_" + std::to_string(c) + "\"";
-            } else {
-                csv += "value" + std::to_string(r) + "_" + std::to_string(c);
-            }
-        }
-        csv += '\n';
-    }
-    return csv;
+  }
+  return csv;
 }
 
 // =============================================================================
@@ -65,13 +66,14 @@ static std::string generate_csv(size_t rows, size_t cols, bool with_quotes = fal
 
 class ConcurrencyTest : public ::testing::Test {
 protected:
-    void SetUp() override {
-        // Get hardware concurrency for adaptive tests
-        hw_concurrency_ = std::thread::hardware_concurrency();
-        if (hw_concurrency_ == 0) hw_concurrency_ = 4;  // Fallback
-    }
+  void SetUp() override {
+    // Get hardware concurrency for adaptive tests
+    hw_concurrency_ = std::thread::hardware_concurrency();
+    if (hw_concurrency_ == 0)
+      hw_concurrency_ = 4; // Fallback
+  }
 
-    unsigned int hw_concurrency_;
+  unsigned int hw_concurrency_;
 };
 
 // =============================================================================
@@ -80,91 +82,91 @@ protected:
 
 // Test: Many threads parsing identical data concurrently
 TEST_F(ConcurrencyTest, ManyThreadsSameData) {
-    const std::string csv = generate_csv(100, 5);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  const std::string csv = generate_csv(100, 5);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    const int num_threads = 100;
-    std::vector<std::future<bool>> futures;
-    std::atomic<int> success_count{0};
-    std::atomic<int> failure_count{0};
+  const int num_threads = 100;
+  std::vector<std::future<bool>> futures;
+  std::atomic<int> success_count{0};
+  std::atomic<int> failure_count{0};
 
-    for (int i = 0; i < num_threads; ++i) {
-        futures.push_back(std::async(std::launch::async, [&buffer, &success_count, &failure_count]() {
-            libvroom::Parser parser(4);  // Each parser uses 4 threads
-            auto result = parser.parse(buffer.data(), buffer.size());
-            if (result.success() && result.total_indexes() > 0) {
-                success_count++;
-                return true;
-            } else {
-                failure_count++;
-                return false;
-            }
-        }));
-    }
+  for (int i = 0; i < num_threads; ++i) {
+    futures.push_back(std::async(std::launch::async, [&buffer, &success_count, &failure_count]() {
+      libvroom::Parser parser(4); // Each parser uses 4 threads
+      auto result = parser.parse(buffer.data(), buffer.size());
+      if (result.success() && result.total_indexes() > 0) {
+        success_count++;
+        return true;
+      } else {
+        failure_count++;
+        return false;
+      }
+    }));
+  }
 
-    // Wait for all threads to complete
-    for (auto& f : futures) {
-        EXPECT_TRUE(f.get());
-    }
+  // Wait for all threads to complete
+  for (auto& f : futures) {
+    EXPECT_TRUE(f.get());
+  }
 
-    EXPECT_EQ(success_count.load(), num_threads);
-    EXPECT_EQ(failure_count.load(), 0);
+  EXPECT_EQ(success_count.load(), num_threads);
+  EXPECT_EQ(failure_count.load(), 0);
 }
 
 // Test: Concurrent parser instances with different data
 TEST_F(ConcurrencyTest, ConcurrentParsersWithDifferentData) {
-    const int num_parsers = 50;
-    std::vector<std::string> csv_data;
-    std::vector<std::pair<uint8_t*, size_t>> buffers;
+  const int num_parsers = 50;
+  std::vector<std::string> csv_data;
+  std::vector<std::pair<uint8_t*, size_t>> buffers;
 
-    // Create different CSV data for each parser
-    for (int i = 0; i < num_parsers; ++i) {
-        csv_data.push_back(generate_csv(50 + i, 3 + (i % 5)));
-        buffers.push_back(make_buffer(csv_data.back()));
-    }
+  // Create different CSV data for each parser
+  for (int i = 0; i < num_parsers; ++i) {
+    csv_data.push_back(generate_csv(50 + i, 3 + (i % 5)));
+    buffers.push_back(make_buffer(csv_data.back()));
+  }
 
-    std::vector<std::future<bool>> futures;
-    std::atomic<int> success_count{0};
+  std::vector<std::future<bool>> futures;
+  std::atomic<int> success_count{0};
 
-    for (int i = 0; i < num_parsers; ++i) {
-        futures.push_back(std::async(std::launch::async, [i, &buffers, &success_count]() {
-            libvroom::Parser parser(2);
-            auto result = parser.parse(buffers[i].first, buffers[i].second);
-            if (result.success()) {
-                success_count++;
-                return true;
-            }
-            return false;
-        }));
-    }
+  for (int i = 0; i < num_parsers; ++i) {
+    futures.push_back(std::async(std::launch::async, [i, &buffers, &success_count]() {
+      libvroom::Parser parser(2);
+      auto result = parser.parse(buffers[i].first, buffers[i].second);
+      if (result.success()) {
+        success_count++;
+        return true;
+      }
+      return false;
+    }));
+  }
 
-    for (auto& f : futures) {
-        EXPECT_TRUE(f.get());
-    }
+  for (auto& f : futures) {
+    EXPECT_TRUE(f.get());
+  }
 
-    EXPECT_EQ(success_count.load(), num_parsers);
+  EXPECT_EQ(success_count.load(), num_parsers);
 
-    // Clean up buffers not managed by FileBuffer
-    for (auto& [ptr, _] : buffers) {
-        aligned_free(ptr);
-    }
+  // Clean up buffers not managed by FileBuffer
+  for (auto& [ptr, _] : buffers) {
+    aligned_free(ptr);
+  }
 }
 
 // Test: Repeated parsing in tight loop (stress test for memory management)
 TEST_F(ConcurrencyTest, RepeatedParsingStress) {
-    const std::string csv = generate_csv(50, 5);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  const std::string csv = generate_csv(50, 5);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    const int iterations = 1000;
-    libvroom::Parser parser(hw_concurrency_);
+  const int iterations = 1000;
+  libvroom::Parser parser(hw_concurrency_);
 
-    for (int i = 0; i < iterations; ++i) {
-        auto result = parser.parse(buffer.data(), buffer.size());
-        ASSERT_TRUE(result.success()) << "Failed at iteration " << i;
-        ASSERT_GT(result.total_indexes(), 0) << "No indexes at iteration " << i;
-    }
+  for (int i = 0; i < iterations; ++i) {
+    auto result = parser.parse(buffer.data(), buffer.size());
+    ASSERT_TRUE(result.success()) << "Failed at iteration " << i;
+    ASSERT_GT(result.total_indexes(), 0) << "No indexes at iteration " << i;
+  }
 }
 
 // =============================================================================
@@ -173,92 +175,93 @@ TEST_F(ConcurrencyTest, RepeatedParsingStress) {
 
 // Test: File smaller than minimum chunk size (64 bytes)
 TEST_F(ConcurrencyTest, FileSmallerThanChunkSize) {
-    // Create a small CSV that's definitely less than 64 bytes
-    const std::string csv = "a,b,c\n1,2,3\n";  // ~12 bytes
-    ASSERT_LT(csv.size(), 64);
+  // Create a small CSV that's definitely less than 64 bytes
+  const std::string csv = "a,b,c\n1,2,3\n"; // ~12 bytes
+  ASSERT_LT(csv.size(), 64);
 
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Try with various thread counts - should all succeed
-    for (int threads = 1; threads <= 8; ++threads) {
-        libvroom::Parser parser(threads);
-        auto result = parser.parse(buffer.data(), buffer.size());
-        EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
-        EXPECT_GT(result.total_indexes(), 0);
-    }
+  // Try with various thread counts - should all succeed
+  for (int threads = 1; threads <= 8; ++threads) {
+    libvroom::Parser parser(threads);
+    auto result = parser.parse(buffer.data(), buffer.size());
+    EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
+    EXPECT_GT(result.total_indexes(), 0);
+  }
 }
 
 // Test: Chunk boundary coinciding with quote characters
 TEST_F(ConcurrencyTest, ChunkBoundaryAtQuote) {
-    // Create CSV where quotes might fall on chunk boundaries
-    // Use repeated quoted fields to increase likelihood
-    std::string csv = "name,description\n";
-    for (int i = 0; i < 100; ++i) {
-        csv += "\"item" + std::to_string(i) + "\",\"This is a description with, comma\"\n";
-    }
+  // Create CSV where quotes might fall on chunk boundaries
+  // Use repeated quoted fields to increase likelihood
+  std::string csv = "name,description\n";
+  for (int i = 0; i < 100; ++i) {
+    csv += "\"item" + std::to_string(i) + "\",\"This is a description with, comma\"\n";
+  }
 
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Parse with different thread counts - all should succeed without crashes
-    for (int threads = 1; threads <= 8; ++threads) {
-        libvroom::Parser parser(threads);
-        auto result = parser.parse(buffer.data(), buffer.size());
-        EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
-        EXPECT_GT(result.total_indexes(), 0) << "No indexes with " << threads << " threads";
-    }
+  // Parse with different thread counts - all should succeed without crashes
+  for (int threads = 1; threads <= 8; ++threads) {
+    libvroom::Parser parser(threads);
+    auto result = parser.parse(buffer.data(), buffer.size());
+    EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
+    EXPECT_GT(result.total_indexes(), 0) << "No indexes with " << threads << " threads";
+  }
 }
 
 // Test: Single quoted field spanning entire file
 TEST_F(ConcurrencyTest, SingleQuotedFieldSpanningFile) {
-    // A CSV with one quoted field that spans a large portion of the file
-    std::string long_value(500, 'x');  // 500 character value
-    std::string csv = "col1,col2\n\"" + long_value + "\",value2\n";
+  // A CSV with one quoted field that spans a large portion of the file
+  std::string long_value(500, 'x'); // 500 character value
+  std::string csv = "col1,col2\n\"" + long_value + "\",value2\n";
 
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // This tests quote parity tracking across chunks
-    for (int threads = 1; threads <= 8; ++threads) {
-        libvroom::Parser parser(threads);
-        auto result = parser.parse(buffer.data(), buffer.size());
-        EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
-    }
+  // This tests quote parity tracking across chunks
+  for (int threads = 1; threads <= 8; ++threads) {
+    libvroom::Parser parser(threads);
+    auto result = parser.parse(buffer.data(), buffer.size());
+    EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
+  }
 }
 
 // Test: Single line content with multiple threads
 TEST_F(ConcurrencyTest, SingleLineMultipleThreads) {
-    // CSV with header and one very long data row
-    std::string csv = "a,b,c,d,e,f,g,h,i,j\n";
-    for (int i = 0; i < 100; ++i) {
-        if (i > 0) csv += ",";
-        csv += "value" + std::to_string(i);
-    }
-    csv += "\n";
+  // CSV with header and one very long data row
+  std::string csv = "a,b,c,d,e,f,g,h,i,j\n";
+  for (int i = 0; i < 100; ++i) {
+    if (i > 0)
+      csv += ",";
+    csv += "value" + std::to_string(i);
+  }
+  csv += "\n";
 
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Parse with 8 threads on essentially 2-line data
-    libvroom::Parser parser(8);
-    auto result = parser.parse(buffer.data(), buffer.size());
-    EXPECT_TRUE(result.success());
-    EXPECT_GT(result.total_indexes(), 0);
+  // Parse with 8 threads on essentially 2-line data
+  libvroom::Parser parser(8);
+  auto result = parser.parse(buffer.data(), buffer.size());
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(result.total_indexes(), 0);
 }
 
 // Test: No newlines in file (forces fallback)
 TEST_F(ConcurrencyTest, NoNewlines) {
-    // CSV with no newlines - just a single line
-    std::string csv = "a,b,c,d,e,f,g,h,i,j";
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  // CSV with no newlines - just a single line
+  std::string csv = "a,b,c,d,e,f,g,h,i,j";
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Should handle gracefully even with multiple threads
-    libvroom::Parser parser(4);
-    auto result = parser.parse(buffer.data(), buffer.size());
-    // May succeed or fail, but should not crash
-    SUCCEED();
+  // Should handle gracefully even with multiple threads
+  libvroom::Parser parser(4);
+  auto result = parser.parse(buffer.data(), buffer.size());
+  // May succeed or fail, but should not crash
+  SUCCEED();
 }
 
 // =============================================================================
@@ -267,83 +270,83 @@ TEST_F(ConcurrencyTest, NoNewlines) {
 
 // Test: Thread count exceeding row count
 TEST_F(ConcurrencyTest, MoreThreadsThanRows) {
-    // CSV with only 3 rows
-    const std::string csv = "a,b,c\n1,2,3\n4,5,6\n";
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  // CSV with only 3 rows
+  const std::string csv = "a,b,c\n1,2,3\n4,5,6\n";
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Try with 8 threads on 3 rows
-    libvroom::Parser parser(8);
-    auto result = parser.parse(buffer.data(), buffer.size());
-    EXPECT_TRUE(result.success());
-    EXPECT_GT(result.total_indexes(), 0);
+  // Try with 8 threads on 3 rows
+  libvroom::Parser parser(8);
+  auto result = parser.parse(buffer.data(), buffer.size());
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(result.total_indexes(), 0);
 }
 
 // Test: Thread count exceeding byte count
 TEST_F(ConcurrencyTest, MoreThreadsThanBytes) {
-    // 10 byte CSV with 255 threads
-    const std::string csv = "a,b\n1,2\n";
-    ASSERT_LT(csv.size(), 255);
+  // 10 byte CSV with 255 threads
+  const std::string csv = "a,b\n1,2\n";
+  ASSERT_LT(csv.size(), 255);
 
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    libvroom::Parser parser(255);  // Max uint8_t
-    auto result = parser.parse(buffer.data(), buffer.size());
-    EXPECT_TRUE(result.success());
+  libvroom::Parser parser(255); // Max uint8_t
+  auto result = parser.parse(buffer.data(), buffer.size());
+  EXPECT_TRUE(result.success());
 }
 
 // Test: Zero thread count (should default to 1)
 TEST_F(ConcurrencyTest, ZeroThreads) {
-    const std::string csv = "a,b,c\n1,2,3\n";
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  const std::string csv = "a,b,c\n1,2,3\n";
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    libvroom::Parser parser(0);
-    EXPECT_EQ(parser.num_threads(), 1);  // Should default to 1
+  libvroom::Parser parser(0);
+  EXPECT_EQ(parser.num_threads(), 1); // Should default to 1
 
-    auto result = parser.parse(buffer.data(), buffer.size());
-    EXPECT_TRUE(result.success());
+  auto result = parser.parse(buffer.data(), buffer.size());
+  EXPECT_TRUE(result.success());
 }
 
 // Test: Maximum thread count (255 due to uint8_t)
 TEST_F(ConcurrencyTest, MaximumThreadCount) {
-    // Generate larger CSV to actually utilize threads
-    const std::string csv = generate_csv(1000, 10);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  // Generate larger CSV to actually utilize threads
+  const std::string csv = generate_csv(1000, 10);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    libvroom::Parser parser(255);
-    auto result = parser.parse(buffer.data(), buffer.size());
-    EXPECT_TRUE(result.success());
-    EXPECT_GT(result.total_indexes(), 0);
+  libvroom::Parser parser(255);
+  auto result = parser.parse(buffer.data(), buffer.size());
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(result.total_indexes(), 0);
 }
 
 // Test: Single thread parsing
 TEST_F(ConcurrencyTest, SingleThreadParsing) {
-    const std::string csv = generate_csv(100, 5);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  const std::string csv = generate_csv(100, 5);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    libvroom::Parser parser(1);
-    auto result = parser.parse(buffer.data(), buffer.size());
-    EXPECT_TRUE(result.success());
-    EXPECT_GT(result.total_indexes(), 0);
+  libvroom::Parser parser(1);
+  auto result = parser.parse(buffer.data(), buffer.size());
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(result.total_indexes(), 0);
 }
 
 // Test: set_num_threads() changes thread count
 TEST_F(ConcurrencyTest, SetNumThreads) {
-    libvroom::Parser parser(1);
-    EXPECT_EQ(parser.num_threads(), 1);
+  libvroom::Parser parser(1);
+  EXPECT_EQ(parser.num_threads(), 1);
 
-    parser.set_num_threads(4);
-    EXPECT_EQ(parser.num_threads(), 4);
+  parser.set_num_threads(4);
+  EXPECT_EQ(parser.num_threads(), 4);
 
-    parser.set_num_threads(0);
-    EXPECT_EQ(parser.num_threads(), 1);  // Should clamp to 1
+  parser.set_num_threads(0);
+  EXPECT_EQ(parser.num_threads(), 1); // Should clamp to 1
 
-    parser.set_num_threads(255);
-    EXPECT_EQ(parser.num_threads(), 255);
+  parser.set_num_threads(255);
+  EXPECT_EQ(parser.num_threads(), 255);
 }
 
 // =============================================================================
@@ -352,47 +355,51 @@ TEST_F(ConcurrencyTest, SetNumThreads) {
 
 // Test: Multi-threaded parsing produces valid results
 TEST_F(ConcurrencyTest, MultiThreadedProducesValidResults) {
-    const std::string csv = generate_csv(500, 10, true);  // With quotes
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  const std::string csv = generate_csv(500, 10, true); // With quotes
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Parse with various thread counts - all should succeed and produce valid results
-    for (int threads = 1; threads <= 8; ++threads) {
-        libvroom::Parser parser(threads);
-        auto result = parser.parse(buffer.data(), buffer.size());
-        ASSERT_TRUE(result.success()) << "Failed with " << threads << " threads";
-        ASSERT_GT(result.total_indexes(), 0) << "No indexes with " << threads << " threads";
-    }
+  // Parse with various thread counts - all should succeed and produce valid results
+  for (int threads = 1; threads <= 8; ++threads) {
+    libvroom::Parser parser(threads);
+    auto result = parser.parse(buffer.data(), buffer.size());
+    ASSERT_TRUE(result.success()) << "Failed with " << threads << " threads";
+    ASSERT_GT(result.total_indexes(), 0) << "No indexes with " << threads << " threads";
+  }
 }
 
 // Test: Different algorithms succeed with multi-threading
 TEST_F(ConcurrencyTest, AlgorithmsSucceedMultiThreaded) {
-    const std::string csv = generate_csv(200, 5, true);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  const std::string csv = generate_csv(200, 5, true);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    libvroom::Parser parser(4);
+  libvroom::Parser parser(4);
 
-    // Parse with different algorithms - all should succeed
-    auto result_auto = parser.parse(buffer.data(), buffer.size(),
-        {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::AUTO});
-    auto result_spec = parser.parse(buffer.data(), buffer.size(),
-        {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::SPECULATIVE});
-    auto result_two = parser.parse(buffer.data(), buffer.size(),
-        {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::TWO_PASS});
-    auto result_branch = parser.parse(buffer.data(), buffer.size(),
-        {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::BRANCHLESS});
+  // Parse with different algorithms - all should succeed
+  auto result_auto = parser.parse(
+      buffer.data(), buffer.size(),
+      {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::AUTO});
+  auto result_spec = parser.parse(
+      buffer.data(), buffer.size(),
+      {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::SPECULATIVE});
+  auto result_two = parser.parse(
+      buffer.data(), buffer.size(),
+      {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::TWO_PASS});
+  auto result_branch = parser.parse(
+      buffer.data(), buffer.size(),
+      {.dialect = libvroom::Dialect::csv(), .algorithm = libvroom::ParseAlgorithm::BRANCHLESS});
 
-    EXPECT_TRUE(result_auto.success());
-    EXPECT_TRUE(result_spec.success());
-    EXPECT_TRUE(result_two.success());
-    EXPECT_TRUE(result_branch.success());
+  EXPECT_TRUE(result_auto.success());
+  EXPECT_TRUE(result_spec.success());
+  EXPECT_TRUE(result_two.success());
+  EXPECT_TRUE(result_branch.success());
 
-    // All should produce valid index counts
-    EXPECT_GT(result_auto.total_indexes(), 0);
-    EXPECT_GT(result_spec.total_indexes(), 0);
-    EXPECT_GT(result_two.total_indexes(), 0);
-    EXPECT_GT(result_branch.total_indexes(), 0);
+  // All should produce valid index counts
+  EXPECT_GT(result_auto.total_indexes(), 0);
+  EXPECT_GT(result_spec.total_indexes(), 0);
+  EXPECT_GT(result_two.total_indexes(), 0);
+  EXPECT_GT(result_branch.total_indexes(), 0);
 }
 
 // =============================================================================
@@ -401,59 +408,59 @@ TEST_F(ConcurrencyTest, AlgorithmsSucceedMultiThreaded) {
 
 // Test: Thread-local error collection
 TEST_F(ConcurrencyTest, ThreadLocalErrorCollection) {
-    // CSV with inconsistent field counts
-    std::string csv = "a,b,c\n";
-    for (int i = 0; i < 100; ++i) {
-        if (i % 10 == 0) {
-            csv += "x,y\n";  // Missing field
-        } else {
-            csv += "1,2,3\n";
-        }
+  // CSV with inconsistent field counts
+  std::string csv = "a,b,c\n";
+  for (int i = 0; i < 100; ++i) {
+    if (i % 10 == 0) {
+      csv += "x,y\n"; // Missing field
+    } else {
+      csv += "1,2,3\n";
     }
+  }
 
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-    libvroom::Parser parser(4);
+  libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
+  libvroom::Parser parser(4);
 
-    auto result = parser.parse(buffer.data(), buffer.size(),
-        libvroom::ParseOptions::with_errors(errors));
+  auto result =
+      parser.parse(buffer.data(), buffer.size(), libvroom::ParseOptions::with_errors(errors));
 
-    EXPECT_TRUE(result.success());  // Permissive mode succeeds
-    EXPECT_TRUE(errors.has_errors());  // But errors should be collected
+  EXPECT_TRUE(result.success());    // Permissive mode succeeds
+  EXPECT_TRUE(errors.has_errors()); // But errors should be collected
 }
 
 // Test: Multiple concurrent parsers with error collection
 TEST_F(ConcurrencyTest, ConcurrentParsersWithErrors) {
-    // CSV with some errors
-    std::string csv = "a,b,c\n1,2,3\n4,5\n6,7,8\n";
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  // CSV with some errors
+  std::string csv = "a,b,c\n1,2,3\n4,5\n6,7,8\n";
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    const int num_parsers = 20;
-    std::vector<std::future<bool>> futures;
-    std::atomic<int> errors_found{0};
+  const int num_parsers = 20;
+  std::vector<std::future<bool>> futures;
+  std::atomic<int> errors_found{0};
 
-    for (int i = 0; i < num_parsers; ++i) {
-        futures.push_back(std::async(std::launch::async, [&buffer, &errors_found]() {
-            libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
-            libvroom::Parser parser(2);
-            auto result = parser.parse(buffer.data(), buffer.size(),
-                libvroom::ParseOptions::with_errors(errors));
-            if (errors.has_errors()) {
-                errors_found++;
-            }
-            return result.success();
-        }));
-    }
+  for (int i = 0; i < num_parsers; ++i) {
+    futures.push_back(std::async(std::launch::async, [&buffer, &errors_found]() {
+      libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
+      libvroom::Parser parser(2);
+      auto result =
+          parser.parse(buffer.data(), buffer.size(), libvroom::ParseOptions::with_errors(errors));
+      if (errors.has_errors()) {
+        errors_found++;
+      }
+      return result.success();
+    }));
+  }
 
-    for (auto& f : futures) {
-        EXPECT_TRUE(f.get());
-    }
+  for (auto& f : futures) {
+    EXPECT_TRUE(f.get());
+  }
 
-    // All parsers should find the same error
-    EXPECT_EQ(errors_found.load(), num_parsers);
+  // All parsers should find the same error
+  EXPECT_EQ(errors_found.load(), num_parsers);
 }
 
 // =============================================================================
@@ -462,32 +469,32 @@ TEST_F(ConcurrencyTest, ConcurrentParsersWithErrors) {
 
 // Test: Large file with many threads
 TEST_F(ConcurrencyTest, LargeFileMultiThreaded) {
-    // Generate a reasonably large CSV (1000 rows, 20 columns)
-    const std::string csv = generate_csv(1000, 20, true);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  // Generate a reasonably large CSV (1000 rows, 20 columns)
+  const std::string csv = generate_csv(1000, 20, true);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Parse with hardware concurrency
-    libvroom::Parser parser(hw_concurrency_);
-    auto result = parser.parse(buffer.data(), buffer.size());
+  // Parse with hardware concurrency
+  libvroom::Parser parser(hw_concurrency_);
+  auto result = parser.parse(buffer.data(), buffer.size());
 
-    EXPECT_TRUE(result.success());
-    EXPECT_GT(result.total_indexes(), 0);
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(result.total_indexes(), 0);
 }
 
 // Test: Scaling with thread count
 TEST_F(ConcurrencyTest, ScalingWithThreadCount) {
-    // Medium-sized CSV
-    const std::string csv = generate_csv(500, 10);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  // Medium-sized CSV
+  const std::string csv = generate_csv(500, 10);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Parse with increasing thread counts - all should succeed
-    for (int threads = 1; threads <= 16; threads *= 2) {
-        libvroom::Parser parser(threads);
-        auto result = parser.parse(buffer.data(), buffer.size());
-        EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
-    }
+  // Parse with increasing thread counts - all should succeed
+  for (int threads = 1; threads <= 16; threads *= 2) {
+    libvroom::Parser parser(threads);
+    auto result = parser.parse(buffer.data(), buffer.size());
+    EXPECT_TRUE(result.success()) << "Failed with " << threads << " threads";
+  }
 }
 
 // =============================================================================
@@ -496,29 +503,29 @@ TEST_F(ConcurrencyTest, ScalingWithThreadCount) {
 
 // Test: Rapid sequential parsing (catches use-after-free, double-free)
 TEST_F(ConcurrencyTest, RapidSequentialParsing) {
-    for (int i = 0; i < 100; ++i) {
-        std::string csv = generate_csv(10 + i, 3);
-        auto [data, len] = make_buffer(csv);
-        libvroom::FileBuffer buffer(data, len);
+  for (int i = 0; i < 100; ++i) {
+    std::string csv = generate_csv(10 + i, 3);
+    auto [data, len] = make_buffer(csv);
+    libvroom::FileBuffer buffer(data, len);
 
-        libvroom::Parser parser(4);
-        auto result = parser.parse(buffer.data(), buffer.size());
-        EXPECT_TRUE(result.success()) << "Failed at iteration " << i;
-    }
+    libvroom::Parser parser(4);
+    auto result = parser.parse(buffer.data(), buffer.size());
+    EXPECT_TRUE(result.success()) << "Failed at iteration " << i;
+  }
 }
 
 // Test: Parser reuse across different data
 TEST_F(ConcurrencyTest, ParserReuse) {
-    libvroom::Parser parser(4);
+  libvroom::Parser parser(4);
 
-    for (int i = 0; i < 50; ++i) {
-        std::string csv = generate_csv(20 + i * 2, 5);
-        auto [data, len] = make_buffer(csv);
-        libvroom::FileBuffer buffer(data, len);
+  for (int i = 0; i < 50; ++i) {
+    std::string csv = generate_csv(20 + i * 2, 5);
+    auto [data, len] = make_buffer(csv);
+    libvroom::FileBuffer buffer(data, len);
 
-        auto result = parser.parse(buffer.data(), buffer.size());
-        EXPECT_TRUE(result.success()) << "Failed at iteration " << i;
-    }
+    auto result = parser.parse(buffer.data(), buffer.size());
+    EXPECT_TRUE(result.success()) << "Failed at iteration " << i;
+  }
 }
 
 // =============================================================================
@@ -527,47 +534,48 @@ TEST_F(ConcurrencyTest, ParserReuse) {
 
 // Test: Concurrent parsing with different dialects
 TEST_F(ConcurrencyTest, ConcurrentDifferentDialects) {
-    // CSV data
-    std::string csv_data = "a,b,c\n1,2,3\n";
-    // TSV data
-    std::string tsv_data = "a\tb\tc\n1\t2\t3\n";
-    // Semicolon-separated
-    std::string ssv_data = "a;b;c\n1;2;3\n";
+  // CSV data
+  std::string csv_data = "a,b,c\n1,2,3\n";
+  // TSV data
+  std::string tsv_data = "a\tb\tc\n1\t2\t3\n";
+  // Semicolon-separated
+  std::string ssv_data = "a;b;c\n1;2;3\n";
 
-    auto [csv_buf, csv_len] = make_buffer(csv_data);
-    auto [tsv_buf, tsv_len] = make_buffer(tsv_data);
-    auto [ssv_buf, ssv_len] = make_buffer(ssv_data);
+  auto [csv_buf, csv_len] = make_buffer(csv_data);
+  auto [tsv_buf, tsv_len] = make_buffer(tsv_data);
+  auto [ssv_buf, ssv_len] = make_buffer(ssv_data);
 
-    libvroom::FileBuffer csv_file(csv_buf, csv_len);
-    libvroom::FileBuffer tsv_file(tsv_buf, tsv_len);
-    libvroom::FileBuffer ssv_file(ssv_buf, ssv_len);
+  libvroom::FileBuffer csv_file(csv_buf, csv_len);
+  libvroom::FileBuffer tsv_file(tsv_buf, tsv_len);
+  libvroom::FileBuffer ssv_file(ssv_buf, ssv_len);
 
-    std::vector<std::future<bool>> futures;
+  std::vector<std::future<bool>> futures;
 
-    // Launch parsers for each dialect concurrently
-    for (int i = 0; i < 10; ++i) {
-        futures.push_back(std::async(std::launch::async, [&csv_file]() {
-            libvroom::Parser parser(2);
-            return parser.parse(csv_file.data(), csv_file.size(),
-                libvroom::Dialect::csv()).success();
-        }));
+  // Launch parsers for each dialect concurrently
+  for (int i = 0; i < 10; ++i) {
+    futures.push_back(std::async(std::launch::async, [&csv_file]() {
+      libvroom::Parser parser(2);
+      return parser.parse(csv_file.data(), csv_file.size(), {.dialect = libvroom::Dialect::csv()})
+          .success();
+    }));
 
-        futures.push_back(std::async(std::launch::async, [&tsv_file]() {
-            libvroom::Parser parser(2);
-            return parser.parse(tsv_file.data(), tsv_file.size(),
-                libvroom::Dialect::tsv()).success();
-        }));
+    futures.push_back(std::async(std::launch::async, [&tsv_file]() {
+      libvroom::Parser parser(2);
+      return parser.parse(tsv_file.data(), tsv_file.size(), {.dialect = libvroom::Dialect::tsv()})
+          .success();
+    }));
 
-        futures.push_back(std::async(std::launch::async, [&ssv_file]() {
-            libvroom::Parser parser(2);
-            return parser.parse(ssv_file.data(), ssv_file.size(),
-                libvroom::Dialect::semicolon()).success();
-        }));
-    }
+    futures.push_back(std::async(std::launch::async, [&ssv_file]() {
+      libvroom::Parser parser(2);
+      return parser
+          .parse(ssv_file.data(), ssv_file.size(), {.dialect = libvroom::Dialect::semicolon()})
+          .success();
+    }));
+  }
 
-    for (auto& f : futures) {
-        EXPECT_TRUE(f.get());
-    }
+  for (auto& f : futures) {
+    EXPECT_TRUE(f.get());
+  }
 }
 
 // =============================================================================
@@ -576,18 +584,18 @@ TEST_F(ConcurrencyTest, ConcurrentDifferentDialects) {
 
 // Test: Mixed line endings with multiple threads
 TEST_F(ConcurrencyTest, MixedLineEndingsMultiThreaded) {
-    // CSV with CRLF line endings
-    std::string csv = "a,b,c\r\n";
-    for (int i = 0; i < 100; ++i) {
-        csv += "1,2,3\r\n";
-    }
+  // CSV with CRLF line endings
+  std::string csv = "a,b,c\r\n";
+  for (int i = 0; i < 100; ++i) {
+    csv += "1,2,3\r\n";
+  }
 
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    libvroom::Parser parser(8);
-    auto result = parser.parse(buffer.data(), buffer.size());
-    EXPECT_TRUE(result.success());
+  libvroom::Parser parser(8);
+  auto result = parser.parse(buffer.data(), buffer.size());
+  EXPECT_TRUE(result.success());
 }
 
 // =============================================================================
@@ -596,17 +604,17 @@ TEST_F(ConcurrencyTest, MixedLineEndingsMultiThreaded) {
 
 // Test: Verify interleaved index pattern is correct
 TEST_F(ConcurrencyTest, InterleavedIndexPattern) {
-    // This test verifies that the interleaved index storage pattern
-    // works correctly with multiple threads
-    const std::string csv = generate_csv(100, 5);
-    auto [data, len] = make_buffer(csv);
-    libvroom::FileBuffer buffer(data, len);
+  // This test verifies that the interleaved index storage pattern
+  // works correctly with multiple threads
+  const std::string csv = generate_csv(100, 5);
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
 
-    // Parse with 4 threads
-    libvroom::Parser parser(4);
-    auto result = parser.parse(buffer.data(), buffer.size());
+  // Parse with 4 threads
+  libvroom::Parser parser(4);
+  auto result = parser.parse(buffer.data(), buffer.size());
 
-    EXPECT_TRUE(result.success());
-    // The indexes should be populated without any gaps in the pattern
-    EXPECT_GT(result.total_indexes(), 0);
+  EXPECT_TRUE(result.success());
+  // The indexes should be populated without any gaps in the pattern
+  EXPECT_GT(result.total_indexes(), 0);
 }

--- a/test/size_limits_test.cpp
+++ b/test/size_limits_test.cpp
@@ -156,7 +156,7 @@ TEST_F(FileSizeLimitTest, AllowsWithUnlimitedSize) {
 // ============================================================================
 
 TEST(IndexAllocationTest, ThrowsOnOverflow) {
-  two_pass parser;
+  TwoPass parser;
 
   // Attempt to allocate with extreme size that would overflow
   // SIZE_MAX / 8 would overflow when multiplied by sizeof(uint64_t)
@@ -166,7 +166,7 @@ TEST(IndexAllocationTest, ThrowsOnOverflow) {
 }
 
 TEST(IndexAllocationTest, ReportsOverflowWithErrorCollector) {
-  two_pass parser;
+  TwoPass parser;
   ErrorCollector errors(ErrorMode::PERMISSIVE);
 
   size_t huge_len = std::numeric_limits<size_t>::max() - 10;
@@ -179,7 +179,7 @@ TEST(IndexAllocationTest, ReportsOverflowWithErrorCollector) {
 }
 
 TEST(IndexAllocationTest, MultiThreadOverflow) {
-  two_pass parser;
+  TwoPass parser;
   ErrorCollector errors(ErrorMode::PERMISSIVE);
 
   // A size that's fine for single thread but overflows with many threads
@@ -194,7 +194,7 @@ TEST(IndexAllocationTest, MultiThreadOverflow) {
 }
 
 TEST(IndexAllocationTest, AcceptsNormalSize) {
-  two_pass parser;
+  TwoPass parser;
 
   // Normal allocation should succeed
   auto idx = parser.init_safe(1000, 4, nullptr);
@@ -220,7 +220,7 @@ TEST(StreamingFieldSizeTest, RejectsOversizeField) {
   parser.parse_chunk(csv.data(), csv.size());
   parser.finish();
 
-  const auto& errors = parser.errors();
+  const auto& errors = parser.error_collector();
   EXPECT_TRUE(errors.has_errors());
 
   // Find the FIELD_TOO_LARGE error
@@ -246,7 +246,7 @@ TEST(StreamingFieldSizeTest, AcceptsFieldWithinLimit) {
   parser.parse_chunk(csv.data(), csv.size());
   parser.finish();
 
-  const auto& errors = parser.errors();
+  const auto& errors = parser.error_collector();
   // Should not have any FIELD_TOO_LARGE errors
   for (const auto& err : errors.errors()) {
     EXPECT_NE(err.code, ErrorCode::FIELD_TOO_LARGE);
@@ -267,7 +267,7 @@ TEST(StreamingFieldSizeTest, DisabledWithZeroLimit) {
   parser.parse_chunk(csv.data(), csv.size());
   parser.finish();
 
-  const auto& errors = parser.errors();
+  const auto& errors = parser.error_collector();
   for (const auto& err : errors.errors()) {
     EXPECT_NE(err.code, ErrorCode::FIELD_TOO_LARGE);
   }

--- a/test/streaming_test.cpp
+++ b/test/streaming_test.cpp
@@ -3,8 +3,9 @@
  * @brief Unit tests for the streaming CSV parser.
  */
 
-#include <gtest/gtest.h>
 #include "streaming.h"
+
+#include <gtest/gtest.h>
 #include <sstream>
 #include <vector>
 
@@ -15,107 +16,107 @@ using namespace libvroom;
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, BasicParsing) {
-    std::string csv = "a,b,c\n1,2,3\n4,5,6\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b,c\n1,2,3\n4,5,6\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    std::vector<std::vector<std::string>> rows;
-    for (const auto& row : reader) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
+  std::vector<std::vector<std::string>> rows;
+  for (const auto& row : reader) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
     }
+    rows.push_back(fields);
+  }
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"1", "2", "3"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"4", "5", "6"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"1", "2", "3"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"4", "5", "6"}));
 
-    // Check header
-    EXPECT_EQ(reader.header(), (std::vector<std::string>{"a", "b", "c"}));
+  // Check header
+  EXPECT_EQ(reader.header(), (std::vector<std::string>{"a", "b", "c"}));
 }
 
 TEST(StreamingTest, NoHeader) {
-    std::string csv = "1,2,3\n4,5,6\n";
-    std::istringstream input(csv);
+  std::string csv = "1,2,3\n4,5,6\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    std::vector<std::vector<std::string>> rows;
-    while (reader.next_row()) {
-        std::vector<std::string> fields;
-        for (const auto& field : reader.row()) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
+  std::vector<std::vector<std::string>> rows;
+  while (reader.next_row()) {
+    std::vector<std::string> fields;
+    for (const auto& field : reader.row()) {
+      fields.push_back(std::string(field.data));
     }
+    rows.push_back(fields);
+  }
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"1", "2", "3"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"4", "5", "6"}));
-    EXPECT_TRUE(reader.header().empty());
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"1", "2", "3"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"4", "5", "6"}));
+  EXPECT_TRUE(reader.header().empty());
 }
 
 TEST(StreamingTest, EmptyFile) {
-    std::string csv = "";
-    std::istringstream input(csv);
+  std::string csv = "";
+  std::istringstream input(csv);
 
-    StreamReader reader(input);
+  StreamReader reader(input);
 
-    int count = 0;
-    for (const auto& row : reader) {
-        (void)row;
-        ++count;
-    }
+  int count = 0;
+  for (const auto& row : reader) {
+    (void)row;
+    ++count;
+  }
 
-    EXPECT_EQ(count, 0);
+  EXPECT_EQ(count, 0);
 }
 
 TEST(StreamingTest, SingleField) {
-    std::string csv = "hello\n";
-    std::istringstream input(csv);
+  std::string csv = "hello\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    ASSERT_EQ(reader.row().field_count(), 1);
-    EXPECT_EQ(reader.row()[0].data, "hello");
-    EXPECT_FALSE(reader.next_row());
+  ASSERT_TRUE(reader.next_row());
+  ASSERT_EQ(reader.row().field_count(), 1);
+  EXPECT_EQ(reader.row()[0].data, "hello");
+  EXPECT_FALSE(reader.next_row());
 }
 
 TEST(StreamingTest, EmptyFields) {
-    std::string csv = "a,,c\n,b,\n";
-    std::istringstream input(csv);
+  std::string csv = "a,,c\n,b,\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    ASSERT_EQ(reader.row().field_count(), 3);
-    EXPECT_EQ(reader.row()[0].data, "a");
-    EXPECT_EQ(reader.row()[1].data, "");
-    EXPECT_EQ(reader.row()[2].data, "c");
+  ASSERT_TRUE(reader.next_row());
+  ASSERT_EQ(reader.row().field_count(), 3);
+  EXPECT_EQ(reader.row()[0].data, "a");
+  EXPECT_EQ(reader.row()[1].data, "");
+  EXPECT_EQ(reader.row()[2].data, "c");
 
-    ASSERT_TRUE(reader.next_row());
-    ASSERT_EQ(reader.row().field_count(), 3);
-    EXPECT_EQ(reader.row()[0].data, "");
-    EXPECT_EQ(reader.row()[1].data, "b");
-    EXPECT_EQ(reader.row()[2].data, "");
+  ASSERT_TRUE(reader.next_row());
+  ASSERT_EQ(reader.row().field_count(), 3);
+  EXPECT_EQ(reader.row()[0].data, "");
+  EXPECT_EQ(reader.row()[1].data, "b");
+  EXPECT_EQ(reader.row()[2].data, "");
 
-    EXPECT_FALSE(reader.next_row());
+  EXPECT_FALSE(reader.next_row());
 }
 
 //-----------------------------------------------------------------------------
@@ -123,67 +124,67 @@ TEST(StreamingTest, EmptyFields) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, QuotedFields) {
-    std::string csv = "\"hello\",\"world\"\n";
-    std::istringstream input(csv);
+  std::string csv = "\"hello\",\"world\"\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    ASSERT_EQ(reader.row().field_count(), 2);
-    EXPECT_EQ(reader.row()[0].data, "hello");
-    EXPECT_TRUE(reader.row()[0].is_quoted);
-    EXPECT_EQ(reader.row()[1].data, "world");
-    EXPECT_TRUE(reader.row()[1].is_quoted);
+  ASSERT_TRUE(reader.next_row());
+  ASSERT_EQ(reader.row().field_count(), 2);
+  EXPECT_EQ(reader.row()[0].data, "hello");
+  EXPECT_TRUE(reader.row()[0].is_quoted);
+  EXPECT_EQ(reader.row()[1].data, "world");
+  EXPECT_TRUE(reader.row()[1].is_quoted);
 }
 
 TEST(StreamingTest, QuotedFieldWithComma) {
-    std::string csv = "\"hello, world\",test\n";
-    std::istringstream input(csv);
+  std::string csv = "\"hello, world\",test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    ASSERT_EQ(reader.row().field_count(), 2);
-    EXPECT_EQ(reader.row()[0].data, "hello, world");
-    EXPECT_EQ(reader.row()[1].data, "test");
+  ASSERT_TRUE(reader.next_row());
+  ASSERT_EQ(reader.row().field_count(), 2);
+  EXPECT_EQ(reader.row()[0].data, "hello, world");
+  EXPECT_EQ(reader.row()[1].data, "test");
 }
 
 TEST(StreamingTest, QuotedFieldWithNewline) {
-    std::string csv = "\"line1\nline2\",test\n";
-    std::istringstream input(csv);
+  std::string csv = "\"line1\nline2\",test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    ASSERT_EQ(reader.row().field_count(), 2);
-    EXPECT_EQ(reader.row()[0].data, "line1\nline2");
-    EXPECT_EQ(reader.row()[1].data, "test");
+  ASSERT_TRUE(reader.next_row());
+  ASSERT_EQ(reader.row().field_count(), 2);
+  EXPECT_EQ(reader.row()[0].data, "line1\nline2");
+  EXPECT_EQ(reader.row()[1].data, "test");
 }
 
 TEST(StreamingTest, EscapedQuotes) {
-    std::string csv = "\"say \"\"hello\"\"\",test\n";
-    std::istringstream input(csv);
+  std::string csv = "\"say \"\"hello\"\"\",test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    ASSERT_EQ(reader.row().field_count(), 2);
-    // The raw data contains the escaped quotes
-    EXPECT_EQ(reader.row()[0].data, "say \"\"hello\"\"");
-    // The unescaped version removes the escaping
-    EXPECT_EQ(reader.row()[0].unescaped(), "say \"hello\"");
+  ASSERT_TRUE(reader.next_row());
+  ASSERT_EQ(reader.row().field_count(), 2);
+  // The raw data contains the escaped quotes
+  EXPECT_EQ(reader.row()[0].data, "say \"\"hello\"\"");
+  // The unescaped version removes the escaping
+  EXPECT_EQ(reader.row()[0].unescaped(), "say \"hello\"");
 }
 
 //-----------------------------------------------------------------------------
@@ -191,55 +192,55 @@ TEST(StreamingTest, EscapedQuotes) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, UnixLineEndings) {
-    std::string csv = "a,b\n1,2\n3,4\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b\n1,2\n3,4\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    int count = 0;
-    while (reader.next_row()) {
-        ++count;
-    }
-    EXPECT_EQ(count, 3);
+  int count = 0;
+  while (reader.next_row()) {
+    ++count;
+  }
+  EXPECT_EQ(count, 3);
 }
 
 TEST(StreamingTest, WindowsLineEndings) {
-    std::string csv = "a,b\r\n1,2\r\n3,4\r\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b\r\n1,2\r\n3,4\r\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    int count = 0;
-    while (reader.next_row()) {
-        EXPECT_EQ(reader.row().field_count(), 2);
-        ++count;
-    }
-    EXPECT_EQ(count, 3);
+  int count = 0;
+  while (reader.next_row()) {
+    EXPECT_EQ(reader.row().field_count(), 2);
+    ++count;
+  }
+  EXPECT_EQ(count, 3);
 }
 
 TEST(StreamingTest, NoTrailingNewline) {
-    std::string csv = "a,b\n1,2";
-    std::istringstream input(csv);
+  std::string csv = "a,b\n1,2";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "a");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "a");
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "1");
-    EXPECT_EQ(reader.row()[1].data, "2");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "1");
+  EXPECT_EQ(reader.row()[1].data, "2");
 
-    EXPECT_FALSE(reader.next_row());
+  EXPECT_FALSE(reader.next_row());
 }
 
 //-----------------------------------------------------------------------------
@@ -247,53 +248,53 @@ TEST(StreamingTest, NoTrailingNewline) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, PushModelBasic) {
-    std::string csv = "a,b,c\n1,2,3\n4,5,6\n";
+  std::string csv = "a,b,c\n1,2,3\n4,5,6\n";
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> collected_rows;
+  std::vector<std::vector<std::string>> collected_rows;
 
-    parser.set_row_handler([&collected_rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        collected_rows.push_back(fields);
-        return true;
-    });
+  parser.set_row_handler([&collected_rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    collected_rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    ASSERT_EQ(collected_rows.size(), 2);
-    EXPECT_EQ(collected_rows[0], (std::vector<std::string>{"1", "2", "3"}));
-    EXPECT_EQ(collected_rows[1], (std::vector<std::string>{"4", "5", "6"}));
+  ASSERT_EQ(collected_rows.size(), 2);
+  EXPECT_EQ(collected_rows[0], (std::vector<std::string>{"1", "2", "3"}));
+  EXPECT_EQ(collected_rows[1], (std::vector<std::string>{"4", "5", "6"}));
 
-    EXPECT_EQ(parser.header(), (std::vector<std::string>{"a", "b", "c"}));
+  EXPECT_EQ(parser.header(), (std::vector<std::string>{"a", "b", "c"}));
 }
 
 TEST(StreamingTest, PushModelStopEarly) {
-    std::string csv = "a\n1\n2\n3\n4\n5\n";
+  std::string csv = "a\n1\n2\n3\n4\n5\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    int row_count = 0;
-    parser.set_row_handler([&row_count](const Row& row) {
-        (void)row;
-        ++row_count;
-        return row_count < 3;  // Stop after 3 rows
-    });
+  int row_count = 0;
+  parser.set_row_handler([&row_count](const Row& row) {
+    (void)row;
+    ++row_count;
+    return row_count < 3; // Stop after 3 rows
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_EQ(row_count, 3);
+  EXPECT_EQ(row_count, 3);
 }
 
 //-----------------------------------------------------------------------------
@@ -301,90 +302,90 @@ TEST(StreamingTest, PushModelStopEarly) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ChunkBoundaryInField) {
-    std::string csv = "hello,world\n";
+  std::string csv = "hello,world\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Split in middle of "hello"
-    parser.parse_chunk(csv.substr(0, 3));
-    parser.parse_chunk(csv.substr(3));
-    parser.finish();
+  // Split in middle of "hello"
+  parser.parse_chunk(csv.substr(0, 3));
+  parser.parse_chunk(csv.substr(3));
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row().field_count(), 2);
-    EXPECT_EQ(parser.current_row()[0].data, "hello");
-    EXPECT_EQ(parser.current_row()[1].data, "world");
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row().field_count(), 2);
+  EXPECT_EQ(parser.current_row()[0].data, "hello");
+  EXPECT_EQ(parser.current_row()[1].data, "world");
 }
 
 TEST(StreamingTest, ChunkBoundaryAtDelimiter) {
-    std::string csv = "hello,world\n";
+  std::string csv = "hello,world\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Split at the comma
-    parser.parse_chunk(csv.substr(0, 5));  // "hello"
-    parser.parse_chunk(csv.substr(5));     // ",world\n"
-    parser.finish();
+  // Split at the comma
+  parser.parse_chunk(csv.substr(0, 5)); // "hello"
+  parser.parse_chunk(csv.substr(5));    // ",world\n"
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row().field_count(), 2);
-    EXPECT_EQ(parser.current_row()[0].data, "hello");
-    EXPECT_EQ(parser.current_row()[1].data, "world");
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row().field_count(), 2);
+  EXPECT_EQ(parser.current_row()[0].data, "hello");
+  EXPECT_EQ(parser.current_row()[1].data, "world");
 }
 
 TEST(StreamingTest, ChunkBoundaryInQuotedField) {
-    std::string csv = "\"hello, world\",test\n";
+  std::string csv = "\"hello, world\",test\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Split in middle of quoted field
-    parser.parse_chunk(csv.substr(0, 8));   // "\"hello, "
-    parser.parse_chunk(csv.substr(8));      // "world\",test\n"
-    parser.finish();
+  // Split in middle of quoted field
+  parser.parse_chunk(csv.substr(0, 8)); // "\"hello, "
+  parser.parse_chunk(csv.substr(8));    // "world\",test\n"
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row().field_count(), 2);
-    EXPECT_EQ(parser.current_row()[0].data, "hello, world");
-    EXPECT_EQ(parser.current_row()[1].data, "test");
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row().field_count(), 2);
+  EXPECT_EQ(parser.current_row()[0].data, "hello, world");
+  EXPECT_EQ(parser.current_row()[1].data, "test");
 }
 
 TEST(StreamingTest, ChunkBoundaryAcrossMultipleRows) {
-    std::string csv = "a,b\n1,2\n3,4\n";
+  std::string csv = "a,b\n1,2\n3,4\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
-
-    // Feed one character at a time
-    for (char c : csv) {
-        parser.parse_chunk(std::string_view(&c, 1));
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
     }
-    parser.finish();
+    rows.push_back(fields);
+    return true;
+  });
 
-    ASSERT_EQ(rows.size(), 3);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
-    EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
+  // Feed one character at a time
+  for (char c : csv) {
+    parser.parse_chunk(std::string_view(&c, 1));
+  }
+  parser.finish();
+
+  ASSERT_EQ(rows.size(), 3);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
+  EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
 }
 
 //-----------------------------------------------------------------------------
@@ -392,48 +393,48 @@ TEST(StreamingTest, ChunkBoundaryAcrossMultipleRows) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ColumnAccessByName) {
-    std::string csv = "name,age,city\nAlice,30,NYC\nBob,25,LA\n";
-    std::istringstream input(csv);
+  std::string csv = "name,age,city\nAlice,30,NYC\nBob,25,LA\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    // Must read first row to parse header
-    ASSERT_TRUE(reader.next_row());
+  // Must read first row to parse header
+  ASSERT_TRUE(reader.next_row());
 
-    // Now column_index works
-    EXPECT_EQ(reader.column_index("name"), 0);
-    EXPECT_EQ(reader.column_index("age"), 1);
-    EXPECT_EQ(reader.column_index("city"), 2);
-    EXPECT_EQ(reader.column_index("unknown"), -1);
+  // Now column_index works
+  EXPECT_EQ(reader.column_index("name"), 0);
+  EXPECT_EQ(reader.column_index("age"), 1);
+  EXPECT_EQ(reader.column_index("city"), 2);
+  EXPECT_EQ(reader.column_index("unknown"), -1);
 
-    EXPECT_EQ(reader.row()["name"].data, "Alice");
-    EXPECT_EQ(reader.row()["age"].data, "30");
-    EXPECT_EQ(reader.row()["city"].data, "NYC");
+  EXPECT_EQ(reader.row()["name"].data, "Alice");
+  EXPECT_EQ(reader.row()["age"].data, "30");
+  EXPECT_EQ(reader.row()["city"].data, "NYC");
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()["name"].data, "Bob");
-    EXPECT_EQ(reader.row()["age"].data, "25");
-    EXPECT_EQ(reader.row()["city"].data, "LA");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()["name"].data, "Bob");
+  EXPECT_EQ(reader.row()["age"].data, "25");
+  EXPECT_EQ(reader.row()["city"].data, "LA");
 }
 
 TEST(StreamingTest, RowMetadata) {
-    std::string csv = "a,b\n1,2\n3,4\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b\n1,2\n3,4\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row().row_number(), 1);
-    EXPECT_EQ(reader.row().byte_offset(), 4);  // After "a,b\n"
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row().row_number(), 1);
+  EXPECT_EQ(reader.row().byte_offset(), 4); // After "a,b\n"
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row().row_number(), 2);
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row().row_number(), 2);
 }
 
 //-----------------------------------------------------------------------------
@@ -441,55 +442,55 @@ TEST(StreamingTest, RowMetadata) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, TabSeparated) {
-    std::string tsv = "a\tb\tc\n1\t2\t3\n";
-    std::istringstream input(tsv);
+  std::string tsv = "a\tb\tc\n1\t2\t3\n";
+  std::istringstream input(tsv);
 
-    StreamConfig config;
-    config.dialect = Dialect::tsv();
-    config.parse_header = true;
+  StreamConfig config;
+  config.dialect = Dialect::tsv();
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    // Must read first row to parse header
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.header(), (std::vector<std::string>{"a", "b", "c"}));
-    EXPECT_EQ(reader.row()[0].data, "1");
-    EXPECT_EQ(reader.row()[1].data, "2");
-    EXPECT_EQ(reader.row()[2].data, "3");
+  // Must read first row to parse header
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.header(), (std::vector<std::string>{"a", "b", "c"}));
+  EXPECT_EQ(reader.row()[0].data, "1");
+  EXPECT_EQ(reader.row()[1].data, "2");
+  EXPECT_EQ(reader.row()[2].data, "3");
 }
 
 TEST(StreamingTest, SemicolonSeparated) {
-    std::string csv = "a;b;c\n1;2;3\n";
-    std::istringstream input(csv);
+  std::string csv = "a;b;c\n1;2;3\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.dialect = Dialect::semicolon();
-    config.parse_header = true;
+  StreamConfig config;
+  config.dialect = Dialect::semicolon();
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    // Must read first row to parse header
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.header(), (std::vector<std::string>{"a", "b", "c"}));
-    EXPECT_EQ(reader.row()[0].data, "1");
-    EXPECT_EQ(reader.row()[1].data, "2");
-    EXPECT_EQ(reader.row()[2].data, "3");
+  // Must read first row to parse header
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.header(), (std::vector<std::string>{"a", "b", "c"}));
+  EXPECT_EQ(reader.row()[0].data, "1");
+  EXPECT_EQ(reader.row()[1].data, "2");
+  EXPECT_EQ(reader.row()[2].data, "3");
 }
 
 TEST(StreamingTest, SingleQuote) {
-    std::string csv = "'hello, world',test\n";
-    std::istringstream input(csv);
+  std::string csv = "'hello, world',test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.dialect.quote_char = '\'';
-    config.parse_header = false;
+  StreamConfig config;
+  config.dialect.quote_char = '\'';
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "hello, world");
-    EXPECT_TRUE(reader.row()[0].is_quoted);
-    EXPECT_EQ(reader.row()[1].data, "test");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "hello, world");
+  EXPECT_TRUE(reader.row()[0].is_quoted);
+  EXPECT_EQ(reader.row()[1].data, "test");
 }
 
 //-----------------------------------------------------------------------------
@@ -497,73 +498,73 @@ TEST(StreamingTest, SingleQuote) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, UnclosedQuote) {
-    std::string csv = "\"unclosed\n";
-    std::istringstream input(csv);
+  std::string csv = "\"unclosed\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    while (reader.next_row()) {
-        // Process rows
+  while (reader.next_row()) {
+    // Process rows
+  }
+
+  EXPECT_TRUE(reader.error_collector().has_errors());
+  EXPECT_TRUE(reader.error_collector().has_fatal_errors());
+
+  bool found_unclosed = false;
+  for (const auto& err : reader.error_collector().errors()) {
+    if (err.code == ErrorCode::UNCLOSED_QUOTE) {
+      found_unclosed = true;
+      break;
     }
-
-    EXPECT_TRUE(reader.errors().has_errors());
-    EXPECT_TRUE(reader.errors().has_fatal_errors());
-
-    bool found_unclosed = false;
-    for (const auto& err : reader.errors().errors()) {
-        if (err.code == ErrorCode::UNCLOSED_QUOTE) {
-            found_unclosed = true;
-            break;
-        }
-    }
-    EXPECT_TRUE(found_unclosed);
+  }
+  EXPECT_TRUE(found_unclosed);
 }
 
 TEST(StreamingTest, QuoteInUnquotedField) {
-    std::string csv = "hello\"world,test\n";
-    std::istringstream input(csv);
+  std::string csv = "hello\"world,test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_TRUE(reader.errors().has_errors());
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_TRUE(reader.error_collector().has_errors());
 
-    bool found_error = false;
-    for (const auto& err : reader.errors().errors()) {
-        if (err.code == ErrorCode::QUOTE_IN_UNQUOTED_FIELD) {
-            found_error = true;
-            break;
-        }
+  bool found_error = false;
+  for (const auto& err : reader.error_collector().errors()) {
+    if (err.code == ErrorCode::QUOTE_IN_UNQUOTED_FIELD) {
+      found_error = true;
+      break;
     }
-    EXPECT_TRUE(found_error);
+  }
+  EXPECT_TRUE(found_error);
 }
 
 TEST(StreamingTest, BestEffortMode) {
-    std::string csv = "\"unclosed\nvalid,data\n";
-    std::istringstream input(csv);
+  std::string csv = "\"unclosed\nvalid,data\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::BEST_EFFORT;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::BEST_EFFORT;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    // Should still be able to read rows even with errors
-    int count = 0;
-    while (reader.next_row()) {
-        ++count;
-    }
+  // Should still be able to read rows even with errors
+  int count = 0;
+  while (reader.next_row()) {
+    ++count;
+  }
 
-    // At least parsed something
-    EXPECT_GE(count, 0);
+  // At least parsed something
+  EXPECT_GE(count, 0);
 }
 
 //-----------------------------------------------------------------------------
@@ -571,21 +572,21 @@ TEST(StreamingTest, BestEffortMode) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, RowAndByteCount) {
-    std::string csv = "a,b\n1,2\n3,4\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b\n1,2\n3,4\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    while (reader.next_row()) {
-        // Process rows
-    }
+  while (reader.next_row()) {
+    // Process rows
+  }
 
-    EXPECT_EQ(reader.rows_read(), 2);  // Excluding header
-    EXPECT_EQ(reader.bytes_read(), csv.size());
-    EXPECT_TRUE(reader.eof());
+  EXPECT_EQ(reader.rows_read(), 2); // Excluding header
+  EXPECT_EQ(reader.bytes_read(), csv.size());
+  EXPECT_TRUE(reader.eof());
 }
 
 //-----------------------------------------------------------------------------
@@ -593,52 +594,52 @@ TEST(StreamingTest, RowAndByteCount) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, PullModelWithParser) {
-    std::string csv = "a,b\n1,2\n3,4\n";
+  std::string csv = "a,b\n1,2\n3,4\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
-    parser.parse_chunk(csv);
-    parser.finish();
+  StreamParser parser(config);
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    std::vector<std::vector<std::string>> rows;
-    while (parser.next_row() == StreamStatus::ROW_READY) {
-        std::vector<std::string> fields;
-        for (const auto& field : parser.current_row()) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
+  std::vector<std::vector<std::string>> rows;
+  while (parser.next_row() == StreamStatus::ROW_READY) {
+    std::vector<std::string> fields;
+    for (const auto& field : parser.current_row()) {
+      fields.push_back(std::string(field.data));
     }
+    rows.push_back(fields);
+  }
 
-    ASSERT_EQ(rows.size(), 3);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
-    EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
+  ASSERT_EQ(rows.size(), 3);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
+  EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
 }
 
 TEST(StreamingTest, PullModelNeedMoreData) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // No data yet
-    EXPECT_EQ(parser.next_row(), StreamStatus::NEED_MORE_DATA);
+  // No data yet
+  EXPECT_EQ(parser.next_row(), StreamStatus::NEED_MORE_DATA);
 
-    // Add partial row
-    parser.parse_chunk("hello,wor");
-    EXPECT_EQ(parser.next_row(), StreamStatus::NEED_MORE_DATA);
+  // Add partial row
+  parser.parse_chunk("hello,wor");
+  EXPECT_EQ(parser.next_row(), StreamStatus::NEED_MORE_DATA);
 
-    // Complete the row
-    parser.parse_chunk("ld\n");
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row()[0].data, "hello");
-    EXPECT_EQ(parser.current_row()[1].data, "world");
+  // Complete the row
+  parser.parse_chunk("ld\n");
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row()[0].data, "hello");
+  EXPECT_EQ(parser.current_row()[1].data, "world");
 
-    // No more data
-    parser.finish();
-    EXPECT_EQ(parser.next_row(), StreamStatus::END_OF_DATA);
+  // No more data
+  parser.finish();
+  EXPECT_EQ(parser.next_row(), StreamStatus::END_OF_DATA);
 }
 
 //-----------------------------------------------------------------------------
@@ -646,29 +647,29 @@ TEST(StreamingTest, PullModelNeedMoreData) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ParserReset) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // First parse
-    parser.parse_chunk("a,b\n");
-    parser.finish();
+  // First parse
+  parser.parse_chunk("a,b\n");
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.rows_processed(), 1);
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.rows_processed(), 1);
 
-    // Reset and parse again
-    parser.reset();
-    EXPECT_EQ(parser.rows_processed(), 0);
-    EXPECT_FALSE(parser.is_finished());
+  // Reset and parse again
+  parser.reset();
+  EXPECT_EQ(parser.rows_processed(), 0);
+  EXPECT_FALSE(parser.is_finished());
 
-    parser.parse_chunk("x,y,z\n");
-    parser.finish();
+  parser.parse_chunk("x,y,z\n");
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row().field_count(), 3);
-    EXPECT_EQ(parser.current_row()[0].data, "x");
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row().field_count(), 3);
+  EXPECT_EQ(parser.current_row()[0].data, "x");
 }
 
 //-----------------------------------------------------------------------------
@@ -676,23 +677,23 @@ TEST(StreamingTest, ParserReset) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, FieldAtBoundsCheck) {
-    std::string csv = "a,b\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
+  ASSERT_TRUE(reader.next_row());
 
-    // Valid access
-    EXPECT_NO_THROW(reader.row().at(0));
-    EXPECT_NO_THROW(reader.row().at(1));
+  // Valid access
+  EXPECT_NO_THROW(reader.row().at(0));
+  EXPECT_NO_THROW(reader.row().at(1));
 
-    // Invalid access
-    EXPECT_THROW(reader.row().at(2), std::out_of_range);
-    EXPECT_THROW(reader.row().at(100), std::out_of_range);
+  // Invalid access
+  EXPECT_THROW(reader.row().at(2), std::out_of_range);
+  EXPECT_THROW(reader.row().at(100), std::out_of_range);
 }
 
 //-----------------------------------------------------------------------------
@@ -700,22 +701,22 @@ TEST(StreamingTest, FieldAtBoundsCheck) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, IteratorComparison) {
-    std::string csv = "a\n1\n";
-    std::istringstream input(csv);
+  std::string csv = "a\n1\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    auto begin = reader.begin();
-    auto end = reader.end();
+  auto begin = reader.begin();
+  auto end = reader.end();
 
-    EXPECT_NE(begin, end);
-    ++begin;
-    EXPECT_NE(begin, end);
-    ++begin;
-    EXPECT_EQ(begin, end);
+  EXPECT_NE(begin, end);
+  ++begin;
+  EXPECT_NE(begin, end);
+  ++begin;
+  EXPECT_EQ(begin, end);
 }
 
 //-----------------------------------------------------------------------------
@@ -723,44 +724,44 @@ TEST(StreamingTest, IteratorComparison) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ManyRows) {
-    std::ostringstream oss;
-    oss << "id,value\n";
-    for (int i = 0; i < 1000; ++i) {
-        oss << i << "," << (i * 2) << "\n";
-    }
-    std::string csv = oss.str();
-    std::istringstream input(csv);
+  std::ostringstream oss;
+  oss << "id,value\n";
+  for (int i = 0; i < 1000; ++i) {
+    oss << i << "," << (i * 2) << "\n";
+  }
+  std::string csv = oss.str();
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    int count = 0;
-    int sum = 0;
-    while (reader.next_row()) {
-        sum += std::stoi(std::string(reader.row()[1].data));
-        ++count;
-    }
+  int count = 0;
+  int sum = 0;
+  while (reader.next_row()) {
+    sum += std::stoi(std::string(reader.row()[1].data));
+    ++count;
+  }
 
-    EXPECT_EQ(count, 1000);
-    EXPECT_EQ(sum, 999 * 1000);  // Sum of 0 + 2 + 4 + ... + 1998
+  EXPECT_EQ(count, 1000);
+  EXPECT_EQ(sum, 999 * 1000); // Sum of 0 + 2 + 4 + ... + 1998
 }
 
 TEST(StreamingTest, LongFields) {
-    std::string long_field(10000, 'x');
-    std::string csv = long_field + "," + long_field + "\n";
-    std::istringstream input(csv);
+  std::string long_field(10000, 'x');
+  std::string csv = long_field + "," + long_field + "\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row().field_count(), 2);
-    EXPECT_EQ(reader.row()[0].data.size(), 10000);
-    EXPECT_EQ(reader.row()[1].data.size(), 10000);
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row().field_count(), 2);
+  EXPECT_EQ(reader.row()[0].data.size(), 10000);
+  EXPECT_EQ(reader.row()[1].data.size(), 10000);
 }
 
 //-----------------------------------------------------------------------------
@@ -768,53 +769,53 @@ TEST(StreamingTest, LongFields) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, UnescapedEmptyField) {
-    std::string csv = "\"\",test\n";
-    std::istringstream input(csv);
+  std::string csv = "\"\",test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    // Empty quoted field
-    EXPECT_TRUE(reader.row()[0].is_quoted);
-    EXPECT_EQ(reader.row()[0].data, "");
-    EXPECT_EQ(reader.row()[0].unescaped(), "");
+  ASSERT_TRUE(reader.next_row());
+  // Empty quoted field
+  EXPECT_TRUE(reader.row()[0].is_quoted);
+  EXPECT_EQ(reader.row()[0].data, "");
+  EXPECT_EQ(reader.row()[0].unescaped(), "");
 }
 
 TEST(StreamingTest, UnescapedUnquotedField) {
-    std::string csv = "hello,world\n";
-    std::istringstream input(csv);
+  std::string csv = "hello,world\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    // Unquoted field - unescaped returns data as-is
-    EXPECT_FALSE(reader.row()[0].is_quoted);
-    EXPECT_EQ(reader.row()[0].data, "hello");
-    EXPECT_EQ(reader.row()[0].unescaped(), "hello");
+  ASSERT_TRUE(reader.next_row());
+  // Unquoted field - unescaped returns data as-is
+  EXPECT_FALSE(reader.row()[0].is_quoted);
+  EXPECT_EQ(reader.row()[0].data, "hello");
+  EXPECT_EQ(reader.row()[0].unescaped(), "hello");
 }
 
 TEST(StreamingTest, UnescapedWithCustomQuoteChar) {
-    std::string csv = "'say ''hello''',test\n";
-    std::istringstream input(csv);
+  std::string csv = "'say ''hello''',test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.dialect.quote_char = '\'';
-    config.parse_header = false;
+  StreamConfig config;
+  config.dialect.quote_char = '\'';
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_TRUE(reader.row()[0].is_quoted);
-    // Raw data contains escaped quotes
-    EXPECT_EQ(reader.row()[0].data, "say ''hello''");
-    // unescaped with custom quote char
-    EXPECT_EQ(reader.row()[0].unescaped('\''), "say 'hello'");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_TRUE(reader.row()[0].is_quoted);
+  // Raw data contains escaped quotes
+  EXPECT_EQ(reader.row()[0].data, "say ''hello''");
+  // unescaped with custom quote char
+  EXPECT_EQ(reader.row()[0].unescaped('\''), "say 'hello'");
 }
 
 //-----------------------------------------------------------------------------
@@ -822,36 +823,36 @@ TEST(StreamingTest, UnescapedWithCustomQuoteChar) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ColumnNameLookupNoHeader) {
-    std::string csv = "a,b,c\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b,c\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;  // No header parsing
+  StreamConfig config;
+  config.parse_header = false; // No header parsing
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
+  ASSERT_TRUE(reader.next_row());
 
-    // Column name lookup without header parsing should throw
-    EXPECT_THROW(reader.row()["a"], std::out_of_range);
+  // Column name lookup without header parsing should throw
+  EXPECT_THROW(reader.row()["a"], std::out_of_range);
 }
 
 TEST(StreamingTest, ColumnNameLookupUnknownColumn) {
-    std::string csv = "name,age\nAlice,30\n";
-    std::istringstream input(csv);
+  std::string csv = "name,age\nAlice,30\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
+  ASSERT_TRUE(reader.next_row());
 
-    // Valid column lookup
-    EXPECT_NO_THROW(reader.row()["name"]);
+  // Valid column lookup
+  EXPECT_NO_THROW(reader.row()["name"]);
 
-    // Unknown column should throw
-    EXPECT_THROW(reader.row()["unknown_column"], std::out_of_range);
+  // Unknown column should throw
+  EXPECT_THROW(reader.row()["unknown_column"], std::out_of_range);
 }
 
 //-----------------------------------------------------------------------------
@@ -859,77 +860,77 @@ TEST(StreamingTest, ColumnNameLookupUnknownColumn) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, CarriageReturnOnlyLineEndings) {
-    // Old Mac-style CR-only line endings
-    std::string csv = "a,b\r1,2\r3,4\r";
-    std::istringstream input(csv);
+  // Old Mac-style CR-only line endings
+  std::string csv = "a,b\r1,2\r3,4\r";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    std::vector<std::vector<std::string>> rows;
-    while (reader.next_row()) {
-        std::vector<std::string> fields;
-        for (const auto& field : reader.row()) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
+  std::vector<std::vector<std::string>> rows;
+  while (reader.next_row()) {
+    std::vector<std::string> fields;
+    for (const auto& field : reader.row()) {
+      fields.push_back(std::string(field.data));
     }
+    rows.push_back(fields);
+  }
 
-    ASSERT_EQ(rows.size(), 3);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
-    EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
+  ASSERT_EQ(rows.size(), 3);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
+  EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
 }
 
 TEST(StreamingTest, CRLFInQuotedField) {
-    // CRLF inside quoted field should be preserved
-    std::string csv = "\"line1\r\nline2\",test\n";
-    std::istringstream input(csv);
+  // CRLF inside quoted field should be preserved
+  std::string csv = "\"line1\r\nline2\",test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "line1\r\nline2");
-    EXPECT_EQ(reader.row()[1].data, "test");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "line1\r\nline2");
+  EXPECT_EQ(reader.row()[1].data, "test");
 }
 
 TEST(StreamingTest, CROnlyInUnquotedField) {
-    // CR-only at end of unquoted field
-    std::string csv = "hello\rworld\n";
-    std::istringstream input(csv);
+  // CR-only at end of unquoted field
+  std::string csv = "hello\rworld\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "hello");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "hello");
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "world");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "world");
 }
 
 TEST(StreamingTest, CROnlyAtQuotedEnd) {
-    // CR at end of quoted field
-    std::string csv = "\"quoted\"\rvalue\n";
-    std::istringstream input(csv);
+  // CR at end of quoted field
+  std::string csv = "\"quoted\"\rvalue\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "quoted");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "quoted");
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "value");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "value");
 }
 
 //-----------------------------------------------------------------------------
@@ -937,26 +938,26 @@ TEST(StreamingTest, CROnlyAtQuotedEnd) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, InvalidCharAfterQuote) {
-    std::string csv = "\"hello\"world,test\n";
-    std::istringstream input(csv);
+  std::string csv = "\"hello\"world,test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_TRUE(reader.errors().has_errors());
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_TRUE(reader.error_collector().has_errors());
 
-    bool found_error = false;
-    for (const auto& err : reader.errors().errors()) {
-        if (err.code == ErrorCode::INVALID_QUOTE_ESCAPE) {
-            found_error = true;
-            break;
-        }
+  bool found_error = false;
+  for (const auto& err : reader.error_collector().errors()) {
+    if (err.code == ErrorCode::INVALID_QUOTE_ESCAPE) {
+      found_error = true;
+      break;
     }
-    EXPECT_TRUE(found_error);
+  }
+  EXPECT_TRUE(found_error);
 }
 
 //-----------------------------------------------------------------------------
@@ -964,29 +965,29 @@ TEST(StreamingTest, InvalidCharAfterQuote) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, SkipEmptyRows) {
-    std::string csv = "a,b\n\n1,2\n\n3,4\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b\n\n1,2\n\n3,4\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.skip_empty_rows = true;
+  StreamConfig config;
+  config.parse_header = false;
+  config.skip_empty_rows = true;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    std::vector<std::vector<std::string>> rows;
-    while (reader.next_row()) {
-        std::vector<std::string> fields;
-        for (const auto& field : reader.row()) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
+  std::vector<std::vector<std::string>> rows;
+  while (reader.next_row()) {
+    std::vector<std::string> fields;
+    for (const auto& field : reader.row()) {
+      fields.push_back(std::string(field.data));
     }
+    rows.push_back(fields);
+  }
 
-    // Only non-empty rows should be returned
-    ASSERT_EQ(rows.size(), 3);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
-    EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
+  // Only non-empty rows should be returned
+  ASSERT_EQ(rows.size(), 3);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"1", "2"}));
+  EXPECT_EQ(rows[2], (std::vector<std::string>{"3", "4"}));
 }
 
 //-----------------------------------------------------------------------------
@@ -994,49 +995,49 @@ TEST(StreamingTest, SkipEmptyRows) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, MaxFieldSizeExceeded) {
-    // Create a field that exceeds max size
-    std::string big_field(1000, 'x');
-    std::string csv = big_field + ",test\n";
-    std::istringstream input(csv);
+  // Create a field that exceeds max size
+  std::string big_field(1000, 'x');
+  std::string csv = big_field + ",test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.max_field_size = 100;  // Set a small limit
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.max_field_size = 100; // Set a small limit
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    while (reader.next_row()) {
-        // Process rows
-    }
+  while (reader.next_row()) {
+    // Process rows
+  }
 
-    // Should have recorded an error for the oversized field
-    EXPECT_TRUE(reader.errors().has_errors());
+  // Should have recorded an error for the oversized field
+  EXPECT_TRUE(reader.error_collector().has_errors());
 }
 
 TEST(StreamingTest, MaxFieldSizeWithErrorCallback) {
-    // Create a field that exceeds max size
-    std::string big_field(1000, 'x');
-    std::string csv = big_field + ",test\n";
+  // Create a field that exceeds max size
+  std::string big_field(1000, 'x');
+  std::string csv = big_field + ",test\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.max_field_size = 100;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.max_field_size = 100;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    bool error_callback_invoked = false;
-    parser.set_error_handler([&error_callback_invoked](const ParseError& err) {
-        (void)err;
-        error_callback_invoked = true;
-        return true;  // Continue parsing
-    });
+  bool error_callback_invoked = false;
+  parser.set_error_handler([&error_callback_invoked](const ParseError& err) {
+    (void)err;
+    error_callback_invoked = true;
+    return true; // Continue parsing
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_TRUE(error_callback_invoked);
+  EXPECT_TRUE(error_callback_invoked);
 }
 
 //-----------------------------------------------------------------------------
@@ -1044,64 +1045,64 @@ TEST(StreamingTest, MaxFieldSizeWithErrorCallback) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ParseChunkAfterFinish) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.parse_chunk("a,b\n");
-    parser.finish();
+  parser.parse_chunk("a,b\n");
+  parser.finish();
 
-    // Parse after finish should return END_OF_DATA
-    EXPECT_EQ(parser.parse_chunk("c,d\n"), StreamStatus::END_OF_DATA);
+  // Parse after finish should return END_OF_DATA
+  EXPECT_EQ(parser.parse_chunk("c,d\n"), StreamStatus::END_OF_DATA);
 }
 
 TEST(StreamingTest, ParseChunkAfterStop) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Stop early via callback
-    parser.set_row_handler([](const Row& row) {
-        (void)row;
-        return false;  // Stop immediately
-    });
+  // Stop early via callback
+  parser.set_row_handler([](const Row& row) {
+    (void)row;
+    return false; // Stop immediately
+  });
 
-    parser.parse_chunk("a,b\n");
+  parser.parse_chunk("a,b\n");
 
-    // Subsequent parse should return OK (stopped state)
-    EXPECT_EQ(parser.parse_chunk("c,d\n"), StreamStatus::OK);
+  // Subsequent parse should return OK (stopped state)
+  EXPECT_EQ(parser.parse_chunk("c,d\n"), StreamStatus::OK);
 }
 
 TEST(StreamingTest, FinishWhenStopped) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.set_row_handler([](const Row& row) {
-        (void)row;
-        return false;  // Stop
-    });
+  parser.set_row_handler([](const Row& row) {
+    (void)row;
+    return false; // Stop
+  });
 
-    parser.parse_chunk("a,b\n");
+  parser.parse_chunk("a,b\n");
 
-    // Finish when stopped
-    EXPECT_EQ(parser.finish(), StreamStatus::OK);
+  // Finish when stopped
+  EXPECT_EQ(parser.finish(), StreamStatus::OK);
 }
 
 TEST(StreamingTest, FinishCalledTwice) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.parse_chunk("a,b\n");
-    parser.finish();
+  parser.parse_chunk("a,b\n");
+  parser.finish();
 
-    // Second finish should return END_OF_DATA
-    EXPECT_EQ(parser.finish(), StreamStatus::END_OF_DATA);
+  // Second finish should return END_OF_DATA
+  EXPECT_EQ(parser.finish(), StreamStatus::END_OF_DATA);
 }
 
 //-----------------------------------------------------------------------------
@@ -1109,88 +1110,88 @@ TEST(StreamingTest, FinishCalledTwice) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, FinishInQuotedEndState) {
-    // File ends right after closing quote (no newline)
-    std::string csv = "\"hello\"";
+  // File ends right after closing quote (no newline)
+  std::string csv = "\"hello\"";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.parse_chunk(csv);
-    StreamStatus status = parser.finish();
+  parser.parse_chunk(csv);
+  StreamStatus status = parser.finish();
 
-    EXPECT_EQ(status, StreamStatus::END_OF_DATA);
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row()[0].data, "hello");
+  EXPECT_EQ(status, StreamStatus::END_OF_DATA);
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row()[0].data, "hello");
 }
 
 TEST(StreamingTest, FinishInFieldStartState) {
-    // File ends with a trailing delimiter (empty last field)
-    std::string csv = "a,b,";
+  // File ends with a trailing delimiter (empty last field)
+  std::string csv = "a,b,";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row().field_count(), 3);
-    EXPECT_EQ(parser.current_row()[0].data, "a");
-    EXPECT_EQ(parser.current_row()[1].data, "b");
-    EXPECT_EQ(parser.current_row()[2].data, "");
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row().field_count(), 3);
+  EXPECT_EQ(parser.current_row()[0].data, "a");
+  EXPECT_EQ(parser.current_row()[1].data, "b");
+  EXPECT_EQ(parser.current_row()[2].data, "");
 }
 
 TEST(StreamingTest, FinishWithPartialFieldBounds) {
-    // This tests the branch where we have current_field_bounds but state is RECORD_START
-    std::string csv = "a,b\n";
+  // This tests the branch where we have current_field_bounds but state is RECORD_START
+  std::string csv = "a,b\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Parse normally - should process row
-    parser.parse_chunk(csv);
-    parser.finish();
+  // Parse normally - should process row
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
 }
 
 TEST(StreamingTest, UnclosedQuoteStrict) {
-    std::string csv = "\"unclosed";
+  std::string csv = "\"unclosed";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::STRICT;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::STRICT;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.parse_chunk(csv);
-    StreamStatus status = parser.finish();
+  parser.parse_chunk(csv);
+  StreamStatus status = parser.finish();
 
-    EXPECT_EQ(status, StreamStatus::ERROR);
-    EXPECT_TRUE(parser.errors().has_fatal_errors());
+  EXPECT_EQ(status, StreamStatus::ERROR);
+  EXPECT_TRUE(parser.error_collector().has_fatal_errors());
 }
 
 TEST(StreamingTest, UnclosedQuotePermissive) {
-    std::string csv = "\"unclosed";
+  std::string csv = "\"unclosed";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Should still emit partial row in permissive mode
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_TRUE(parser.errors().has_fatal_errors());
+  // Should still emit partial row in permissive mode
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_TRUE(parser.error_collector().has_fatal_errors());
 }
 
 //-----------------------------------------------------------------------------
@@ -1198,26 +1199,26 @@ TEST(StreamingTest, UnclosedQuotePermissive) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, PullModelPendingRowCleanup) {
-    // Generate enough rows to trigger periodic cleanup (>100 rows)
-    std::ostringstream oss;
-    for (int i = 0; i < 150; ++i) {
-        oss << i << "\n";
-    }
-    std::string csv = oss.str();
+  // Generate enough rows to trigger periodic cleanup (>100 rows)
+  std::ostringstream oss;
+  for (int i = 0; i < 150; ++i) {
+    oss << i << "\n";
+  }
+  std::string csv = oss.str();
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
-    parser.parse_chunk(csv);
-    parser.finish();
+  StreamParser parser(config);
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    int count = 0;
-    while (parser.next_row() == StreamStatus::ROW_READY) {
-        ++count;
-    }
+  int count = 0;
+  while (parser.next_row() == StreamStatus::ROW_READY) {
+    ++count;
+  }
 
-    EXPECT_EQ(count, 150);
+  EXPECT_EQ(count, 150);
 }
 
 //-----------------------------------------------------------------------------
@@ -1225,11 +1226,10 @@ TEST(StreamingTest, PullModelPendingRowCleanup) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, FileOpenError) {
-    StreamConfig config;
+  StreamConfig config;
 
-    // Attempting to open non-existent file should throw
-    EXPECT_THROW(StreamReader("/nonexistent/path/to/file.csv", config),
-                 std::runtime_error);
+  // Attempting to open non-existent file should throw
+  EXPECT_THROW(StreamReader("/nonexistent/path/to/file.csv", config), std::runtime_error);
 }
 
 //-----------------------------------------------------------------------------
@@ -1237,64 +1237,64 @@ TEST(StreamingTest, FileOpenError) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, RowIteratorPostIncrement) {
-    std::string csv = "a\n1\n2\n";
-    std::istringstream input(csv);
+  std::string csv = "a\n1\n2\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    auto it = reader.begin();
-    auto prev = it++;  // Post-increment
+  auto it = reader.begin();
+  auto prev = it++; // Post-increment
 
-    // prev should have the old value (though comparing iterators is tricky for input iterators)
-    EXPECT_NE(it, reader.end());
+  // prev should have the old value (though comparing iterators is tricky for input iterators)
+  EXPECT_NE(it, reader.end());
 
-    // Continue to exhaust
-    ++it;
-    ++it;
-    EXPECT_EQ(it, reader.end());
+  // Continue to exhaust
+  ++it;
+  ++it;
+  EXPECT_EQ(it, reader.end());
 }
 
 TEST(StreamingTest, RowIteratorDereference) {
-    std::string csv = "hello,world\n";
-    std::istringstream input(csv);
+  std::string csv = "hello,world\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    auto it = reader.begin();
+  auto it = reader.begin();
 
-    // Test operator*
-    const Row& row = *it;
-    EXPECT_EQ(row[0].data, "hello");
+  // Test operator*
+  const Row& row = *it;
+  EXPECT_EQ(row[0].data, "hello");
 
-    // Test operator->
-    EXPECT_EQ(it->field_count(), 2);
-    EXPECT_EQ(it->at(0).data, "hello");
+  // Test operator->
+  EXPECT_EQ(it->field_count(), 2);
+  EXPECT_EQ(it->at(0).data, "hello");
 }
 
 TEST(StreamingTest, RowIteratorEndComparison) {
-    std::string csv = "";
-    std::istringstream input(csv);
+  std::string csv = "";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    auto begin = reader.begin();
-    auto end = reader.end();
-    auto end2 = reader.end();
+  auto begin = reader.begin();
+  auto end = reader.end();
+  auto end2 = reader.end();
 
-    // Two end iterators should be equal
-    EXPECT_EQ(end, end2);
+  // Two end iterators should be equal
+  EXPECT_EQ(end, end2);
 
-    // begin should equal end for empty input
-    EXPECT_EQ(begin, end);
+  // begin should equal end for empty input
+  EXPECT_EQ(begin, end);
 }
 
 //-----------------------------------------------------------------------------
@@ -1302,35 +1302,35 @@ TEST(StreamingTest, RowIteratorEndComparison) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, StreamParserMove) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser1(config);
-    parser1.parse_chunk("a,b\n");
+  StreamParser parser1(config);
+  parser1.parse_chunk("a,b\n");
 
-    // Move construct
-    StreamParser parser2(std::move(parser1));
+  // Move construct
+  StreamParser parser2(std::move(parser1));
 
-    parser2.finish();
-    EXPECT_EQ(parser2.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser2.current_row()[0].data, "a");
+  parser2.finish();
+  EXPECT_EQ(parser2.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser2.current_row()[0].data, "a");
 }
 
 TEST(StreamingTest, StreamParserMoveAssign) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser1(config);
-    parser1.parse_chunk("a,b\n");
+  StreamParser parser1(config);
+  parser1.parse_chunk("a,b\n");
 
-    StreamParser parser2(config);
+  StreamParser parser2(config);
 
-    // Move assign
-    parser2 = std::move(parser1);
+  // Move assign
+  parser2 = std::move(parser1);
 
-    parser2.finish();
-    EXPECT_EQ(parser2.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser2.current_row()[0].data, "a");
+  parser2.finish();
+  EXPECT_EQ(parser2.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser2.current_row()[0].data, "a");
 }
 
 //-----------------------------------------------------------------------------
@@ -1338,38 +1338,38 @@ TEST(StreamingTest, StreamParserMoveAssign) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, StreamReaderMove) {
-    std::string csv = "a,b\n1,2\n";
-    std::istringstream input(csv);
+  std::string csv = "a,b\n1,2\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader1(input, config);
+  StreamReader reader1(input, config);
 
-    // Move construct
-    StreamReader reader2(std::move(reader1));
+  // Move construct
+  StreamReader reader2(std::move(reader1));
 
-    ASSERT_TRUE(reader2.next_row());
-    EXPECT_EQ(reader2.row()[0].data, "a");
+  ASSERT_TRUE(reader2.next_row());
+  EXPECT_EQ(reader2.row()[0].data, "a");
 }
 
 TEST(StreamingTest, StreamReaderMoveAssign) {
-    std::string csv1 = "a,b\n";
-    std::string csv2 = "x,y\n";
-    std::istringstream input1(csv1);
-    std::istringstream input2(csv2);
+  std::string csv1 = "a,b\n";
+  std::string csv2 = "x,y\n";
+  std::istringstream input1(csv1);
+  std::istringstream input2(csv2);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader1(input1, config);
-    StreamReader reader2(input2, config);
+  StreamReader reader1(input1, config);
+  StreamReader reader2(input2, config);
 
-    // Move assign
-    reader2 = std::move(reader1);
+  // Move assign
+  reader2 = std::move(reader1);
 
-    ASSERT_TRUE(reader2.next_row());
-    EXPECT_EQ(reader2.row()[0].data, "a");
+  ASSERT_TRUE(reader2.next_row());
+  EXPECT_EQ(reader2.row()[0].data, "a");
 }
 
 //-----------------------------------------------------------------------------
@@ -1377,26 +1377,26 @@ TEST(StreamingTest, StreamReaderMoveAssign) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ConfigAccessParser) {
-    StreamConfig config;
-    config.dialect.delimiter = ';';
-    config.parse_header = true;
+  StreamConfig config;
+  config.dialect.delimiter = ';';
+  config.parse_header = true;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    EXPECT_EQ(parser.config().dialect.delimiter, ';');
-    EXPECT_TRUE(parser.config().parse_header);
+  EXPECT_EQ(parser.config().dialect.delimiter, ';');
+  EXPECT_TRUE(parser.config().parse_header);
 }
 
 TEST(StreamingTest, ConfigAccessReader) {
-    std::string csv = "a;b\n";
-    std::istringstream input(csv);
+  std::string csv = "a;b\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.dialect.delimiter = ';';
+  StreamConfig config;
+  config.dialect.delimiter = ';';
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    EXPECT_EQ(reader.config().dialect.delimiter, ';');
+  EXPECT_EQ(reader.config().dialect.delimiter, ';');
 }
 
 //-----------------------------------------------------------------------------
@@ -1408,241 +1408,241 @@ TEST(StreamingTest, ConfigAccessReader) {
 // This validates the fix for issue #112.
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_CRLFSplit) {
-    // CRLF split across chunks: CR at end of chunk 1, LF at start of chunk 2
-    std::string chunk1 = "hello,world\r";
-    std::string chunk2 = "\nnext,row\n";
+  // CRLF split across chunks: CR at end of chunk 1, LF at start of chunk 2
+  std::string chunk1 = "hello,world\r";
+  std::string chunk2 = "\nnext,row\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(chunk1);
-    parser.parse_chunk(chunk2);
-    parser.finish();
+  parser.parse_chunk(chunk1);
+  parser.parse_chunk(chunk2);
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"hello", "world"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"next", "row"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"hello", "world"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"next", "row"}));
 }
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_CRLFSplitMultipleRows) {
-    // Multiple CRLF pairs split across chunks
-    std::string chunk1 = "a,b\r";
-    std::string chunk2 = "\nc,d\r";
-    std::string chunk3 = "\ne,f\r";
-    std::string chunk4 = "\n";
+  // Multiple CRLF pairs split across chunks
+  std::string chunk1 = "a,b\r";
+  std::string chunk2 = "\nc,d\r";
+  std::string chunk3 = "\ne,f\r";
+  std::string chunk4 = "\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(chunk1);
-    parser.parse_chunk(chunk2);
-    parser.parse_chunk(chunk3);
-    parser.parse_chunk(chunk4);
-    parser.finish();
+  parser.parse_chunk(chunk1);
+  parser.parse_chunk(chunk2);
+  parser.parse_chunk(chunk3);
+  parser.parse_chunk(chunk4);
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 3);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"c", "d"}));
-    EXPECT_EQ(rows[2], (std::vector<std::string>{"e", "f"}));
+  ASSERT_EQ(rows.size(), 3);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"c", "d"}));
+  EXPECT_EQ(rows[2], (std::vector<std::string>{"e", "f"}));
 }
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_CRNotFollowedByLF) {
-    // CR at end of chunk, next chunk starts with regular character (not LF)
-    // This tests that CR-only line endings work across chunk boundaries
-    std::string chunk1 = "hello\r";
-    std::string chunk2 = "world\n";
+  // CR at end of chunk, next chunk starts with regular character (not LF)
+  // This tests that CR-only line endings work across chunk boundaries
+  std::string chunk1 = "hello\r";
+  std::string chunk2 = "world\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(chunk1);
-    parser.parse_chunk(chunk2);
-    parser.finish();
+  parser.parse_chunk(chunk1);
+  parser.parse_chunk(chunk2);
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"hello"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"world"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"hello"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"world"}));
 }
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_QuotedFieldCRLFSplit) {
-    // Quoted field followed by CRLF split across chunks
-    std::string chunk1 = "\"quoted\"\r";
-    std::string chunk2 = "\nnext\n";
+  // Quoted field followed by CRLF split across chunks
+  std::string chunk1 = "\"quoted\"\r";
+  std::string chunk2 = "\nnext\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(chunk1);
-    parser.parse_chunk(chunk2);
-    parser.finish();
+  parser.parse_chunk(chunk1);
+  parser.parse_chunk(chunk2);
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"quoted"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"next"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"quoted"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"next"}));
 }
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_EmptyFieldCRLFSplit) {
-    // Row ending with empty field followed by CRLF split across chunks
-    std::string chunk1 = "a,\r";
-    std::string chunk2 = "\nb,c\n";
+  // Row ending with empty field followed by CRLF split across chunks
+  std::string chunk1 = "a,\r";
+  std::string chunk2 = "\nb,c\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(chunk1);
-    parser.parse_chunk(chunk2);
-    parser.finish();
+  parser.parse_chunk(chunk1);
+  parser.parse_chunk(chunk2);
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a", ""}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"b", "c"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a", ""}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"b", "c"}));
 }
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_SingleCharChunks) {
-    // Extreme case: single character chunks around CR LF
-    std::string csv = "a\r\nb\r\n";
+  // Extreme case: single character chunks around CR LF
+  std::string csv = "a\r\nb\r\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
-
-    // Feed one character at a time
-    for (char c : csv) {
-        parser.parse_chunk(std::string_view(&c, 1));
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
     }
-    parser.finish();
+    rows.push_back(fields);
+    return true;
+  });
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"b"}));
+  // Feed one character at a time
+  for (char c : csv) {
+    parser.parse_chunk(std::string_view(&c, 1));
+  }
+  parser.finish();
+
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"b"}));
 }
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_CRAtEndOfFile) {
-    // CR at end of chunk, then finish() called (no more data)
-    std::string csv = "hello,world\r";
+  // CR at end of chunk, then finish() called (no more data)
+  std::string csv = "hello,world\r";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 1);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"hello", "world"}));
+  ASSERT_EQ(rows.size(), 1);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"hello", "world"}));
 }
 
 TEST(StreamingTest, ChunkBoundaryAfterCR_PullModel) {
-    // Test AFTER_CR chunk boundary using pull model
-    std::string chunk1 = "a,b\r";
-    std::string chunk2 = "\nc,d\n";
+  // Test AFTER_CR chunk boundary using pull model
+  std::string chunk1 = "a,b\r";
+  std::string chunk2 = "\nc,d\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    parser.parse_chunk(chunk1);
-    // At this point, row is emitted but parser is in AFTER_CR state
+  parser.parse_chunk(chunk1);
+  // At this point, row is emitted but parser is in AFTER_CR state
 
-    parser.parse_chunk(chunk2);
-    parser.finish();
+  parser.parse_chunk(chunk2);
+  parser.finish();
 
-    // Collect rows
-    std::vector<std::vector<std::string>> rows;
-    while (parser.next_row() == StreamStatus::ROW_READY) {
-        std::vector<std::string> fields;
-        for (const auto& field : parser.current_row()) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
+  // Collect rows
+  std::vector<std::vector<std::string>> rows;
+  while (parser.next_row() == StreamStatus::ROW_READY) {
+    std::vector<std::string> fields;
+    for (const auto& field : parser.current_row()) {
+      fields.push_back(std::string(field.data));
     }
+    rows.push_back(fields);
+  }
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"c", "d"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"c", "d"}));
 }
 
 //-----------------------------------------------------------------------------
@@ -1650,37 +1650,37 @@ TEST(StreamingTest, ChunkBoundaryAfterCR_PullModel) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, CRFollowedByNonLF) {
-    // CR followed by regular character (not LF)
-    std::string csv = "a\rb\n";
-    std::istringstream input(csv);
+  // CR followed by regular character (not LF)
+  std::string csv = "a\rb\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "a");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "a");
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "b");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "b");
 }
 
 TEST(StreamingTest, CRLFAtEndOfQuotedField) {
-    // Quoted field ending with CRLF
-    std::string csv = "\"hello\"\r\nworld\n";
-    std::istringstream input(csv);
+  // Quoted field ending with CRLF
+  std::string csv = "\"hello\"\r\nworld\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "hello");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "hello");
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "world");
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "world");
 }
 
 //-----------------------------------------------------------------------------
@@ -1688,20 +1688,20 @@ TEST(StreamingTest, CRLFAtEndOfQuotedField) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, QuoteInUnquotedFieldBestEffort) {
-    std::string csv = "hello\"world,test\n";
-    std::istringstream input(csv);
+  std::string csv = "hello\"world,test\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::BEST_EFFORT;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::BEST_EFFORT;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    // In best effort mode, no error should be recorded
-    EXPECT_FALSE(reader.errors().has_errors());
-    // Field should contain the quote
-    EXPECT_EQ(reader.row()[0].data, "hello\"world");
+  ASSERT_TRUE(reader.next_row());
+  // In best effort mode, no error should be recorded
+  EXPECT_FALSE(reader.error_collector().has_errors());
+  // Field should contain the quote
+  EXPECT_EQ(reader.row()[0].data, "hello\"world");
 }
 
 //-----------------------------------------------------------------------------
@@ -1709,20 +1709,20 @@ TEST(StreamingTest, QuoteInUnquotedFieldBestEffort) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, ParserColumnIndex) {
-    std::string csv = "name,age,city\nAlice,30,NYC\n";
+  std::string csv = "name,age,city\nAlice,30,NYC\n";
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamParser parser(config);
-    parser.parse_chunk(csv);
-    parser.finish();
+  StreamParser parser(config);
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // After parsing header
-    EXPECT_EQ(parser.column_index("name"), 0);
-    EXPECT_EQ(parser.column_index("age"), 1);
-    EXPECT_EQ(parser.column_index("city"), 2);
-    EXPECT_EQ(parser.column_index("unknown"), -1);
+  // After parsing header
+  EXPECT_EQ(parser.column_index("name"), 0);
+  EXPECT_EQ(parser.column_index("age"), 1);
+  EXPECT_EQ(parser.column_index("city"), 2);
+  EXPECT_EQ(parser.column_index("unknown"), -1);
 }
 
 //-----------------------------------------------------------------------------
@@ -1730,19 +1730,20 @@ TEST(StreamingTest, ParserColumnIndex) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, BytesProcessed) {
-    std::string csv = "hello,world\n";
+  std::string csv = "hello,world\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
-    parser.parse_chunk(csv);
-    parser.finish();
+  StreamParser parser(config);
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Process all rows
-    while (parser.next_row() == StreamStatus::ROW_READY) {}
+  // Process all rows
+  while (parser.next_row() == StreamStatus::ROW_READY) {
+  }
 
-    EXPECT_EQ(parser.bytes_processed(), csv.size());
+  EXPECT_EQ(parser.bytes_processed(), csv.size());
 }
 
 //-----------------------------------------------------------------------------
@@ -1750,27 +1751,27 @@ TEST(StreamingTest, BytesProcessed) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, EmptyRowAtRecordStart) {
-    // Multiple consecutive newlines
-    std::string csv = "\n\na,b\n";
-    std::istringstream input(csv);
+  // Multiple consecutive newlines
+  std::string csv = "\n\na,b\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.skip_empty_rows = false;
+  StreamConfig config;
+  config.parse_header = false;
+  config.skip_empty_rows = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    // First empty row
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row().field_count(), 0);
+  // First empty row
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row().field_count(), 0);
 
-    // Second empty row
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row().field_count(), 0);
+  // Second empty row
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row().field_count(), 0);
 
-    // Actual data row
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row().field_count(), 2);
+  // Actual data row
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row().field_count(), 2);
 }
 
 //-----------------------------------------------------------------------------
@@ -1778,32 +1779,32 @@ TEST(StreamingTest, EmptyRowAtRecordStart) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, FieldEmptyMethod) {
-    std::string csv = "hello,,world\n";
-    std::istringstream input(csv);
+  std::string csv = "hello,,world\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_FALSE(reader.row()[0].empty());
-    EXPECT_TRUE(reader.row()[1].empty());
-    EXPECT_FALSE(reader.row()[2].empty());
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_FALSE(reader.row()[0].empty());
+  EXPECT_TRUE(reader.row()[1].empty());
+  EXPECT_FALSE(reader.row()[2].empty());
 }
 
 TEST(StreamingTest, FieldStrMethod) {
-    std::string csv = "hello,world\n";
-    std::istringstream input(csv);
+  std::string csv = "hello,world\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    std::string s = reader.row()[0].str();
-    EXPECT_EQ(s, "hello");
+  ASSERT_TRUE(reader.next_row());
+  std::string s = reader.row()[0].str();
+  EXPECT_EQ(s, "hello");
 }
 
 //-----------------------------------------------------------------------------
@@ -1811,20 +1812,20 @@ TEST(StreamingTest, FieldStrMethod) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, RowEmptyMethod) {
-    std::string csv = "\na,b\n";
-    std::istringstream input(csv);
+  std::string csv = "\na,b\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.skip_empty_rows = false;
+  StreamConfig config;
+  config.parse_header = false;
+  config.skip_empty_rows = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_TRUE(reader.row().empty());
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_TRUE(reader.row().empty());
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_FALSE(reader.row().empty());
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_FALSE(reader.row().empty());
 }
 
 //-----------------------------------------------------------------------------
@@ -1832,19 +1833,19 @@ TEST(StreamingTest, RowEmptyMethod) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, StrictErrorModeStopsOnError) {
-    // Quote in unquoted field triggers an immediate error during parsing
-    std::string csv = "hello\"world,test\n";
+  // Quote in unquoted field triggers an immediate error during parsing
+  std::string csv = "hello\"world,test\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::STRICT;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::STRICT;
 
-    StreamParser parser(config);
-    StreamStatus status = parser.parse_chunk(csv);
+  StreamParser parser(config);
+  StreamStatus status = parser.parse_chunk(csv);
 
-    // Strict mode should stop on first error (quote in unquoted field)
-    EXPECT_EQ(status, StreamStatus::ERROR);
-    EXPECT_TRUE(parser.errors().has_errors());
+  // Strict mode should stop on first error (quote in unquoted field)
+  EXPECT_EQ(status, StreamStatus::ERROR);
+  EXPECT_TRUE(parser.error_collector().has_errors());
 }
 
 //-----------------------------------------------------------------------------
@@ -1852,202 +1853,202 @@ TEST(StreamingTest, StrictErrorModeStopsOnError) {
 //-----------------------------------------------------------------------------
 
 TEST(StreamingTest, InvalidQuoteEscapeErrorCallbackInvoked) {
-    // "hello"world triggers INVALID_QUOTE_ESCAPE when 'w' follows closing quote
-    std::string csv = "\"hello\"world,test\n";
+  // "hello"world triggers INVALID_QUOTE_ESCAPE when 'w' follows closing quote
+  std::string csv = "\"hello\"world,test\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    bool error_callback_invoked = false;
-    ErrorCode received_code = ErrorCode::NONE;
-    parser.set_error_handler([&error_callback_invoked, &received_code](const ParseError& err) {
-        error_callback_invoked = true;
-        received_code = err.code;
-        return true;  // Continue parsing
-    });
+  bool error_callback_invoked = false;
+  ErrorCode received_code = ErrorCode::NONE;
+  parser.set_error_handler([&error_callback_invoked, &received_code](const ParseError& err) {
+    error_callback_invoked = true;
+    received_code = err.code;
+    return true; // Continue parsing
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_TRUE(error_callback_invoked);
-    EXPECT_EQ(received_code, ErrorCode::INVALID_QUOTE_ESCAPE);
+  EXPECT_TRUE(error_callback_invoked);
+  EXPECT_EQ(received_code, ErrorCode::INVALID_QUOTE_ESCAPE);
 }
 
 TEST(StreamingTest, QuoteInUnquotedFieldErrorCallbackInvoked) {
-    // hello"world triggers QUOTE_IN_UNQUOTED_FIELD
-    std::string csv = "hello\"world,test\n";
+  // hello"world triggers QUOTE_IN_UNQUOTED_FIELD
+  std::string csv = "hello\"world,test\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    bool error_callback_invoked = false;
-    ErrorCode received_code = ErrorCode::NONE;
-    parser.set_error_handler([&error_callback_invoked, &received_code](const ParseError& err) {
-        error_callback_invoked = true;
-        received_code = err.code;
-        return true;  // Continue parsing
-    });
+  bool error_callback_invoked = false;
+  ErrorCode received_code = ErrorCode::NONE;
+  parser.set_error_handler([&error_callback_invoked, &received_code](const ParseError& err) {
+    error_callback_invoked = true;
+    received_code = err.code;
+    return true; // Continue parsing
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_TRUE(error_callback_invoked);
-    EXPECT_EQ(received_code, ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
+  EXPECT_TRUE(error_callback_invoked);
+  EXPECT_EQ(received_code, ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
 }
 
 TEST(StreamingTest, ErrorCallbackReceivesCorrectLocation) {
-    // Verify that error callback receives accurate line/column/offset info
-    std::string csv = "a,b\nhello\"world,test\n";
+  // Verify that error callback receives accurate line/column/offset info
+  std::string csv = "a,b\nhello\"world,test\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    size_t error_line = 0;
-    size_t error_column = 0;
-    parser.set_error_handler([&error_line, &error_column](const ParseError& err) {
-        error_line = err.line;
-        error_column = err.column;
-        return true;
-    });
+  size_t error_line = 0;
+  size_t error_column = 0;
+  parser.set_error_handler([&error_line, &error_column](const ParseError& err) {
+    error_line = err.line;
+    error_column = err.column;
+    return true;
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Error should be on line 2 (second row), column 1 (first field)
-    EXPECT_EQ(error_line, 2);
-    EXPECT_EQ(error_column, 1);
+  // Error should be on line 2 (second row), column 1 (first field)
+  EXPECT_EQ(error_line, 2);
+  EXPECT_EQ(error_column, 1);
 }
 
 TEST(StreamingTest, ErrorCallbackReturnFalseHaltsParsing) {
-    // Test that returning false from error callback halts parsing
-    std::string csv = "a\"b,c\nd,e,f\ng,h,i\n";
+  // Test that returning false from error callback halts parsing
+  std::string csv = "a\"b,c\nd,e,f\ng,h,i\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    int error_count = 0;
-    parser.set_error_handler([&error_count](const ParseError& err) {
-        (void)err;
-        ++error_count;
-        return false;  // Request halt on first error
-    });
+  int error_count = 0;
+  parser.set_error_handler([&error_count](const ParseError& err) {
+    (void)err;
+    ++error_count;
+    return false; // Request halt on first error
+  });
 
-    int row_count = 0;
-    parser.set_row_handler([&row_count](const Row& row) {
-        (void)row;
-        ++row_count;
-        return true;
-    });
+  int row_count = 0;
+  parser.set_row_handler([&row_count](const Row& row) {
+    (void)row;
+    ++row_count;
+    return true;
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Error callback was invoked once
-    EXPECT_EQ(error_count, 1);
-    // Parsing halts immediately after the error callback returns false.
-    // The stopped flag is checked after processing each character, so the
-    // row with the error is NOT emitted since we stop before reaching the newline.
-    EXPECT_EQ(row_count, 0);
+  // Error callback was invoked once
+  EXPECT_EQ(error_count, 1);
+  // Parsing halts immediately after the error callback returns false.
+  // The stopped flag is checked after processing each character, so the
+  // row with the error is NOT emitted since we stop before reaching the newline.
+  EXPECT_EQ(row_count, 0);
 }
 
 TEST(StreamingTest, MultipleErrorsInvokeCallbackMultipleTimes) {
-    // CSV with multiple errors
-    std::string csv = "a\"b,c\n\"d\"e,f\n";
+  // CSV with multiple errors
+  std::string csv = "a\"b,c\n\"d\"e,f\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    int error_count = 0;
-    std::vector<ErrorCode> error_codes;
-    parser.set_error_handler([&error_count, &error_codes](const ParseError& err) {
-        ++error_count;
-        error_codes.push_back(err.code);
-        return true;  // Continue parsing
-    });
+  int error_count = 0;
+  std::vector<ErrorCode> error_codes;
+  parser.set_error_handler([&error_count, &error_codes](const ParseError& err) {
+    ++error_count;
+    error_codes.push_back(err.code);
+    return true; // Continue parsing
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Should have at least 2 errors
-    EXPECT_GE(error_count, 2);
-    // First error: quote in unquoted field (a"b)
-    EXPECT_EQ(error_codes[0], ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
-    // Second error: invalid quote escape ("d"e - 'e' after closing quote)
-    EXPECT_EQ(error_codes[1], ErrorCode::INVALID_QUOTE_ESCAPE);
+  // Should have at least 2 errors
+  EXPECT_GE(error_count, 2);
+  // First error: quote in unquoted field (a"b)
+  EXPECT_EQ(error_codes[0], ErrorCode::QUOTE_IN_UNQUOTED_FIELD);
+  // Second error: invalid quote escape ("d"e - 'e' after closing quote)
+  EXPECT_EQ(error_codes[1], ErrorCode::INVALID_QUOTE_ESCAPE);
 }
 
 TEST(StreamingTest, ErrorCallbackNotInvokedInBestEffortMode) {
-    // In BEST_EFFORT mode, errors should not invoke callback
-    std::string csv = "hello\"world,test\n";
+  // In BEST_EFFORT mode, errors should not invoke callback
+  std::string csv = "hello\"world,test\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::BEST_EFFORT;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::BEST_EFFORT;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    bool error_callback_invoked = false;
-    parser.set_error_handler([&error_callback_invoked](const ParseError& err) {
-        (void)err;
-        error_callback_invoked = true;
-        return true;
-    });
+  bool error_callback_invoked = false;
+  parser.set_error_handler([&error_callback_invoked](const ParseError& err) {
+    (void)err;
+    error_callback_invoked = true;
+    return true;
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Error callback should NOT be invoked in BEST_EFFORT mode
-    EXPECT_FALSE(error_callback_invoked);
+  // Error callback should NOT be invoked in BEST_EFFORT mode
+  EXPECT_FALSE(error_callback_invoked);
 }
 
 TEST(StreamingTest, MaxFieldSizeErrorCallbackReturnFalseHaltsParsing) {
-    // Test that max field size error callback return value is respected
-    std::string big_field(1000, 'x');
-    std::string csv = big_field + ",test\nnormal,data\n";
+  // Test that max field size error callback return value is respected
+  std::string big_field(1000, 'x');
+  std::string csv = big_field + ",test\nnormal,data\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.max_field_size = 100;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.max_field_size = 100;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    int error_count = 0;
-    parser.set_error_handler([&error_count](const ParseError& err) {
-        (void)err;
-        ++error_count;
-        return false;  // Request halt
-    });
+  int error_count = 0;
+  parser.set_error_handler([&error_count](const ParseError& err) {
+    (void)err;
+    ++error_count;
+    return false; // Request halt
+  });
 
-    int row_count = 0;
-    parser.set_row_handler([&row_count](const Row& row) {
-        (void)row;
-        ++row_count;
-        return true;
-    });
+  int row_count = 0;
+  parser.set_row_handler([&row_count](const Row& row) {
+    (void)row;
+    ++row_count;
+    return true;
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Error callback was invoked once for the oversized field
-    EXPECT_EQ(error_count, 1);
-    // Parsing should have halted, so second row is not processed
-    EXPECT_EQ(row_count, 0);
+  // Error callback was invoked once for the oversized field
+  EXPECT_EQ(error_count, 1);
+  // Parsing should have halted, so second row is not processed
+  EXPECT_EQ(row_count, 0);
 }
 
 //-----------------------------------------------------------------------------
@@ -2056,493 +2057,493 @@ TEST(StreamingTest, MaxFieldSizeErrorCallbackReturnFalseHaltsParsing) {
 
 // Test that error callback returning false in QUOTED_END state stops parsing
 TEST(StreamingTest, InvalidQuoteEscapeErrorCallbackReturnFalseHaltsParsing) {
-    // "hello"world triggers INVALID_QUOTE_ESCAPE when 'w' follows closing quote
-    std::string csv = "\"hello\"world,test\nmore,data\n";
+  // "hello"world triggers INVALID_QUOTE_ESCAPE when 'w' follows closing quote
+  std::string csv = "\"hello\"world,test\nmore,data\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    int error_count = 0;
-    parser.set_error_handler([&error_count](const ParseError& err) {
-        (void)err;
-        ++error_count;
-        return false;  // Request halt on error
-    });
+  int error_count = 0;
+  parser.set_error_handler([&error_count](const ParseError& err) {
+    (void)err;
+    ++error_count;
+    return false; // Request halt on error
+  });
 
-    int row_count = 0;
-    parser.set_row_handler([&row_count](const Row& row) {
-        (void)row;
-        ++row_count;
-        return true;
-    });
+  int row_count = 0;
+  parser.set_row_handler([&row_count](const Row& row) {
+    (void)row;
+    ++row_count;
+    return true;
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    // Error callback was invoked once
-    EXPECT_EQ(error_count, 1);
-    // Parsing halted immediately - no rows should be processed
-    EXPECT_EQ(row_count, 0);
+  // Error callback was invoked once
+  EXPECT_EQ(error_count, 1);
+  // Parsing halted immediately - no rows should be processed
+  EXPECT_EQ(row_count, 0);
 }
 
 // Test field_start adjustment when field_start < last_row_end in chunk processing
 TEST(StreamingTest, FieldStartAdjustmentWhenLessThanLastRowEnd) {
-    // This tests the branch where field_start < last_row_end after processing a chunk
-    // We need a scenario where:
-    // 1. A complete row is found
-    // 2. The field_start for the next row is at the very start (0 relative to last_row_end)
-    std::string chunk1 = "hello,world\n";
-    std::string chunk2 = "next,row\n";
+  // This tests the branch where field_start < last_row_end after processing a chunk
+  // We need a scenario where:
+  // 1. A complete row is found
+  // 2. The field_start for the next row is at the very start (0 relative to last_row_end)
+  std::string chunk1 = "hello,world\n";
+  std::string chunk2 = "next,row\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    // Parse first chunk - row ends exactly at chunk boundary
-    parser.parse_chunk(chunk1);
-    // At this point, field_start should be 0 (relative to start of any remaining buffer)
+  // Parse first chunk - row ends exactly at chunk boundary
+  parser.parse_chunk(chunk1);
+  // At this point, field_start should be 0 (relative to start of any remaining buffer)
 
-    // Parse second chunk
-    parser.parse_chunk(chunk2);
-    parser.finish();
+  // Parse second chunk
+  parser.parse_chunk(chunk2);
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"hello", "world"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"next", "row"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"hello", "world"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"next", "row"}));
 }
 
 // Test finish() with partial field_bounds (state is RECORD_START but we have field bounds)
 TEST(StreamingTest, FinishWithPartialFieldBoundsAtRecordStart) {
-    // This is a tricky case - we need current_field_bounds to be non-empty
-    // while state is RECORD_START at finish time. This can happen if
-    // we parsed part of a row but didn't complete it, then the row ended.
-    // Actually, re-examining the code, if we have field_bounds and state is RECORD_START,
-    // we're at the end of a row that was already processed.
-    // The actual branch at line 509 is for when we have field_bounds but are in an
-    // unexpected state. Let me look more carefully.
+  // This is a tricky case - we need current_field_bounds to be non-empty
+  // while state is RECORD_START at finish time. This can happen if
+  // we parsed part of a row but didn't complete it, then the row ended.
+  // Actually, re-examining the code, if we have field_bounds and state is RECORD_START,
+  // we're at the end of a row that was already processed.
+  // The actual branch at line 509 is for when we have field_bounds but are in an
+  // unexpected state. Let me look more carefully.
 
-    // After reviewing the code, the branch at line 507-509:
-    // } else if (!current_field_bounds.empty()) {
-    //     // Have partial row data
-    //     emit_row();
-    // }
-    // This is reached when state is not RECORD_START, UNQUOTED_FIELD, QUOTED_FIELD,
-    // QUOTED_END, or FIELD_START, but we have field bounds. However, there's no
-    // other state in the enum, so this is essentially dead code / defensive programming.
-    // We can verify it's not reachable in current design.
+  // After reviewing the code, the branch at line 507-509:
+  // } else if (!current_field_bounds.empty()) {
+  //     // Have partial row data
+  //     emit_row();
+  // }
+  // This is reached when state is not RECORD_START, UNQUOTED_FIELD, QUOTED_FIELD,
+  // QUOTED_END, or FIELD_START, but we have field bounds. However, there's no
+  // other state in the enum, so this is essentially dead code / defensive programming.
+  // We can verify it's not reachable in current design.
 
-    // Let's test what we can - which is the field_start < last_row_end case
-    // We need partial data that ends mid-field to test field_start adjustment.
+  // Let's test what we can - which is the field_start < last_row_end case
+  // We need partial data that ends mid-field to test field_start adjustment.
 
-    // Create a scenario where a row ends and the next field_start would be 0
-    std::string csv = "ab\ncd\n";
+  // Create a scenario where a row ends and the next field_start would be 0
+  std::string csv = "ab\ncd\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Parse byte by byte to force many adjustments
-    for (char c : csv) {
-        parser.parse_chunk(std::string_view(&c, 1));
+  // Parse byte by byte to force many adjustments
+  for (char c : csv) {
+    parser.parse_chunk(std::string_view(&c, 1));
+  }
+  parser.finish();
+
+  std::vector<std::vector<std::string>> rows;
+  while (parser.next_row() == StreamStatus::ROW_READY) {
+    std::vector<std::string> fields;
+    for (const auto& field : parser.current_row()) {
+      fields.push_back(std::string(field.data));
     }
-    parser.finish();
+    rows.push_back(fields);
+  }
 
-    std::vector<std::vector<std::string>> rows;
-    while (parser.next_row() == StreamStatus::ROW_READY) {
-        std::vector<std::string> fields;
-        for (const auto& field : parser.current_row()) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-    }
-
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], (std::vector<std::string>{"ab"}));
-    EXPECT_EQ(rows[1], (std::vector<std::string>{"cd"}));
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], (std::vector<std::string>{"ab"}));
+  EXPECT_EQ(rows[1], (std::vector<std::string>{"cd"}));
 }
 
 // Test RowIterator comparison when both iterators are not at end
 TEST(StreamingTest, RowIteratorNonEndComparison) {
-    std::string csv = "a\nb\nc\n";
-    std::istringstream input1(csv);
-    std::istringstream input2(csv);
+  std::string csv = "a\nb\nc\n";
+  std::istringstream input1(csv);
+  std::istringstream input2(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader1(input1, config);
-    StreamReader reader2(input2, config);
+  StreamReader reader1(input1, config);
+  StreamReader reader2(input2, config);
 
-    auto it1 = reader1.begin();
-    auto it2 = reader2.begin();
-    auto end = reader1.end();
+  auto it1 = reader1.begin();
+  auto it2 = reader2.begin();
+  auto end = reader1.end();
 
-    // Both iterators are not at end
-    EXPECT_NE(it1, end);
-    EXPECT_NE(it2, end);
+  // Both iterators are not at end
+  EXPECT_NE(it1, end);
+  EXPECT_NE(it2, end);
 
-    // Two begin iterators from different readers should not be equal
-    // (they point to different readers)
-    EXPECT_NE(it1, it2);
+  // Two begin iterators from different readers should not be equal
+  // (they point to different readers)
+  EXPECT_NE(it1, it2);
 
-    // Same iterator should equal itself (testing reflexivity)
-    EXPECT_EQ(it1, it1);
+  // Same iterator should equal itself (testing reflexivity)
+  EXPECT_EQ(it1, it1);
 }
 
 // Test read_more_data returning false when input is null
 TEST(StreamingTest, StreamReaderFromFileReadsBinaryData) {
-    // Create a temporary file with binary-safe content
-    std::string temp_file = "/tmp/streaming_test_binary.csv";
-    {
-        std::ofstream out(temp_file, std::ios::binary);
-        out << "a,b\n1,2\n";
-    }
+  // Create a temporary file with binary-safe content
+  std::string temp_file = "/tmp/streaming_test_binary.csv";
+  {
+    std::ofstream out(temp_file, std::ios::binary);
+    out << "a,b\n1,2\n";
+  }
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    // Use the file constructor (tests line 715)
-    StreamReader reader(temp_file, config);
+  // Use the file constructor (tests line 715)
+  StreamReader reader(temp_file, config);
 
-    ASSERT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()[0].data, "1");
-    EXPECT_EQ(reader.row()[1].data, "2");
-    EXPECT_FALSE(reader.next_row());
+  ASSERT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()[0].data, "1");
+  EXPECT_EQ(reader.row()[1].data, "2");
+  EXPECT_FALSE(reader.next_row());
 
-    // Cleanup
-    std::remove(temp_file.c_str());
+  // Cleanup
+  std::remove(temp_file.c_str());
 }
 
 // Test chunk boundary where field_start needs adjustment to 0
 TEST(StreamingTest, ChunkBoundaryFieldStartZeroAdjustment) {
-    // Set up a scenario where after processing:
-    // - last_row_end > 0 (a row was completed)
-    // - field_start < last_row_end (the next field starts within processed data)
-    // This forces the else branch: field_start = 0
+  // Set up a scenario where after processing:
+  // - last_row_end > 0 (a row was completed)
+  // - field_start < last_row_end (the next field starts within processed data)
+  // This forces the else branch: field_start = 0
 
-    // Create CSV where row ends at specific position
-    std::string csv = "x\ny\n";
+  // Create CSV where row ends at specific position
+  std::string csv = "x\ny\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::string> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        rows.push_back(std::string(row[0].data));
-        return true;
-    });
+  std::vector<std::string> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    rows.push_back(std::string(row[0].data));
+    return true;
+  });
 
-    // Feed data one byte at a time to ensure field_start adjustments happen
-    for (size_t i = 0; i < csv.size(); ++i) {
-        parser.parse_chunk(std::string_view(csv.data() + i, 1));
-    }
-    parser.finish();
+  // Feed data one byte at a time to ensure field_start adjustments happen
+  for (size_t i = 0; i < csv.size(); ++i) {
+    parser.parse_chunk(std::string_view(csv.data() + i, 1));
+  }
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], "x");
-    EXPECT_EQ(rows[1], "y");
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], "x");
+  EXPECT_EQ(rows[1], "y");
 }
 
 // Test that StreamReader constructor with ifstream properly sets up input
 TEST(StreamingTest, StreamReaderFromFileWithHeader) {
-    std::string temp_file = "/tmp/streaming_test_header.csv";
-    {
-        std::ofstream out(temp_file, std::ios::binary);
-        out << "name,value\nfoo,100\nbar,200\n";
-    }
+  std::string temp_file = "/tmp/streaming_test_header.csv";
+  {
+    std::ofstream out(temp_file, std::ios::binary);
+    out << "name,value\nfoo,100\nbar,200\n";
+  }
 
-    StreamConfig config;
-    config.parse_header = true;
+  StreamConfig config;
+  config.parse_header = true;
 
-    StreamReader reader(temp_file, config);
+  StreamReader reader(temp_file, config);
 
-    EXPECT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.header(), (std::vector<std::string>{"name", "value"}));
-    EXPECT_EQ(reader.row()["name"].data, "foo");
-    EXPECT_EQ(reader.row()["value"].data, "100");
+  EXPECT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.header(), (std::vector<std::string>{"name", "value"}));
+  EXPECT_EQ(reader.row()["name"].data, "foo");
+  EXPECT_EQ(reader.row()["value"].data, "100");
 
-    EXPECT_TRUE(reader.next_row());
-    EXPECT_EQ(reader.row()["name"].data, "bar");
-    EXPECT_EQ(reader.row()["value"].data, "200");
+  EXPECT_TRUE(reader.next_row());
+  EXPECT_EQ(reader.row()["name"].data, "bar");
+  EXPECT_EQ(reader.row()["value"].data, "200");
 
-    EXPECT_FALSE(reader.next_row());
-    EXPECT_TRUE(reader.eof());
+  EXPECT_FALSE(reader.next_row());
+  EXPECT_TRUE(reader.eof());
 
-    std::remove(temp_file.c_str());
+  std::remove(temp_file.c_str());
 }
 
 // Test StreamReader with large file triggering multiple read_more_data calls
 TEST(StreamingTest, StreamReaderMultipleChunks) {
-    std::string temp_file = "/tmp/streaming_test_large.csv";
-    {
-        std::ofstream out(temp_file, std::ios::binary);
-        out << "id\n";
-        for (int i = 0; i < 1000; ++i) {
-            out << i << "\n";
-        }
+  std::string temp_file = "/tmp/streaming_test_large.csv";
+  {
+    std::ofstream out(temp_file, std::ios::binary);
+    out << "id\n";
+    for (int i = 0; i < 1000; ++i) {
+      out << i << "\n";
     }
+  }
 
-    StreamConfig config;
-    config.parse_header = true;
-    config.chunk_size = 64;  // Small chunk size to force multiple reads
+  StreamConfig config;
+  config.parse_header = true;
+  config.chunk_size = 64; // Small chunk size to force multiple reads
 
-    StreamReader reader(temp_file, config);
+  StreamReader reader(temp_file, config);
 
-    int count = 0;
-    while (reader.next_row()) {
-        ++count;
-    }
+  int count = 0;
+  while (reader.next_row()) {
+    ++count;
+  }
 
-    EXPECT_EQ(count, 1000);
-    EXPECT_TRUE(reader.eof());
+  EXPECT_EQ(count, 1000);
+  EXPECT_TRUE(reader.eof());
 
-    std::remove(temp_file.c_str());
+  std::remove(temp_file.c_str());
 }
 
 // Test empty chunks don't break state
 TEST(StreamingTest, EmptyChunkProcessing) {
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::string> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        rows.push_back(std::string(row[0].data));
-        return true;
-    });
+  std::vector<std::string> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    rows.push_back(std::string(row[0].data));
+    return true;
+  });
 
-    // Empty chunk
-    parser.parse_chunk(std::string_view("", 0));
-    // Actual data
-    parser.parse_chunk("hello\n");
-    // Another empty chunk
-    parser.parse_chunk(std::string_view("", 0));
-    // More data
-    parser.parse_chunk("world\n");
-    parser.finish();
+  // Empty chunk
+  parser.parse_chunk(std::string_view("", 0));
+  // Actual data
+  parser.parse_chunk("hello\n");
+  // Another empty chunk
+  parser.parse_chunk(std::string_view("", 0));
+  // More data
+  parser.parse_chunk("world\n");
+  parser.finish();
 
-    ASSERT_EQ(rows.size(), 2);
-    EXPECT_EQ(rows[0], "hello");
-    EXPECT_EQ(rows[1], "world");
+  ASSERT_EQ(rows.size(), 2);
+  EXPECT_EQ(rows[0], "hello");
+  EXPECT_EQ(rows[1], "world");
 }
 
 // Test that StreamReader handles EOF correctly during iteration
 TEST(StreamingTest, StreamReaderEOFHandling) {
-    std::string csv = "a\nb\n";
-    std::istringstream input(csv);
+  std::string csv = "a\nb\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    // Before reading, not at EOF
-    EXPECT_FALSE(reader.eof());
+  // Before reading, not at EOF
+  EXPECT_FALSE(reader.eof());
 
-    // Read all rows
-    int count = 0;
-    while (reader.next_row()) {
-        ++count;
-    }
+  // Read all rows
+  int count = 0;
+  while (reader.next_row()) {
+    ++count;
+  }
 
-    // After exhausting, should be at EOF
-    EXPECT_EQ(count, 2);
-    EXPECT_TRUE(reader.eof());
+  // After exhausting, should be at EOF
+  EXPECT_EQ(count, 2);
+  EXPECT_TRUE(reader.eof());
 
-    // Additional next_row calls should continue returning false
-    EXPECT_FALSE(reader.next_row());
-    EXPECT_TRUE(reader.eof());
+  // Additional next_row calls should continue returning false
+  EXPECT_FALSE(reader.next_row());
+  EXPECT_TRUE(reader.eof());
 }
 
 // Test buffer management with very long partial rows
 TEST(StreamingTest, BufferManagementLongPartialRow) {
-    // Create a very long field that spans multiple chunks
-    std::string long_field(10000, 'x');
-    std::string csv = long_field + "\n";
+  // Create a very long field that spans multiple chunks
+  std::string long_field(10000, 'x');
+  std::string csv = long_field + "\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Feed in small chunks
-    size_t chunk_size = 100;
-    for (size_t i = 0; i < csv.size(); i += chunk_size) {
-        size_t len = std::min(chunk_size, csv.size() - i);
-        parser.parse_chunk(std::string_view(csv.data() + i, len));
-    }
-    parser.finish();
+  // Feed in small chunks
+  size_t chunk_size = 100;
+  for (size_t i = 0; i < csv.size(); i += chunk_size) {
+    size_t len = std::min(chunk_size, csv.size() - i);
+    parser.parse_chunk(std::string_view(csv.data() + i, len));
+  }
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row()[0].data.size(), 10000);
-    EXPECT_EQ(parser.next_row(), StreamStatus::END_OF_DATA);
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row()[0].data.size(), 10000);
+  EXPECT_EQ(parser.next_row(), StreamStatus::END_OF_DATA);
 }
 
 // Test that bytes_read reflects actual bytes read from stream
 TEST(StreamingTest, StreamReaderBytesReadAccurate) {
-    std::string csv = "hello,world\nfoo,bar\n";
-    std::istringstream input(csv);
+  std::string csv = "hello,world\nfoo,bar\n";
+  std::istringstream input(csv);
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamReader reader(input, config);
+  StreamReader reader(input, config);
 
-    // Initially, no bytes read
-    EXPECT_EQ(reader.bytes_read(), 0);
+  // Initially, no bytes read
+  EXPECT_EQ(reader.bytes_read(), 0);
 
-    // After reading first row, some bytes read
-    EXPECT_TRUE(reader.next_row());
-    EXPECT_GT(reader.bytes_read(), 0);
+  // After reading first row, some bytes read
+  EXPECT_TRUE(reader.next_row());
+  EXPECT_GT(reader.bytes_read(), 0);
 
-    // After reading all, all bytes should be read
-    while (reader.next_row()) {}
-    EXPECT_EQ(reader.bytes_read(), csv.size());
+  // After reading all, all bytes should be read
+  while (reader.next_row()) {
+  }
+  EXPECT_EQ(reader.bytes_read(), csv.size());
 }
 
 // Test recovery from errors in permissive mode across chunk boundaries
 TEST(StreamingTest, ErrorRecoveryAcrossChunkBoundary) {
-    // First chunk ends with invalid state, second chunk continues
-    std::string chunk1 = "hello\"";  // Quote in unquoted field
-    std::string chunk2 = "world,test\nnext,row\n";
+  // First chunk ends with invalid state, second chunk continues
+  std::string chunk1 = "hello\""; // Quote in unquoted field
+  std::string chunk2 = "world,test\nnext,row\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    std::vector<std::vector<std::string>> rows;
-    parser.set_row_handler([&rows](const Row& row) {
-        std::vector<std::string> fields;
-        for (const auto& field : row) {
-            fields.push_back(std::string(field.data));
-        }
-        rows.push_back(fields);
-        return true;
-    });
+  std::vector<std::vector<std::string>> rows;
+  parser.set_row_handler([&rows](const Row& row) {
+    std::vector<std::string> fields;
+    for (const auto& field : row) {
+      fields.push_back(std::string(field.data));
+    }
+    rows.push_back(fields);
+    return true;
+  });
 
-    parser.parse_chunk(chunk1);
-    parser.parse_chunk(chunk2);
-    parser.finish();
+  parser.parse_chunk(chunk1);
+  parser.parse_chunk(chunk2);
+  parser.finish();
 
-    // Should have recovered and parsed both rows
-    ASSERT_GE(rows.size(), 1);
-    EXPECT_TRUE(parser.errors().has_errors());
+  // Should have recovered and parsed both rows
+  ASSERT_GE(rows.size(), 1);
+  EXPECT_TRUE(parser.error_collector().has_errors());
 }
 
 // Test state preservation when quoted field spans many chunks
 TEST(StreamingTest, QuotedFieldSpansManyChunks) {
-    // Quoted field with embedded newlines and commas spanning many chunks
-    // Use doubled quotes ("") inside to represent literal quotes
-    std::string raw_content = "This is a \"\"long\"\" field,\nwith newlines\r\nand various,commas";
-    std::string csv = "\"" + raw_content + "\",end\n";
+  // Quoted field with embedded newlines and commas spanning many chunks
+  // Use doubled quotes ("") inside to represent literal quotes
+  std::string raw_content = "This is a \"\"long\"\" field,\nwith newlines\r\nand various,commas";
+  std::string csv = "\"" + raw_content + "\",end\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    // Feed character by character
-    for (char c : csv) {
-        parser.parse_chunk(std::string_view(&c, 1));
-    }
-    parser.finish();
+  // Feed character by character
+  for (char c : csv) {
+    parser.parse_chunk(std::string_view(&c, 1));
+  }
+  parser.finish();
 
-    EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
-    EXPECT_EQ(parser.current_row().field_count(), 2);
-    // Raw data should contain the doubled quotes
-    EXPECT_EQ(parser.current_row()[0].data, raw_content);
-    EXPECT_TRUE(parser.current_row()[0].is_quoted);
-    EXPECT_EQ(parser.current_row()[1].data, "end");
+  EXPECT_EQ(parser.next_row(), StreamStatus::ROW_READY);
+  EXPECT_EQ(parser.current_row().field_count(), 2);
+  // Raw data should contain the doubled quotes
+  EXPECT_EQ(parser.current_row()[0].data, raw_content);
+  EXPECT_TRUE(parser.current_row()[0].is_quoted);
+  EXPECT_EQ(parser.current_row()[1].data, "end");
 }
 
 // Test row callback returns false mid-stream
 TEST(StreamingTest, RowCallbackStopsMidStream) {
-    std::string csv = "a\nb\nc\nd\ne\n";
+  std::string csv = "a\nb\nc\nd\ne\n";
 
-    StreamConfig config;
-    config.parse_header = false;
+  StreamConfig config;
+  config.parse_header = false;
 
-    StreamParser parser(config);
+  StreamParser parser(config);
 
-    int row_count = 0;
-    parser.set_row_handler([&row_count](const Row& row) {
-        (void)row;
-        ++row_count;
-        return row_count < 3;  // Stop after 3 rows
-    });
+  int row_count = 0;
+  parser.set_row_handler([&row_count](const Row& row) {
+    (void)row;
+    ++row_count;
+    return row_count < 3; // Stop after 3 rows
+  });
 
-    parser.parse_chunk(csv);
-    parser.finish();
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_EQ(row_count, 3);
+  EXPECT_EQ(row_count, 3);
 }
 
 // Test that errors() returns correct error collector state
 TEST(StreamingTest, ErrorCollectorStateTracking) {
-    std::string csv = "a\"b\n\"unclosed";
+  std::string csv = "a\"b\n\"unclosed";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
-    parser.parse_chunk(csv);
-    parser.finish();
+  StreamParser parser(config);
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    const auto& errors = parser.errors();
+  const auto& errors = parser.error_collector();
 
-    // Should have at least one error
-    EXPECT_TRUE(errors.has_errors());
+  // Should have at least one error
+  EXPECT_TRUE(errors.has_errors());
 
-    // Should have specific error types
-    bool found_quote_error = false;
-    for (const auto& err : errors.errors()) {
-        if (err.code == ErrorCode::QUOTE_IN_UNQUOTED_FIELD ||
-            err.code == ErrorCode::UNCLOSED_QUOTE) {
-            found_quote_error = true;
-        }
+  // Should have specific error types
+  bool found_quote_error = false;
+  for (const auto& err : errors.errors()) {
+    if (err.code == ErrorCode::QUOTE_IN_UNQUOTED_FIELD || err.code == ErrorCode::UNCLOSED_QUOTE) {
+      found_quote_error = true;
     }
-    EXPECT_TRUE(found_quote_error);
+  }
+  EXPECT_TRUE(found_quote_error);
 }
 
 // Test reset clears all state including errors
 TEST(StreamingTest, ResetClearsErrors) {
-    std::string csv = "a\"b\n";
+  std::string csv = "a\"b\n";
 
-    StreamConfig config;
-    config.parse_header = false;
-    config.error_mode = ErrorMode::PERMISSIVE;
+  StreamConfig config;
+  config.parse_header = false;
+  config.error_mode = ErrorMode::PERMISSIVE;
 
-    StreamParser parser(config);
-    parser.parse_chunk(csv);
-    parser.finish();
+  StreamParser parser(config);
+  parser.parse_chunk(csv);
+  parser.finish();
 
-    EXPECT_TRUE(parser.errors().has_errors());
+  EXPECT_TRUE(parser.error_collector().has_errors());
 
-    parser.reset();
+  parser.reset();
 
-    EXPECT_FALSE(parser.errors().has_errors());
-    EXPECT_EQ(parser.rows_processed(), 0);
-    EXPECT_EQ(parser.bytes_processed(), 0);
-    EXPECT_FALSE(parser.is_finished());
+  EXPECT_FALSE(parser.error_collector().has_errors());
+  EXPECT_EQ(parser.rows_processed(), 0);
+  EXPECT_EQ(parser.bytes_processed(), 0);
+  EXPECT_FALSE(parser.is_finished());
 }


### PR DESCRIPTION
## Summary
- Remove deprecated type aliases (`index` -> `ParseIndex`, `two_pass` -> `TwoPass`)
- Remove `LIBVROOM_DEPRECATED` and `LIBVROOM_SUPPRESS_DEPRECATION` macros
- Remove deprecated `Parser` legacy methods: `parse(buf, len, Dialect)`, `parse_with_errors()`, `parse_auto()`
- Remove deprecated `StreamParser`/`StreamReader` `errors()` methods (use `error_collector()` instead)
- Update all test files, documentation, and benchmarks to use the current API

Since libvroom is a new library with no external users, we can remove deprecated APIs entirely rather than maintaining backwards compatibility.

The TwoPass class methods are kept as they are used internally and in tests - they are just no longer marked deprecated.

## Test plan
- [x] All 1860 tests pass
- [x] Build succeeds with no deprecation warnings

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)