### PR TITLE
fix(security): Prevent heap-buffer-overflow in error recovery parsing

### DIFF
--- a/include/libvroom.h
+++ b/include/libvroom.h
@@ -1642,9 +1642,11 @@ public:
 
     // Optimized allocation: Count separators first to allocate right-sized index.
     // This typically reduces memory usage by 2-10x for real-world CSV files.
+    // Pass n_quotes and len to handle error recovery scenarios safely.
     auto count_stats =
         TwoPass::first_pass_simd(buf, 0, len, result.dialect.quote_char, result.dialect.delimiter);
-    result.idx = parser_.init_counted_safe(count_stats.n_separators, num_threads_, collector);
+    result.idx = parser_.init_counted_safe(count_stats.n_separators, num_threads_, collector,
+                                           count_stats.n_quotes, len);
     if (result.idx.indexes == nullptr) {
       // Allocation failed or would overflow
       if (options.errors != nullptr) {

--- a/include/two_pass.h
+++ b/include/two_pass.h
@@ -795,10 +795,15 @@ public:
    * @param total_separators Total number of separators found in first pass.
    * @param n_threads Number of threads for parsing.
    * @param errors Optional error collector for overflow errors.
+   * @param n_quotes Number of quote characters found in first pass. Used to
+   *        determine if safety padding is needed for error recovery scenarios.
+   * @param len File length in bytes. Used as upper bound when n_quotes > 0
+   *        to ensure sufficient allocation for error recovery scenarios.
    * @return ParseIndex with right-sized allocation, or empty on error.
    */
   ParseIndex init_counted_safe(uint64_t total_separators, size_t n_threads,
-                               ErrorCollector* errors = nullptr);
+                               ErrorCollector* errors = nullptr, uint64_t n_quotes = 0,
+                               size_t len = 0);
 };
 
 } // namespace libvroom


### PR DESCRIPTION
## Summary
- Fix heap-buffer-overflow when parsing malformed CSV files with quote errors
- Root cause: First-pass SIMD separator count can be too low due to error recovery behavior differences

## Problem
When the first-pass SIMD counts separators, it uses quote masking where a quote toggles "inside quote" state. If there's an unpaired quote (e.g., `a"b,c,d`), all separators after it are considered "inside quotes" and not counted.

However, the second-pass state machine handles errors differently. When it detects a "quote in unquoted field" error, it reports the error but stays in `UNQUOTED_FIELD` state, causing all subsequent separators to be counted.

This mismatch means the second pass can write more separator positions than were allocated, causing heap-buffer-overflow.

## Solution
Modified `init_counted_safe()` to accept the quote count and file length from the first pass. When quotes are present, the allocation uses `max(counted_separators, file_length)` as an upper bound, ensuring sufficient space for error recovery scenarios.

## Test plan
- [x] Verified the specific failing test now passes: `SIMDErrorDetectionTest.ErrorsFromDifferentPositionsAreCaptured`
- [x] All 35 SIMD error detection tests pass with ASAN
- [x] All 2202 tests pass with ASAN (no memory errors)
- [x] All 2203 tests pass in Release build

Fixes #413