### PR TITLE
feat(c-api): Add error collector summary function

### DIFF
--- a/include/libvroom_c.h
+++ b/include/libvroom_c.h
@@ -110,6 +110,34 @@ size_t libvroom_error_collector_count(const libvroom_error_collector_t* collecto
 libvroom_error_t libvroom_error_collector_get(const libvroom_error_collector_t* collector,
                                               size_t index, libvroom_parse_error_t* error);
 void libvroom_error_collector_clear(libvroom_error_collector_t* collector);
+
+/**
+ * @brief Generate a human-readable summary of all collected parse errors.
+ *
+ * Creates a formatted string containing:
+ * - Total error count with breakdown by severity (warnings, errors, fatal)
+ * - Detailed listing of each error with location and message
+ *
+ * @param collector The error collector to summarize.
+ * @return Newly allocated string containing the summary. The caller is responsible
+ *         for freeing this string using free(). Returns NULL if collector is NULL
+ *         or if memory allocation fails.
+ *
+ * @example
+ * @code
+ * libvroom_error_collector_t* errors = libvroom_error_collector_create(LIBVROOM_MODE_PERMISSIVE,
+ * 100);
+ * // ... parse with errors ...
+ * char* summary = libvroom_error_collector_summary(errors);
+ * if (summary) {
+ *     printf("%s\n", summary);
+ *     free(summary);
+ * }
+ * libvroom_error_collector_destroy(errors);
+ * @endcode
+ */
+char* libvroom_error_collector_summary(const libvroom_error_collector_t* collector);
+
 void libvroom_error_collector_destroy(libvroom_error_collector_t* collector);
 
 /* Index Structure */

--- a/src/libvroom_c.cpp
+++ b/src/libvroom_c.cpp
@@ -373,6 +373,25 @@ void libvroom_error_collector_clear(libvroom_error_collector_t* collector) {
   collector->collector.clear();
 }
 
+char* libvroom_error_collector_summary(const libvroom_error_collector_t* collector) {
+  if (!collector)
+    return nullptr;
+
+  try {
+    std::string summary = collector->collector.summary();
+
+    // Allocate a copy that the caller can free()
+    char* result = static_cast<char*>(std::malloc(summary.size() + 1));
+    if (!result)
+      return nullptr;
+
+    std::memcpy(result, summary.c_str(), summary.size() + 1);
+    return result;
+  } catch (...) {
+    return nullptr;
+  }
+}
+
 void libvroom_error_collector_destroy(libvroom_error_collector_t* collector) {
   delete collector;
 }


### PR DESCRIPTION
## Summary
- Add `libvroom_error_collector_summary()` function to the C API that returns a human-readable summary of all collected parse errors
- The function wraps the existing C++ `ErrorCollector::summary()` method
- Returns a dynamically allocated string that the caller must free with `free()`

## Changes
- **include/libvroom_c.h**: Add function declaration with comprehensive documentation
- **src/libvroom_c.cpp**: Implement wrapper function with null-safety and exception handling
- **test/c_api_test.cpp**: Add 5 test cases covering:
  - Null collector input handling
  - Empty error collector (no errors)
  - Error collector with non-fatal errors
  - Error collector with fatal errors
  - Error collector with mixed severity levels

## Test plan
- [x] All 2148 existing tests pass
- [x] New C API summary function tests pass
- [x] Tests validate correct output format
- [x] Tests validate memory management (caller frees returned string)

Closes #68