### PR TITLE
docs: Update CI workflow documentation after code-quality job removal

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,12 +6,12 @@ This directory contains GitHub Actions workflows for libvroom continuous integra
 
 ### ci.yml - Main CI Pipeline
 
-Runs on every push and pull request to main/master branches and all `claude/**` branches.
+Runs on every push and pull request to main/master branches.
 
 **Build Matrix:**
 - **Platforms**: Ubuntu (latest), macOS (latest)
-- **Build Types**: Release, Debug
-- **Total Jobs**: 4 build combinations
+- **Build Types**: Release, Debug (Debug skipped on macOS)
+- **Total Jobs**: 3 build combinations
 
 **Build Steps:**
 1. Checkout code
@@ -22,10 +22,22 @@ Runs on every push and pull request to main/master branches and all `claude/**` 
 6. Run error handling tests (37 tests)
 7. Run full CTest suite (79 tests)
 
-**Code Quality Checks:**
-1. Verify required files exist
-2. Count and validate test files
-3. Ensure all 16 malformed CSV test files present
+### Additional CI Jobs
+
+**Code Coverage** (runs on every push/PR):
+- Builds with `-DENABLE_COVERAGE=ON`
+- Generates coverage with lcov
+- Uploads to Codecov
+
+**Minimal Release Build** (main branch only):
+- Builds with `-DBUILD_TESTING=OFF -DBUILD_BENCHMARKS=OFF`
+- Verifies library and CLI binary are built
+- Confirms test/benchmark executables are NOT built
+
+**Shared Library Build** (runs on every push/PR):
+- Builds with `-DBUILD_SHARED_LIBS=ON`
+- Verifies shared library (.so) is created
+- Tests vroom binary links correctly
 
 ## CI Badge
 
@@ -53,8 +65,7 @@ When adding new test files:
 
 1. Add test file to appropriate `test/data/` subdirectory
 2. Update test harness (`csv_parser_test.cpp` or `error_handling_test.cpp`)
-3. Update file count validation in `ci.yml` if needed
-4. CI will automatically run new tests on next push
+3. CI will automatically run new tests on next push
 
 ## Platform-Specific Notes
 
@@ -84,14 +95,9 @@ When adding new test files:
 2. Check if test data files are present
 3. Verify file permissions and line endings
 
-### Code Quality Failures
-1. Ensure all required files committed
-2. Check file counts match expected values
-3. Verify directory structure
-
 ## Performance Considerations
 
-- **Caching**: Could add CMake/build caching for faster builds
+- **Caching**: FetchContent dependencies are cached to speed up rebuilds
 - **Parallel builds**: CMake uses multiple cores by default
 - **Test parallelization**: CTest can run tests in parallel
 
@@ -124,10 +130,9 @@ See `fuzz/README.md` for local fuzzing instructions.
 
 Potential workflow additions:
 
-1. **Coverage reporting**: Add code coverage with lcov/gcov
-2. **Benchmarking**: Performance regression testing
-3. **Static analysis**: clang-tidy, cppcheck
-4. **Format checking**: clang-format validation
-5. **Windows builds**: MSVC support
-6. **ARM64 builds**: Native ARM testing
-7. **Release automation**: Automatic tagging and releases
+1. **Benchmarking**: Performance regression testing
+2. **Static analysis**: clang-tidy, cppcheck
+3. **Format checking**: clang-format validation
+4. **Windows builds**: MSVC support
+5. **ARM64 builds**: Native ARM testing
+6. **Release automation**: Automatic tagging and releases


### PR DESCRIPTION
## Summary
- Remove references to "Code Quality Checks" that no longer exist in ci.yml
- Update build matrix to reflect 3 jobs (Debug skipped on macOS)
- Document additional CI jobs (Code Coverage, Minimal Release Build, Shared Library Build)
- Fix several other documentation inaccuracies

## Test plan
- [x] Verified documentation changes are accurate against current ci.yml
- [x] All tests pass locally (1860 tests)

Fixes #365