### PR TITLE
fix: Handle filenames with spaces in pre-commit script

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -19,7 +19,7 @@ fi
 
 # Format each file and re-stage if changed
 REFORMATTED=()
-for file in $STAGED_FILES; do
+while IFS= read -r file; do
     if [ -f "$file" ]; then
         # Get the original content
         ORIGINAL=$(cat "$file")
@@ -33,7 +33,7 @@ for file in $STAGED_FILES; do
             git add "$file"
         fi
     fi
-done
+done <<< "$STAGED_FILES"
 
 # Report what was reformatted
 if [ ${#REFORMATTED[@]} -gt 0 ]; then


### PR DESCRIPTION
## Summary
- Replace `for file in $STAGED_FILES` with `while IFS= read -r file` loop to properly handle filenames containing spaces
- The unquoted variable expansion caused word-splitting issues where filenames with spaces would be incorrectly processed as multiple files

## Test plan
- [x] Existing tests pass (no changes to C++ code)
- [x] Verified fix manually - the `while IFS= read -r` pattern correctly preserves newline-separated filenames including those with spaces

Fixes #364