### PR TITLE
fix: Prevent race condition when copying test data in parallel builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,18 @@ if(BUILD_TESTING)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 
+    # =============================================================================
+    # Test data copying - single target to avoid race conditions during parallel builds
+    # All test targets depend on this target instead of each copying the data themselves.
+    # See: https://github.com/jimhester/libvroom/issues/372
+    # =============================================================================
+    add_custom_target(copy_test_data ALL
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/data
+        ${CMAKE_CURRENT_BINARY_DIR}/test/data
+        COMMENT "Copying test data to build directory"
+    )
+
 # Test executable
 add_executable(libvroom_test
     test/csv_parser_test.cpp
@@ -298,12 +310,7 @@ target_include_directories(libvroom_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory
-add_custom_command(TARGET libvroom_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(libvroom_test copy_test_data)
 
 # Error handling test executable
 add_executable(error_handling_test
@@ -320,12 +327,7 @@ target_include_directories(error_handling_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for error handling tests
-add_custom_command(TARGET error_handling_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(error_handling_test copy_test_data)
 
 # Register tests with CTest
 include(GoogleTest)
@@ -347,12 +349,7 @@ target_include_directories(csv_parsing_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for parsing tests
-add_custom_command(TARGET csv_parsing_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(csv_parsing_test copy_test_data)
 
 # Register parsing tests with CTest
 gtest_discover_tests(csv_parsing_test)
@@ -372,12 +369,7 @@ target_include_directories(csv_parser_errors_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for parser error tests
-add_custom_command(TARGET csv_parser_errors_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(csv_parser_errors_test copy_test_data)
 
 # Register parser error tests with CTest
 gtest_discover_tests(csv_parser_errors_test)
@@ -397,12 +389,7 @@ target_include_directories(csv_extended_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for extended tests
-add_custom_command(TARGET csv_extended_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(csv_extended_test copy_test_data)
 
 # Register extended tests with CTest
 gtest_discover_tests(csv_extended_test)
@@ -422,12 +409,7 @@ target_include_directories(dialect_detection_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for dialect tests
-add_custom_command(TARGET dialect_detection_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(dialect_detection_test copy_test_data)
 
 # Register dialect detection tests with CTest
 gtest_discover_tests(dialect_detection_test)
@@ -448,12 +430,7 @@ if(LIBVROOM_ENABLE_TYPE_DETECTION)
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     )
 
-    # Copy test data to build directory for type detection tests
-    add_custom_command(TARGET type_detection_test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-        ${CMAKE_CURRENT_BINARY_DIR}/test/data
-    )
+    add_dependencies(type_detection_test copy_test_data)
 
     # Register type detection tests with CTest
     gtest_discover_tests(type_detection_test)
@@ -474,12 +451,7 @@ target_include_directories(c_api_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for C API tests
-add_custom_command(TARGET c_api_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(c_api_test copy_test_data)
 
 # Register C API tests with CTest
 gtest_discover_tests(c_api_test)
@@ -517,12 +489,7 @@ target_include_directories(api_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for API tests
-add_custom_command(TARGET api_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(api_test copy_test_data)
 
 # Register API tests with CTest
 gtest_discover_tests(api_test)
@@ -559,12 +526,7 @@ target_include_directories(value_extraction_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for value extraction tests
-add_custom_command(TARGET value_extraction_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(value_extraction_test copy_test_data)
 
 # Register value extraction tests with CTest
 gtest_discover_tests(value_extraction_test)
@@ -584,12 +546,7 @@ target_include_directories(streaming_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for streaming tests
-add_custom_command(TARGET streaming_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(streaming_test copy_test_data)
 
 # Register streaming tests with CTest
 gtest_discover_tests(streaming_test)
@@ -609,12 +566,7 @@ target_include_directories(branchless_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for branchless tests
-add_custom_command(TARGET branchless_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(branchless_test copy_test_data)
 
 # Register branchless tests with CTest
 gtest_discover_tests(branchless_test)
@@ -652,12 +604,7 @@ target_include_directories(simd_number_parsing_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for SIMD number parsing tests
-add_custom_command(TARGET simd_number_parsing_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(simd_number_parsing_test copy_test_data)
 
 # Register SIMD number parsing tests with CTest
 gtest_discover_tests(simd_number_parsing_test)
@@ -677,12 +624,7 @@ target_include_directories(io_util_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for IO utility tests
-add_custom_command(TARGET io_util_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(io_util_test copy_test_data)
 
 # Register IO utility tests with CTest
 gtest_discover_tests(io_util_test)
@@ -701,15 +643,8 @@ target_include_directories(cli_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# CLI test depends on vroom executable being built
-add_dependencies(cli_test vroom-cli)
-
-# Copy test data to build directory for CLI tests
-add_custom_command(TARGET cli_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+# CLI test depends on vroom executable being built and test data
+add_dependencies(cli_test vroom-cli copy_test_data)
 
 # Register CLI tests with CTest
 gtest_discover_tests(cli_test)
@@ -729,12 +664,7 @@ target_include_directories(two_pass_coverage_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for two-pass coverage tests
-add_custom_command(TARGET two_pass_coverage_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(two_pass_coverage_test copy_test_data)
 
 # Register two-pass coverage tests with CTest
 gtest_discover_tests(two_pass_coverage_test)
@@ -754,12 +684,7 @@ target_include_directories(encoding_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for encoding tests
-add_custom_command(TARGET encoding_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(encoding_test copy_test_data)
 
 # Register encoding tests with CTest
 gtest_discover_tests(encoding_test)
@@ -784,12 +709,7 @@ if(LIBVROOM_ENABLE_TYPE_DETECTION)
     target_compile_definitions(bounds_validation_test PRIVATE LIBVROOM_ENABLE_TYPE_DETECTION)
 endif()
 
-# Copy test data to build directory for bounds validation tests
-add_custom_command(TARGET bounds_validation_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(bounds_validation_test copy_test_data)
 
 # Register bounds validation tests with CTest
 gtest_discover_tests(bounds_validation_test)
@@ -809,12 +729,7 @@ target_include_directories(integration_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for integration tests
-add_custom_command(TARGET integration_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(integration_test copy_test_data)
 
 # Register integration tests with CTest
 gtest_discover_tests(integration_test)
@@ -834,12 +749,7 @@ target_include_directories(concurrency_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-# Copy test data to build directory for concurrency tests
-add_custom_command(TARGET concurrency_test POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/data
-    ${CMAKE_CURRENT_BINARY_DIR}/test/data
-)
+add_dependencies(concurrency_test copy_test_data)
 
 # Register concurrency tests with CTest
 gtest_discover_tests(concurrency_test)
@@ -849,16 +759,14 @@ if(LIBVROOM_ENABLE_ARROW)
     add_executable(arrow_output_test test/arrow_output_test.cpp)
     target_link_libraries(arrow_output_test PRIVATE vroom GTest::gtest_main pthread)
     target_include_directories(arrow_output_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-    add_custom_command(TARGET arrow_output_test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/test/data ${CMAKE_CURRENT_BINARY_DIR}/test/data)
+    add_dependencies(arrow_output_test copy_test_data)
     gtest_discover_tests(arrow_output_test)
 
     # Arrow file-based tests (loading real CSV files)
     add_executable(arrow_file_test test/arrow_file_test.cpp)
     target_link_libraries(arrow_file_test PRIVATE vroom GTest::gtest_main pthread)
     target_include_directories(arrow_file_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-    add_custom_command(TARGET arrow_file_test POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/test/data ${CMAKE_CURRENT_BINARY_DIR}/test/data)
+    add_dependencies(arrow_file_test copy_test_data)
     gtest_discover_tests(arrow_file_test)
 endif()
 


### PR DESCRIPTION
## Summary

- Create a single `copy_test_data` custom target for copying test data to the build directory
- All 22 test executables now depend on this shared target instead of each having their own POST_BUILD copy command
- This serializes the copy operation, eliminating the race condition during parallel builds

## Root Cause

During parallel compilation (`-j` flag), multiple test targets would simultaneously reach their POST_BUILD step and try to copy the test data directory. CMake's `copy_if_different` operation isn't atomic at the directory level, causing intermittent failures like:

```
Error copying directory from "/home/runner/work/libvroom/libvroom/test/data" 
to "/home/runner/work/libvroom/libvroom/build/test/data".
```

## Solution

The fix creates a dedicated `copy_test_data` target that runs once early in the build process (`ALL` keyword). All test targets depend on this target via `add_dependencies`, ensuring:

1. The copy happens exactly once
2. The copy completes before any test executable finishes linking
3. No race conditions between parallel test builds

## Test plan

- [x] Configure and build with `cmake -B build && cmake --build build -j$(nproc)` 
- [x] Verify `copy_test_data` target runs once at start: `[  0%] Copying test data to build directory`
- [x] Run tests: `cd build && ctest --output-on-failure -j$(nproc)` - all 1860 tests pass
- [x] Clean rebuild to verify race condition is fixed

Fixes #372