### PR TITLE
fix(cli): Address code review feedback from stats command PR #423

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1669,16 +1669,18 @@ int cmdStats(const char* filename, int n_threads, bool has_header, const libvroo
         cout << "      \"hist\": null";
       }
 
-      // String statistics (for all columns with non-empty values)
-      if (s.has_string && s.min_str_length != SIZE_MAX) {
+      // String statistics (for all columns)
+      // Note: has_string implies min_str_length != SIZE_MAX because both are set
+      // together in add_string_value(). We use has_string as the primary check.
+      if (s.has_string) {
         cout << ",\n";
         cout << "      \"n_unique\": " << s.unique_values.size() << ",\n";
         cout << "      \"min_length\": " << s.min_str_length << ",\n";
         cout << "      \"max_length\": " << s.max_str_length << "\n";
       } else {
-        // No non-empty string values, or defensive check failed
+        // No non-empty string values
         cout << ",\n";
-        cout << "      \"n_unique\": " << s.unique_values.size() << ",\n";
+        cout << "      \"n_unique\": 0,\n";
         cout << "      \"min_length\": null,\n";
         cout << "      \"max_length\": null\n";
       }
@@ -1721,15 +1723,14 @@ int cmdStats(const char* filename, int n_threads, bool has_header, const libvroo
       }
 
       // String statistics for non-numeric columns or columns with string values
-      if (s.has_string && !s.has_numeric && s.min_str_length != SIZE_MAX) {
+      // Note: has_string is only true if add_string_value was called, which requires
+      // non-empty fields. So if has_string is true, min_str_length is always valid.
+      if (s.has_string && !s.has_numeric) {
         cout << "  Unique values: " << s.unique_values.size() << "\n";
         cout << "  Min length:    " << s.min_str_length << "\n";
         cout << "  Max length:    " << s.max_str_length << "\n";
       } else if (s.has_string && s.has_numeric) {
         // For numeric columns, still show unique count
-        cout << "  Unique values: " << s.unique_values.size() << "\n";
-      } else if (s.has_string && !s.has_numeric) {
-        // Only empty strings were present
         cout << "  Unique values: " << s.unique_values.size() << "\n";
       }
       cout << "\n";

--- a/test/cli_test.cpp
+++ b/test/cli_test.cpp
@@ -2528,3 +2528,25 @@ TEST_F(CliTest, StatsStdDevAccuracy) {
   // Should contain sd field with a value (not null)
   EXPECT_TRUE(result.output.find("\"sd\": 3.") != std::string::npos);
 }
+
+TEST_F(CliTest, StatsAllEmptyColumn) {
+  // Test that columns with only empty values are handled correctly
+  // The JSON output should have null for min_length/max_length and 0 for n_unique
+  auto result = CliRunner::run("stats -j " + testDataPath("edge_cases/all_empty_column.csv"));
+  EXPECT_EQ(result.exit_code, 0);
+  // Check the JSON is valid (not corrupted by SIZE_MAX values)
+  // Look for the empty_col column which should have null for string lengths
+  EXPECT_TRUE(result.output.find("\"min_length\": null") != std::string::npos);
+  EXPECT_TRUE(result.output.find("\"max_length\": null") != std::string::npos);
+  EXPECT_TRUE(result.output.find("\"n_unique\": 0") != std::string::npos);
+}
+
+TEST_F(CliTest, StatsAllEmptyColumnHumanReadable) {
+  // Test that human-readable output handles all-empty columns gracefully
+  auto result = CliRunner::run("stats " + testDataPath("edge_cases/all_empty_column.csv"));
+  EXPECT_EQ(result.exit_code, 0);
+  // The empty column should not crash or show SIZE_MAX values
+  // Should show the column exists with proper null count
+  EXPECT_TRUE(result.output.find("empty_col") != std::string::npos);
+  EXPECT_TRUE(result.output.find("Nulls") != std::string::npos);
+}

--- a/test/data/edge_cases/all_empty_column.csv
+++ b/test/data/edge_cases/all_empty_column.csv
@@ -1,0 +1,4 @@
+name,empty_col,value
+alice,,1
+bob,,2
+carol,,3


### PR DESCRIPTION
## Summary
- Remove unreachable dead code branch in human-readable stats output
- Simplify JSON output logic by using has_string as the primary check
- Add tests for columns with only empty values

## Background
This addresses the code review feedback from PR #423 (feat(cli): Extend stats command with comprehensive statistics):

1. **Dead code removal**: The branch at line 1731-1733 was unreachable because `has_string` is only set to `true` when `add_string_value()` is called, which only happens for non-empty fields. Therefore, if `has_string` is true, `min_str_length` is always valid (< SIZE_MAX).

2. **JSON output simplification**: The defensive check `s.min_str_length != SIZE_MAX` is redundant when `has_string` is true, since both are always set together in `add_string_value()`.

3. **Clearer n_unique output**: Changed to output `n_unique: 0` explicitly for columns with no string values instead of `s.unique_values.size()` (which would be 0 anyway), making the intent clearer.

## Test plan
- [x] Added new test `StatsAllEmptyColumn` to verify JSON output for all-empty columns
- [x] Added new test `StatsAllEmptyColumnHumanReadable` to verify human-readable output
- [x] All 2255 existing tests pass
- [x] Verified output manually with test file `all_empty_column.csv`

Ref: https://github.com/jimhester/libvroom/pull/423#issuecomment-3728742638