### PR TITLE
fix: Handle empty input in parse_with_errors and parse_validate

### DIFF
--- a/src/two_pass.cpp
+++ b/src/two_pass.cpp
@@ -924,6 +924,10 @@ bool TwoPass::parse_with_errors(const uint8_t* buf, ParseIndex& out, size_t len,
   char delim = dialect.delimiter;
   char quote = dialect.quote_char;
 
+  // Handle empty input
+  if (len == 0)
+    return true;
+
   // Check structural issues first
   check_empty_header(buf, len, errors);
   if (errors.should_stop())
@@ -950,6 +954,10 @@ bool TwoPass::parse_validate(const uint8_t* buf, ParseIndex& out, size_t len,
                              ErrorCollector& errors, const Dialect& dialect) {
   char delim = dialect.delimiter;
   char quote = dialect.quote_char;
+
+  // Handle empty input
+  if (len == 0)
+    return true;
 
   // Check structural issues first
   check_empty_header(buf, len, errors);

--- a/test/two_pass_coverage_test.cpp
+++ b/test/two_pass_coverage_test.cpp
@@ -2307,6 +2307,94 @@ TEST_F(BranchlessMultiThreadedTest, LargeFileMultiThreaded) {
   EXPECT_TRUE(success);
 }
 
+// ============================================================================
+// EMPTY FILE HANDLING TESTS
+// Verifies that parse_with_errors and parse_validate handle empty input
+// gracefully (fixes issue #352)
+// ============================================================================
+
+class EmptyFileTest : public ::testing::Test {
+protected:
+  std::vector<uint8_t> makeBuffer(const std::string& content) {
+    std::vector<uint8_t> buf(content.size() + LIBVROOM_PADDING);
+    if (!content.empty()) {
+      std::memcpy(buf.data(), content.data(), content.size());
+    }
+    return buf;
+  }
+};
+
+// Test parse_with_errors with empty input (issue #352)
+TEST_F(EmptyFileTest, ParseWithErrorsEmptyInput) {
+  auto buf = makeBuffer("");
+
+  TwoPass parser;
+  libvroom::ParseIndex idx = parser.init(0, 1);
+  libvroom::ErrorCollector errors;
+
+  bool success = parser.parse_with_errors(buf.data(), idx, 0, errors);
+
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
+}
+
+// Test parse_validate with empty input (issue #352)
+TEST_F(EmptyFileTest, ParseValidateEmptyInput) {
+  auto buf = makeBuffer("");
+
+  TwoPass parser;
+  libvroom::ParseIndex idx = parser.init(0, 1);
+  libvroom::ErrorCollector errors;
+
+  bool success = parser.parse_validate(buf.data(), idx, 0, errors);
+
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
+}
+
+// Test parse_two_pass_with_errors with empty input (for comparison)
+TEST_F(EmptyFileTest, ParseTwoPassWithErrorsEmptyInput) {
+  auto buf = makeBuffer("");
+
+  TwoPass parser;
+  libvroom::ParseIndex idx = parser.init(0, 1);
+  libvroom::ErrorCollector errors;
+
+  bool success = parser.parse_two_pass_with_errors(buf.data(), idx, 0, errors);
+
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
+}
+
+// Test parse_branchless_with_errors with empty input
+TEST_F(EmptyFileTest, ParseBranchlessWithErrorsEmptyInput) {
+  auto buf = makeBuffer("");
+
+  TwoPass parser;
+  libvroom::ParseIndex idx = parser.init(0, 1);
+  libvroom::ErrorCollector errors;
+
+  bool success = parser.parse_branchless_with_errors(buf.data(), idx, 0, errors);
+
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
+}
+
+// Test parse_with_errors with empty input and explicit delimiter
+TEST_F(EmptyFileTest, ParseWithErrorsEmptyInputExplicitDialect) {
+  auto buf = makeBuffer("");
+
+  TwoPass parser;
+  libvroom::ParseIndex idx = parser.init(0, 1);
+  libvroom::ErrorCollector errors;
+  libvroom::Dialect dialect = libvroom::Dialect::tsv();
+
+  bool success = parser.parse_with_errors(buf.data(), idx, 0, errors, dialect);
+
+  EXPECT_TRUE(success);
+  EXPECT_FALSE(errors.has_errors());
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
## Summary

- Add early return for `len == 0` to `parse_with_errors()` and `parse_validate()` to match the behavior of `parse_two_pass_with_errors()` and `parse_branchless_with_errors()`
- Without this check, empty files could cause undefined behavior when these functions proceed to validation and parsing code that assumes non-empty input
- Add 5 new tests to verify empty file handling in all error-collecting parse functions

## Test plan

- [x] All 1864 existing tests pass
- [x] 5 new `EmptyFileTest` tests pass
- [x] CLI empty file tests pass (`CliTest.*EmptyFile`)
- [x] Manual testing with `./build/vroom head test/data/edge_cases/empty_file.csv` works correctly

Fixes #352