### PR TITLE
docs: Improve Getting Started guide

### DIFF
--- a/docs/getting-started.qmd
+++ b/docs/getting-started.qmd
@@ -57,12 +57,17 @@ Add libvroom as a dependency in your CMakeLists.txt:
 include(FetchContent)
 FetchContent_Declare(libvroom
   GIT_REPOSITORY https://github.com/jimhester/libvroom.git
-  GIT_TAG main  # or a specific version tag
+  GIT_TAG v0.1.0  # Pin to a specific version for reproducibility
 )
 FetchContent_MakeAvailable(libvroom)
 
 target_link_libraries(your_target PRIVATE libvroom_lib)
 ```
+
+::: {.callout-tip}
+## Pin to Specific Versions
+For reproducible builds, always pin to a specific version tag (e.g., `v0.1.0`) rather than `main`. This ensures your project builds consistently even as libvroom is updated.
+:::
 
 ### Method 3: Add as Git Submodule
 
@@ -235,6 +240,7 @@ All dependencies are automatically fetched via CMake's FetchContent:
 | [Google Highway](https://github.com/google/highway) | 1.3.0 | Portable SIMD abstraction |
 | [Google Test](https://github.com/google/googletest) | 1.14.0 | Unit testing (optional) |
 | [Google Benchmark](https://github.com/google/benchmark) | 1.8.3 | Performance benchmarking (optional) |
+| [Apache Arrow](https://github.com/apache/arrow) | Latest | Arrow output integration (if `LIBVROOM_ENABLE_ARROW=ON`) |
 
 ## C++ Library Usage
 
@@ -357,7 +363,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(FetchContent)
 FetchContent_Declare(libvroom
   GIT_REPOSITORY https://github.com/jimhester/libvroom.git
-  GIT_TAG main
+  GIT_TAG v0.1.0  # Pin to a specific version for reproducibility
 )
 
 # Optionally disable tests/benchmarks to speed up build
@@ -383,13 +389,25 @@ target_link_libraries(your_target PRIVATE libvroom_lib)
 
 After linking, you can include:
 
+#### Primary Headers
+
 | Header | Description |
 |--------|-------------|
 | `<libvroom.h>` | Main header - includes everything |
-| `<libvroom_c.h>` | C API header |
+| `<libvroom_c.h>` | C API header for FFI bindings |
 | `<error.h>` | Error types and ErrorCollector |
 | `<dialect.h>` | Dialect detection and types |
 | `<streaming.h>` | Streaming parser for large files |
+| `<io_util.h>` | File loading utilities |
+
+#### Advanced/Internal Headers
+
+These headers expose lower-level functionality for advanced use cases:
+
+| Header | Description |
+|--------|-------------|
+| `<two_pass.h>` | Low-level two-pass parser implementation |
+| `<mem_util.h>` | Memory allocation utilities |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Add Apache Arrow to dependencies table (Fixes #189)
- Update FetchContent examples to pin version v0.1.0 with recommendation note for reproducibility (Fixes #191)
- Add complete header reference with primary/advanced headers including io_util.h, two_pass.h, and mem_util.h (Fixes #190)

## Test plan

- [ ] Verify the documentation renders correctly
- [ ] Check that all links work
- [ ] Confirm version pinning recommendation is clear