### PR TITLE
feat: Add core mmap infrastructure for index caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ set(VROOM_SOURCES
     src/dialect.cpp
     src/encoding.cpp
     src/libvroom_c.cpp
+    src/mmap_util.cpp
     src/value_extraction.cpp
     src/streaming.cpp
     src/two_pass.cpp
@@ -806,6 +807,26 @@ add_dependencies(comment_line_test copy_test_data)
 
 # Register comment line tests with CTest
 gtest_discover_tests(comment_line_test)
+
+# Memory-mapped file utilities test executable
+add_executable(mmap_util_test
+    test/mmap_util_test.cpp
+)
+
+target_link_libraries(mmap_util_test PRIVATE
+    vroom
+    GTest::gtest_main
+    pthread
+)
+
+target_include_directories(mmap_util_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+add_dependencies(mmap_util_test copy_test_data)
+
+# Register mmap utility tests with CTest
+gtest_discover_tests(mmap_util_test)
 
 # Arrow output test (only if Arrow is enabled)
 if(LIBVROOM_ENABLE_ARROW)

--- a/include/mmap_util.h
+++ b/include/mmap_util.h
@@ -1,0 +1,179 @@
+#ifndef MMAP_UTIL_H
+#define MMAP_UTIL_H
+
+/**
+ * @file mmap_util.h
+ * @brief Cross-platform memory-mapped file utilities.
+ *
+ * This header provides a portable RAII wrapper for memory-mapped files,
+ * supporting both POSIX (mmap/munmap) and Windows (CreateFileMapping/MapViewOfFile).
+ *
+ * Primary use case: Memory-mapping cached index files for direct pointer access
+ * without copying data into heap-allocated memory.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace libvroom {
+
+/**
+ * @brief RAII wrapper for cross-platform memory-mapped files.
+ *
+ * MmapBuffer provides a safe, RAII-based interface for memory-mapping files
+ * as read-only. When the buffer goes out of scope, the mapping is automatically
+ * released.
+ *
+ * Features:
+ * - Cross-platform: Works on POSIX (Linux, macOS) and Windows
+ * - Move-only: Non-copyable but moveable for efficient transfers
+ * - Safe: RAII ensures proper cleanup even on exceptions
+ * - Read-only: Files are mapped with read-only permissions
+ *
+ * @example
+ * @code
+ * MmapBuffer buf;
+ * if (buf.open("data.vidx")) {
+ *     const uint8_t* data = buf.data();
+ *     size_t size = buf.size();
+ *     // Use data...
+ * } // Automatically unmapped when buf goes out of scope
+ * @endcode
+ */
+class MmapBuffer {
+public:
+  /**
+   * @brief Default constructor. Creates an empty, invalid buffer.
+   */
+  MmapBuffer() = default;
+
+  /**
+   * @brief Destructor. Unmaps the file if mapped.
+   */
+  ~MmapBuffer() { unmap(); }
+
+  // Non-copyable
+  MmapBuffer(const MmapBuffer&) = delete;
+  MmapBuffer& operator=(const MmapBuffer&) = delete;
+
+  /**
+   * @brief Move constructor.
+   *
+   * Transfers ownership of the memory mapping from another MmapBuffer.
+   * The source buffer is left in a valid but empty state.
+   *
+   * @param other The MmapBuffer to move from.
+   */
+  MmapBuffer(MmapBuffer&& other) noexcept;
+
+  /**
+   * @brief Move assignment operator.
+   *
+   * Releases any existing mapping and takes ownership from another MmapBuffer.
+   *
+   * @param other The MmapBuffer to move from.
+   * @return Reference to this MmapBuffer.
+   */
+  MmapBuffer& operator=(MmapBuffer&& other) noexcept;
+
+  /**
+   * @brief Open and memory-map a file for reading.
+   *
+   * Maps the entire file into the process's address space with read-only
+   * permissions. The file must exist and be non-empty.
+   *
+   * If a file is already mapped, it is unmapped before opening the new file.
+   *
+   * @param path Path to the file to map.
+   * @return true if the file was successfully mapped, false otherwise.
+   *
+   * @note On failure, the buffer remains in an invalid state.
+   * @note Empty files return false (cannot be memory-mapped).
+   */
+  bool open(const std::string& path);
+
+  /**
+   * @brief Get a pointer to the mapped data.
+   *
+   * @return Pointer to the start of the mapped data, or nullptr if invalid.
+   */
+  const uint8_t* data() const { return static_cast<const uint8_t*>(data_); }
+
+  /**
+   * @brief Get the size of the mapped data in bytes.
+   *
+   * @return Size of the mapped data, or 0 if invalid.
+   */
+  size_t size() const { return size_; }
+
+  /**
+   * @brief Check if the buffer contains a valid mapping.
+   *
+   * @return true if a file is currently mapped, false otherwise.
+   */
+  bool valid() const { return data_ != nullptr; }
+
+private:
+  /**
+   * @brief Unmap the current file.
+   *
+   * Releases all resources associated with the current mapping.
+   * Safe to call even if no file is mapped.
+   */
+  void unmap();
+
+  void* data_ = nullptr;
+  size_t size_ = 0;
+
+#ifdef _WIN32
+  HANDLE file_handle_ = INVALID_HANDLE_VALUE;
+  HANDLE map_handle_ = nullptr;
+#else
+  int fd_ = -1;
+#endif
+};
+
+/**
+ * @brief Get source file metadata for cache validation.
+ *
+ * This structure holds metadata about a source CSV file that can be used
+ * to determine if a cached index is still valid.
+ */
+struct SourceMetadata {
+  uint64_t mtime = 0; ///< Modification time (seconds since epoch)
+  uint64_t size = 0;  ///< File size in bytes
+  bool valid = false; ///< True if metadata was successfully retrieved
+
+  /**
+   * @brief Retrieve metadata from a file.
+   *
+   * @param path Path to the file.
+   * @return SourceMetadata with valid=true if successful, valid=false otherwise.
+   */
+  static SourceMetadata from_file(const std::string& path);
+};
+
+/**
+ * @brief Generate cache file path for a source file.
+ *
+ * @param source_path Path to the source CSV file.
+ * @return Cache file path (source_path + ".vidx").
+ */
+std::string get_cache_path(const std::string& source_path);
+
+} // namespace libvroom
+
+#endif // MMAP_UTIL_H

--- a/src/mmap_util.cpp
+++ b/src/mmap_util.cpp
@@ -1,0 +1,190 @@
+/**
+ * @file mmap_util.cpp
+ * @brief Implementation of cross-platform memory-mapped file utilities.
+ */
+
+#include "mmap_util.h"
+
+namespace libvroom {
+
+MmapBuffer::MmapBuffer(MmapBuffer&& other) noexcept
+    : data_(other.data_), size_(other.size_)
+#ifdef _WIN32
+      ,
+      file_handle_(other.file_handle_), map_handle_(other.map_handle_)
+#else
+      ,
+      fd_(other.fd_)
+#endif
+{
+  other.data_ = nullptr;
+  other.size_ = 0;
+#ifdef _WIN32
+  other.file_handle_ = INVALID_HANDLE_VALUE;
+  other.map_handle_ = nullptr;
+#else
+  other.fd_ = -1;
+#endif
+}
+
+MmapBuffer& MmapBuffer::operator=(MmapBuffer&& other) noexcept {
+  if (this != &other) {
+    unmap();
+    data_ = other.data_;
+    size_ = other.size_;
+#ifdef _WIN32
+    file_handle_ = other.file_handle_;
+    map_handle_ = other.map_handle_;
+    other.file_handle_ = INVALID_HANDLE_VALUE;
+    other.map_handle_ = nullptr;
+#else
+    fd_ = other.fd_;
+    other.fd_ = -1;
+#endif
+    other.data_ = nullptr;
+    other.size_ = 0;
+  }
+  return *this;
+}
+
+bool MmapBuffer::open(const std::string& path) {
+  unmap();
+
+#ifdef _WIN32
+  file_handle_ = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+                             FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (file_handle_ == INVALID_HANDLE_VALUE) {
+    return false;
+  }
+
+  LARGE_INTEGER file_size;
+  if (!GetFileSizeEx(file_handle_, &file_size)) {
+    CloseHandle(file_handle_);
+    file_handle_ = INVALID_HANDLE_VALUE;
+    return false;
+  }
+  size_ = static_cast<size_t>(file_size.QuadPart);
+
+  // Cannot mmap empty files
+  if (size_ == 0) {
+    CloseHandle(file_handle_);
+    file_handle_ = INVALID_HANDLE_VALUE;
+    return false;
+  }
+
+  map_handle_ = CreateFileMappingA(file_handle_, nullptr, PAGE_READONLY, 0, 0, nullptr);
+  if (!map_handle_) {
+    CloseHandle(file_handle_);
+    file_handle_ = INVALID_HANDLE_VALUE;
+    return false;
+  }
+
+  data_ = MapViewOfFile(map_handle_, FILE_MAP_READ, 0, 0, 0);
+  if (!data_) {
+    CloseHandle(map_handle_);
+    CloseHandle(file_handle_);
+    map_handle_ = nullptr;
+    file_handle_ = INVALID_HANDLE_VALUE;
+    return false;
+  }
+#else
+  fd_ = ::open(path.c_str(), O_RDONLY);
+  if (fd_ < 0) {
+    return false;
+  }
+
+  struct stat st;
+  if (fstat(fd_, &st) != 0) {
+    ::close(fd_);
+    fd_ = -1;
+    return false;
+  }
+
+  // Cannot mmap empty files
+  if (st.st_size == 0) {
+    ::close(fd_);
+    fd_ = -1;
+    return false;
+  }
+
+  size_ = static_cast<size_t>(st.st_size);
+
+  data_ = mmap(nullptr, size_, PROT_READ, MAP_PRIVATE, fd_, 0);
+  if (data_ == MAP_FAILED) {
+    data_ = nullptr;
+    ::close(fd_);
+    fd_ = -1;
+    return false;
+  }
+#endif
+  return true;
+}
+
+void MmapBuffer::unmap() {
+#ifdef _WIN32
+  if (data_) {
+    UnmapViewOfFile(data_);
+  }
+  if (map_handle_) {
+    CloseHandle(map_handle_);
+  }
+  if (file_handle_ != INVALID_HANDLE_VALUE) {
+    CloseHandle(file_handle_);
+  }
+  file_handle_ = INVALID_HANDLE_VALUE;
+  map_handle_ = nullptr;
+#else
+  if (data_) {
+    munmap(data_, size_);
+  }
+  if (fd_ >= 0) {
+    ::close(fd_);
+  }
+  fd_ = -1;
+#endif
+  data_ = nullptr;
+  size_ = 0;
+}
+
+SourceMetadata SourceMetadata::from_file(const std::string& path) {
+  SourceMetadata meta;
+
+#ifdef _WIN32
+  WIN32_FILE_ATTRIBUTE_DATA attr;
+  if (GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &attr)) {
+    // Check if it's a regular file (not a directory)
+    if (!(attr.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      // Convert FILETIME to seconds since epoch
+      // FILETIME is 100-nanosecond intervals since January 1, 1601
+      ULARGE_INTEGER ull;
+      ull.LowPart = attr.ftLastWriteTime.dwLowDateTime;
+      ull.HighPart = attr.ftLastWriteTime.dwHighDateTime;
+      // Convert to Unix epoch (seconds since 1970-01-01)
+      // 11644473600 seconds between 1601-01-01 and 1970-01-01
+      meta.mtime = (ull.QuadPart / 10000000ULL) - 11644473600ULL;
+
+      ULARGE_INTEGER size;
+      size.LowPart = attr.nFileSizeLow;
+      size.HighPart = attr.nFileSizeHigh;
+      meta.size = size.QuadPart;
+
+      meta.valid = true;
+    }
+  }
+#else
+  struct stat st;
+  if (stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode)) {
+    meta.mtime = static_cast<uint64_t>(st.st_mtime);
+    meta.size = static_cast<uint64_t>(st.st_size);
+    meta.valid = true;
+  }
+#endif
+
+  return meta;
+}
+
+std::string get_cache_path(const std::string& source_path) {
+  return source_path + ".vidx";
+}
+
+} // namespace libvroom

--- a/src/two_pass.cpp
+++ b/src/two_pass.cpp
@@ -21,7 +21,21 @@ namespace libvroom {
 // Version 1 (legacy): columns (uint64_t), n_threads (uint8_t), n_indexes,
 // indexes Version 2: version (uint8_t=2), columns (uint64_t), n_threads
 // (uint16_t), n_indexes, indexes
+// Version 3: version (uint8_t=3), source_mtime (uint64_t), source_size (uint64_t),
+// columns (uint64_t), n_threads (uint16_t), n_indexes[], indexes[]
 static constexpr uint8_t INDEX_FORMAT_VERSION = 2;
+static constexpr uint8_t INDEX_FORMAT_VERSION_V3 = 3;
+
+// V3 header layout (32 bytes, 8-byte aligned for direct mmap pointer access):
+// - version:    1 byte
+// - padding:    7 bytes (alignment padding)
+// - mtime:      8 bytes (uint64_t)
+// - size:       8 bytes (uint64_t)
+// - columns:    8 bytes (uint64_t)
+// - n_threads:  2 bytes (uint16_t)
+// - padding2:   6 bytes (alignment padding to ensure arrays are 8-byte aligned)
+// Total: 40 bytes
+static constexpr size_t INDEX_V3_HEADER_SIZE = 40;
 
 void ParseIndex::write(const std::string& filename) {
   std::FILE* fp = std::fopen(filename.c_str(), "wb");
@@ -109,6 +123,168 @@ void ParseIndex::read(const std::string& filename) {
   }
 
   std::fclose(fp);
+}
+
+void ParseIndex::write(const std::string& filename, const SourceMetadata& source_meta) {
+  // Write to temp file, then atomic rename for crash safety
+  std::string temp_path = filename + ".tmp";
+
+  std::FILE* fp = std::fopen(temp_path.c_str(), "wb");
+  if (!fp) {
+    throw std::runtime_error("error opening file for writing: " + filename);
+  }
+
+  bool success = true;
+
+  // Write v3 header with alignment padding (40 bytes total)
+  // Layout: version(1) + padding(7) + mtime(8) + size(8) + columns(8) + n_threads(2) + padding(6)
+  uint8_t version = INDEX_FORMAT_VERSION_V3;
+  uint8_t padding[7] = {0};
+  uint8_t padding2[6] = {0};
+
+  success = success && (std::fwrite(&version, sizeof(uint8_t), 1, fp) == 1);
+  success = success && (std::fwrite(padding, 1, 7, fp) == 7); // Align mtime to 8 bytes
+  success = success && (std::fwrite(&source_meta.mtime, sizeof(uint64_t), 1, fp) == 1);
+  success = success && (std::fwrite(&source_meta.size, sizeof(uint64_t), 1, fp) == 1);
+  success = success && (std::fwrite(&columns, sizeof(uint64_t), 1, fp) == 1);
+  success = success && (std::fwrite(&n_threads, sizeof(uint16_t), 1, fp) == 1);
+  success = success && (std::fwrite(padding2, 1, 6, fp) == 6); // Align n_indexes array to 8 bytes
+
+  // Write n_indexes array
+  success = success && (std::fwrite(n_indexes, sizeof(uint64_t), n_threads, fp) == n_threads);
+
+  // Write indexes array
+  size_t total_indexes = 0;
+  for (uint16_t i = 0; i < n_threads; ++i) {
+    total_indexes += n_indexes[i];
+  }
+  success = success && (std::fwrite(indexes, sizeof(uint64_t), total_indexes, fp) == total_indexes);
+
+  std::fclose(fp);
+
+  if (!success) {
+    std::remove(temp_path.c_str());
+    throw std::runtime_error("error writing index v3");
+  }
+
+  // Atomic rename
+  if (std::rename(temp_path.c_str(), filename.c_str()) != 0) {
+    std::remove(temp_path.c_str());
+    throw std::runtime_error("error renaming temp file to: " + filename);
+  }
+}
+
+ParseIndex ParseIndex::from_mmap(const std::string& cache_path, const SourceMetadata& source_meta) {
+  ParseIndex result;
+
+  // Allocate MmapBuffer
+  auto mmap = std::make_unique<MmapBuffer>();
+  if (!mmap->open(cache_path)) {
+    return result; // Return empty, invalid index
+  }
+
+  const uint8_t* data = mmap->data();
+  size_t file_size = mmap->size();
+
+  // Validate minimum size for header
+  if (file_size < INDEX_V3_HEADER_SIZE) {
+    return result;
+  }
+
+  size_t offset = 0;
+
+  // Read and validate version
+  uint8_t version = data[offset];
+  offset += 1;
+  if (version != INDEX_FORMAT_VERSION_V3) {
+    return result; // Not a v3 format file
+  }
+
+  // Skip padding (7 bytes to align mtime to 8-byte boundary)
+  offset += 7;
+
+  // Read source file metadata (now 8-byte aligned)
+  uint64_t cached_mtime;
+  std::memcpy(&cached_mtime, data + offset, sizeof(uint64_t));
+  offset += sizeof(uint64_t);
+
+  uint64_t cached_size;
+  std::memcpy(&cached_size, data + offset, sizeof(uint64_t));
+  offset += sizeof(uint64_t);
+
+  // Validate source file hasn't changed
+  if (cached_mtime != source_meta.mtime || cached_size != source_meta.size) {
+    return result; // Source file changed, cache is stale
+  }
+
+  // Read columns (8-byte aligned)
+  std::memcpy(&result.columns, data + offset, sizeof(uint64_t));
+  offset += sizeof(uint64_t);
+
+  // Read n_threads
+  std::memcpy(&result.n_threads, data + offset, sizeof(uint16_t));
+  offset += sizeof(uint16_t);
+
+  // Skip padding2 (6 bytes to align n_indexes array to 8-byte boundary)
+  offset += 6;
+
+  // Validate we have enough data for n_indexes array
+  size_t n_indexes_size = static_cast<size_t>(result.n_threads) * sizeof(uint64_t);
+  if (offset + n_indexes_size > file_size) {
+    result.n_threads = 0;
+    return result;
+  }
+
+  // Set n_indexes to point directly into mmap'd data
+  // const_cast is safe because we're only reading, and ParseIndex needs non-const
+  result.n_indexes = const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(data + offset));
+  offset += n_indexes_size;
+
+  // Calculate total indexes and validate with overflow checks
+  // Remaining bytes after n_indexes array
+  size_t remaining_bytes = file_size - offset;
+  size_t max_possible_indexes = remaining_bytes / sizeof(uint64_t);
+
+  size_t total_indexes = 0;
+  for (uint16_t i = 0; i < result.n_threads; ++i) {
+    uint64_t n_idx = result.n_indexes[i];
+    // Validate each value is within bounds (prevents overflow and ensures sanity)
+    if (n_idx > max_possible_indexes) {
+      result.n_indexes = nullptr;
+      result.n_threads = 0;
+      return result;
+    }
+    // Check for overflow before adding
+    if (total_indexes > SIZE_MAX - static_cast<size_t>(n_idx)) {
+      result.n_indexes = nullptr;
+      result.n_threads = 0;
+      return result;
+    }
+    total_indexes += static_cast<size_t>(n_idx);
+  }
+
+  // Check for multiplication overflow before computing indexes_size
+  if (total_indexes > SIZE_MAX / sizeof(uint64_t)) {
+    result.n_indexes = nullptr;
+    result.n_threads = 0;
+    return result;
+  }
+  size_t indexes_size = total_indexes * sizeof(uint64_t);
+
+  // Final bounds check (using subtraction to avoid overflow in comparison)
+  if (indexes_size > remaining_bytes) {
+    result.n_indexes = nullptr;
+    result.n_threads = 0;
+    return result;
+  }
+
+  // Set indexes to point directly into mmap'd data
+  result.indexes = const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(data + offset));
+
+  // Transfer mmap ownership to the ParseIndex
+  result.mmap_buffer_ = std::move(mmap);
+
+  return result;
 }
 
 //-----------------------------------------------------------------------------

--- a/test/mmap_util_test.cpp
+++ b/test/mmap_util_test.cpp
@@ -1,0 +1,399 @@
+/**
+ * @file mmap_util_test.cpp
+ * @brief Unit tests for mmap utility functions and index caching.
+ */
+
+#include "libvroom.h"
+
+#include "mmap_util.h"
+#include "two_pass.h"
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <thread>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+// Test fixture for mmap utility tests
+class MmapUtilTest : public ::testing::Test {
+protected:
+  std::string temp_dir;
+  std::vector<std::string> temp_files;
+
+  void SetUp() override {
+    // Create temp directory for test files
+    temp_dir = (fs::temp_directory_path() / ("mmap_test_" + std::to_string(getpid()))).string();
+    fs::create_directories(temp_dir);
+  }
+
+  void TearDown() override {
+    // Clean up temp files
+    for (const auto& file : temp_files) {
+      fs::remove(file);
+    }
+    // Remove temp directory if empty
+    if (fs::exists(temp_dir)) {
+      fs::remove_all(temp_dir);
+    }
+  }
+
+  std::string createTempFile(const std::string& filename, const std::string& content) {
+    std::string path = temp_dir + "/" + filename;
+    std::ofstream file(path, std::ios::binary);
+    file.write(content.data(), content.size());
+    file.close();
+    temp_files.push_back(path);
+    return path;
+  }
+
+  std::string createTempFile(const std::string& filename, const uint8_t* data, size_t size) {
+    std::string path = temp_dir + "/" + filename;
+    std::ofstream file(path, std::ios::binary);
+    file.write(reinterpret_cast<const char*>(data), size);
+    file.close();
+    temp_files.push_back(path);
+    return path;
+  }
+};
+
+// =============================================================================
+// MmapBuffer TESTS
+// =============================================================================
+
+TEST_F(MmapUtilTest, MmapBuffer_DefaultConstructor) {
+  libvroom::MmapBuffer buf;
+  EXPECT_FALSE(buf.valid());
+  EXPECT_EQ(buf.data(), nullptr);
+  EXPECT_EQ(buf.size(), 0);
+}
+
+TEST_F(MmapUtilTest, MmapBuffer_OpenNonExistentFile) {
+  libvroom::MmapBuffer buf;
+  bool result = buf.open("/nonexistent/path/file.txt");
+  EXPECT_FALSE(result);
+  EXPECT_FALSE(buf.valid());
+}
+
+TEST_F(MmapUtilTest, MmapBuffer_OpenEmptyFile) {
+  std::string path = createTempFile("empty.txt", "");
+  libvroom::MmapBuffer buf;
+  bool result = buf.open(path);
+  EXPECT_FALSE(result); // Cannot mmap empty files
+  EXPECT_FALSE(buf.valid());
+}
+
+TEST_F(MmapUtilTest, MmapBuffer_OpenValidFile) {
+  std::string content = "Hello, World!";
+  std::string path = createTempFile("test.txt", content);
+
+  libvroom::MmapBuffer buf;
+  bool result = buf.open(path);
+
+  EXPECT_TRUE(result);
+  EXPECT_TRUE(buf.valid());
+  EXPECT_EQ(buf.size(), content.size());
+  EXPECT_EQ(std::memcmp(buf.data(), content.data(), content.size()), 0);
+}
+
+TEST_F(MmapUtilTest, MmapBuffer_MoveConstructor) {
+  std::string content = "Test content for move";
+  std::string path = createTempFile("move_test.txt", content);
+
+  libvroom::MmapBuffer buf1;
+  ASSERT_TRUE(buf1.open(path));
+
+  const uint8_t* original_data = buf1.data();
+  size_t original_size = buf1.size();
+
+  libvroom::MmapBuffer buf2(std::move(buf1));
+
+  // buf2 should have the data
+  EXPECT_TRUE(buf2.valid());
+  EXPECT_EQ(buf2.data(), original_data);
+  EXPECT_EQ(buf2.size(), original_size);
+
+  // buf1 should be empty
+  EXPECT_FALSE(buf1.valid());
+  EXPECT_EQ(buf1.data(), nullptr);
+  EXPECT_EQ(buf1.size(), 0);
+}
+
+TEST_F(MmapUtilTest, MmapBuffer_MoveAssignment) {
+  std::string content1 = "Content for buffer 1";
+  std::string content2 = "Content for buffer 2";
+  std::string path1 = createTempFile("move_assign1.txt", content1);
+  std::string path2 = createTempFile("move_assign2.txt", content2);
+
+  libvroom::MmapBuffer buf1;
+  libvroom::MmapBuffer buf2;
+  ASSERT_TRUE(buf1.open(path1));
+  ASSERT_TRUE(buf2.open(path2));
+
+  const uint8_t* data2 = buf2.data();
+  size_t size2 = buf2.size();
+
+  buf1 = std::move(buf2);
+
+  // buf1 should have buf2's data
+  EXPECT_TRUE(buf1.valid());
+  EXPECT_EQ(buf1.data(), data2);
+  EXPECT_EQ(buf1.size(), size2);
+
+  // buf2 should be empty
+  EXPECT_FALSE(buf2.valid());
+}
+
+TEST_F(MmapUtilTest, MmapBuffer_Reopen) {
+  std::string content1 = "First file content";
+  std::string content2 = "Second file content";
+  std::string path1 = createTempFile("reopen1.txt", content1);
+  std::string path2 = createTempFile("reopen2.txt", content2);
+
+  libvroom::MmapBuffer buf;
+  ASSERT_TRUE(buf.open(path1));
+  EXPECT_EQ(buf.size(), content1.size());
+
+  // Opening another file should unmap the first
+  ASSERT_TRUE(buf.open(path2));
+  EXPECT_EQ(buf.size(), content2.size());
+  EXPECT_EQ(std::memcmp(buf.data(), content2.data(), content2.size()), 0);
+}
+
+// =============================================================================
+// SourceMetadata TESTS
+// =============================================================================
+
+TEST_F(MmapUtilTest, SourceMetadata_NonExistentFile) {
+  auto meta = libvroom::SourceMetadata::from_file("/nonexistent/file.csv");
+  EXPECT_FALSE(meta.valid);
+}
+
+TEST_F(MmapUtilTest, SourceMetadata_ValidFile) {
+  std::string content = "a,b,c\n1,2,3\n";
+  std::string path = createTempFile("meta_test.csv", content);
+
+  auto meta = libvroom::SourceMetadata::from_file(path);
+
+  EXPECT_TRUE(meta.valid);
+  EXPECT_EQ(meta.size, content.size());
+  EXPECT_GT(meta.mtime, 0);
+}
+
+TEST_F(MmapUtilTest, SourceMetadata_Directory) {
+  auto meta = libvroom::SourceMetadata::from_file(temp_dir);
+  EXPECT_FALSE(meta.valid); // Directories should not be valid
+}
+
+// =============================================================================
+// get_cache_path TESTS
+// =============================================================================
+
+TEST_F(MmapUtilTest, GetCachePath) {
+  EXPECT_EQ(libvroom::get_cache_path("/path/to/file.csv"), "/path/to/file.csv.vidx");
+  EXPECT_EQ(libvroom::get_cache_path("data.csv"), "data.csv.vidx");
+  EXPECT_EQ(libvroom::get_cache_path(""), ".vidx");
+}
+
+// =============================================================================
+// ParseIndex v3 format TESTS
+// =============================================================================
+
+TEST_F(MmapUtilTest, ParseIndex_WriteV3AndFromMmap) {
+  // Create a simple CSV and parse it
+  std::string csv_content = "a,b,c\n1,2,3\n4,5,6\n";
+  std::string csv_path = createTempFile("test.csv", csv_content);
+  std::string cache_path = csv_path + ".vidx";
+  temp_files.push_back(cache_path);
+
+  // Parse the CSV
+  libvroom::Parser parser(1);
+  auto load_result = libvroom::load_file(csv_path);
+  auto parse_result = parser.parse(load_result.data(), load_result.size());
+
+  // Get source metadata
+  auto source_meta = libvroom::SourceMetadata::from_file(csv_path);
+  ASSERT_TRUE(source_meta.valid);
+
+  // Write v3 format
+  EXPECT_NO_THROW(parse_result.idx.write(cache_path, source_meta));
+
+  // Load via mmap
+  auto loaded_idx = libvroom::ParseIndex::from_mmap(cache_path, source_meta);
+
+  EXPECT_TRUE(loaded_idx.is_valid());
+  EXPECT_TRUE(loaded_idx.is_mmap_backed());
+  EXPECT_EQ(loaded_idx.columns, parse_result.idx.columns);
+  EXPECT_EQ(loaded_idx.n_threads, parse_result.idx.n_threads);
+
+  // Compare n_indexes
+  for (uint16_t i = 0; i < loaded_idx.n_threads; ++i) {
+    EXPECT_EQ(loaded_idx.n_indexes[i], parse_result.idx.n_indexes[i]);
+  }
+
+  // Compare indexes
+  size_t total_indexes = 0;
+  for (uint16_t i = 0; i < loaded_idx.n_threads; ++i) {
+    total_indexes += loaded_idx.n_indexes[i];
+  }
+  for (size_t i = 0; i < total_indexes; ++i) {
+    EXPECT_EQ(loaded_idx.indexes[i], parse_result.idx.indexes[i]);
+  }
+}
+
+TEST_F(MmapUtilTest, ParseIndex_FromMmapInvalidVersion) {
+  std::string csv_path = createTempFile("test_invalid.csv", "a,b\n1,2\n");
+  std::string cache_path = csv_path + ".vidx";
+  temp_files.push_back(cache_path);
+
+  // Write a file with wrong version
+  uint8_t data[] = {99}; // Invalid version
+  createTempFile("test_invalid.csv.vidx", data, sizeof(data));
+
+  auto source_meta = libvroom::SourceMetadata::from_file(csv_path);
+  auto loaded_idx = libvroom::ParseIndex::from_mmap(cache_path, source_meta);
+
+  EXPECT_FALSE(loaded_idx.is_valid());
+}
+
+TEST_F(MmapUtilTest, ParseIndex_FromMmapStaleCache) {
+  // Create a simple CSV and parse it
+  std::string csv_content = "a,b,c\n1,2,3\n";
+  std::string csv_path = createTempFile("stale_test.csv", csv_content);
+  std::string cache_path = csv_path + ".vidx";
+  temp_files.push_back(cache_path);
+
+  // Parse and write cache
+  libvroom::Parser parser(1);
+  auto load_result = libvroom::load_file(csv_path);
+  auto parse_result = parser.parse(load_result.data(), load_result.size());
+  auto source_meta = libvroom::SourceMetadata::from_file(csv_path);
+  parse_result.idx.write(cache_path, source_meta);
+
+  // Modify the source file (change mtime and size)
+  std::this_thread::sleep_for(std::chrono::milliseconds(1100)); // Ensure mtime changes
+  std::ofstream file(csv_path, std::ios::binary);
+  file << "a,b,c,d\n1,2,3,4\n5,6,7,8\n"; // Different content
+  file.close();
+
+  // Try to load with new metadata - should fail due to mtime/size mismatch
+  auto new_meta = libvroom::SourceMetadata::from_file(csv_path);
+  auto loaded_idx = libvroom::ParseIndex::from_mmap(cache_path, new_meta);
+
+  EXPECT_FALSE(loaded_idx.is_valid());
+}
+
+TEST_F(MmapUtilTest, ParseIndex_FromMmapTruncatedFile) {
+  std::string csv_path = createTempFile("truncated.csv", "a,b\n1,2\n");
+  std::string cache_path = csv_path + ".vidx";
+  temp_files.push_back(cache_path);
+
+  // Write a truncated cache file (just the version byte)
+  uint8_t data[] = {3}; // v3 version, but no data
+  createTempFile("truncated.csv.vidx", data, sizeof(data));
+
+  auto source_meta = libvroom::SourceMetadata::from_file(csv_path);
+  auto loaded_idx = libvroom::ParseIndex::from_mmap(cache_path, source_meta);
+
+  EXPECT_FALSE(loaded_idx.is_valid());
+}
+
+TEST_F(MmapUtilTest, ParseIndex_FromMmapNonExistent) {
+  std::string csv_path = createTempFile("noexist.csv", "a,b\n1,2\n");
+  std::string cache_path = csv_path + ".vidx"; // Don't create this file
+
+  auto source_meta = libvroom::SourceMetadata::from_file(csv_path);
+  auto loaded_idx = libvroom::ParseIndex::from_mmap(cache_path, source_meta);
+
+  EXPECT_FALSE(loaded_idx.is_valid());
+}
+
+TEST_F(MmapUtilTest, ParseIndex_MovePreservesMmap) {
+  // Create and cache a CSV
+  std::string csv_content = "x,y\n10,20\n30,40\n";
+  std::string csv_path = createTempFile("move_mmap.csv", csv_content);
+  std::string cache_path = csv_path + ".vidx";
+  temp_files.push_back(cache_path);
+
+  libvroom::Parser parser(1);
+  auto load_result = libvroom::load_file(csv_path);
+  auto parse_result = parser.parse(load_result.data(), load_result.size());
+  auto source_meta = libvroom::SourceMetadata::from_file(csv_path);
+  parse_result.idx.write(cache_path, source_meta);
+
+  // Load via mmap
+  auto idx1 = libvroom::ParseIndex::from_mmap(cache_path, source_meta);
+  ASSERT_TRUE(idx1.is_valid());
+  ASSERT_TRUE(idx1.is_mmap_backed());
+
+  // Move to another index
+  libvroom::ParseIndex idx2 = std::move(idx1);
+
+  // idx2 should have the data
+  EXPECT_TRUE(idx2.is_valid());
+  EXPECT_TRUE(idx2.is_mmap_backed());
+
+  // idx1 should be invalid
+  EXPECT_FALSE(idx1.is_valid());
+  EXPECT_FALSE(idx1.is_mmap_backed());
+}
+
+TEST_F(MmapUtilTest, ParseIndex_V2FormatStillWorks) {
+  // Ensure existing v2 format write/read still works
+  std::string csv_content = "col1,col2\nval1,val2\n";
+  std::string csv_path = createTempFile("v2_test.csv", csv_content);
+  std::string idx_path = csv_path + ".idx";
+  temp_files.push_back(idx_path);
+
+  libvroom::Parser parser(1);
+  auto load_result = libvroom::load_file(csv_path);
+  auto parse_result = parser.parse(load_result.data(), load_result.size());
+
+  // Write v2 format
+  EXPECT_NO_THROW(parse_result.idx.write(idx_path));
+
+  // Read v2 format into a new index
+  libvroom::TwoPass tp;
+  auto new_idx = tp.init(load_result.size(), 1);
+  EXPECT_NO_THROW(new_idx.read(idx_path));
+
+  EXPECT_EQ(new_idx.columns, parse_result.idx.columns);
+  EXPECT_EQ(new_idx.n_threads, parse_result.idx.n_threads);
+}
+
+// =============================================================================
+// Multi-threaded index tests
+// =============================================================================
+
+TEST_F(MmapUtilTest, ParseIndex_MultiThreadedWriteAndLoad) {
+  // Create a larger CSV that will use multiple threads
+  std::string csv_content = "a,b,c,d,e\n";
+  for (int i = 0; i < 1000; ++i) {
+    csv_content += std::to_string(i) + "," + std::to_string(i * 2) + "," + std::to_string(i * 3) +
+                   "," + std::to_string(i * 4) + "," + std::to_string(i * 5) + "\n";
+  }
+  std::string csv_path = createTempFile("multithread.csv", csv_content);
+  std::string cache_path = csv_path + ".vidx";
+  temp_files.push_back(cache_path);
+
+  // Parse with multiple threads
+  libvroom::Parser parser(4);
+  auto load_result = libvroom::load_file(csv_path);
+  auto parse_result = parser.parse(load_result.data(), load_result.size());
+
+  auto source_meta = libvroom::SourceMetadata::from_file(csv_path);
+  ASSERT_TRUE(source_meta.valid);
+
+  // Write v3 format
+  parse_result.idx.write(cache_path, source_meta);
+
+  // Load via mmap
+  auto loaded_idx = libvroom::ParseIndex::from_mmap(cache_path, source_meta);
+
+  EXPECT_TRUE(loaded_idx.is_valid());
+  EXPECT_EQ(loaded_idx.columns, parse_result.idx.columns);
+  // n_threads might be different if single-threaded fallback was used
+  // but the data should be equivalent
+}


### PR DESCRIPTION
## Summary

- Add cross-platform memory-mapped file utilities for direct pointer access to cached index files
- Extend `ParseIndex` to support mmap-backed data with zero-copy loading
- Implement v3 index format with source file metadata for cache invalidation

## Changes

### New Files
- `include/mmap_util.h`: `MmapBuffer` RAII wrapper, `SourceMetadata` struct, `get_cache_path()` helper
- `src/mmap_util.cpp`: Cross-platform implementation (POSIX mmap + Windows CreateFileMapping)
- `test/mmap_util_test.cpp`: Comprehensive tests for MmapBuffer, SourceMetadata, and v3 index format

### Modified Files
- `include/two_pass.h`: Added mmap ownership to ParseIndex
- `src/two_pass.cpp`: Implemented v3 format write/read and `from_mmap()` factory
- `CMakeLists.txt`: Added new source and test files

### Key Features

**MmapBuffer class:**
- RAII wrapper for cross-platform mmap
- Non-copyable, moveable
- Automatic cleanup on destruction

**ParseIndex extensions:**
- `static ParseIndex from_mmap(cache_path, source_meta)` - load cached index
- `write(filename, source_meta)` - write v3 format with metadata
- `is_valid()` - check if index has data
- `is_mmap_backed()` - check if backed by mmap

**Index format v3:**
```
version: uint8_t (3)
source_mtime: uint64_t
source_size: uint64_t
columns: uint64_t
n_threads: uint16_t
n_indexes[]: uint64_t * n_threads
indexes[]: uint64_t * sum(n_indexes)
```

## Test plan

- [x] All existing tests pass (2163 tests)
- [x] New mmap utility tests cover:
  - MmapBuffer default constructor, open, move semantics, reopen
  - SourceMetadata for valid/invalid files
  - get_cache_path helper
  - ParseIndex v3 write and load via mmap
  - Cache invalidation when source file changes
  - Multi-threaded index write/load
  - Backwards compatibility with v2 format

Closes #418