### PR TITLE
fix(python): Make type inference respect skip_rows/n_rows and handle boolean-integer mix

### DIFF
--- a/include/libvroom_types.h
+++ b/include/libvroom_types.h
@@ -115,12 +115,13 @@ struct ColumnTypeStats {
 
     // Check if integers dominate (integers can include booleans like 0/1)
     // But only if booleans don't already dominate
-    if (static_cast<double>(integer_count) / non_empty >= threshold)
+    // Include boolean count since 0/1 are valid integers
+    if (static_cast<double>(integer_count + boolean_count) / non_empty >= threshold)
       return FieldType::INTEGER;
 
     // Check if floats dominate (floats include integers which are valid floats)
-    // Use cumulative count: floats + integers (not booleans, as "true" is not a float)
-    if (static_cast<double>(float_count + integer_count) / non_empty >= threshold)
+    // Use cumulative count: floats + integers + booleans (0/1 are valid floats)
+    if (static_cast<double>(float_count + integer_count + boolean_count) / non_empty >= threshold)
       return FieldType::FLOAT;
 
     // Check if dates dominate

--- a/python/tests/test_arrow.py
+++ b/python/tests/test_arrow.py
@@ -683,8 +683,9 @@ class TestSkipRowsNRowsWithPyArrow:
         arrow_table = pa.table(table)
 
         assert arrow_table.num_rows == 7
+        # With auto-inference, numeric columns are detected as int64
         ids = arrow_table.column("id").to_pylist()
-        assert ids == ["3", "4", "5", "6", "7", "8", "9"]
+        assert ids == [3, 4, 5, 6, 7, 8, 9]
 
     def test_n_rows_arrow_table(self, larger_csv_for_arrow):
         """Test n_rows works correctly when converting to PyArrow."""
@@ -696,8 +697,9 @@ class TestSkipRowsNRowsWithPyArrow:
         arrow_table = pa.table(table)
 
         assert arrow_table.num_rows == 3
+        # With auto-inference, numeric columns are detected as int64
         ids = arrow_table.column("id").to_pylist()
-        assert ids == ["0", "1", "2"]
+        assert ids == [0, 1, 2]
 
     def test_skip_rows_and_n_rows_combined_arrow(self, larger_csv_for_arrow):
         """Test skip_rows and n_rows combined with PyArrow."""
@@ -709,10 +711,11 @@ class TestSkipRowsNRowsWithPyArrow:
         arrow_table = pa.table(table)
 
         assert arrow_table.num_rows == 4
+        # With auto-inference, numeric columns are detected as int64
         ids = arrow_table.column("id").to_pylist()
-        assert ids == ["2", "3", "4", "5"]
+        assert ids == [2, 3, 4, 5]
         values = arrow_table.column("value").to_pylist()
-        assert values == ["20", "30", "40", "50"]
+        assert values == [20, 30, 40, 50]
 
     def test_skip_rows_with_dtype_arrow(self, larger_csv_for_arrow):
         """Test skip_rows works with dtype parameter for Arrow."""
@@ -763,8 +766,9 @@ class TestSkipRowsNRowsWithPolars:
         df = pl.from_arrow(table)
 
         assert df.shape[0] == 7
+        # With auto-inference, numeric columns are detected as int64
         ids = df["id"].to_list()
-        assert ids == ["3", "4", "5", "6", "7", "8", "9"]
+        assert ids == [3, 4, 5, 6, 7, 8, 9]
 
     def test_n_rows_polars_dataframe(self, larger_csv_for_arrow):
         """Test n_rows works correctly when converting to Polars."""
@@ -776,8 +780,9 @@ class TestSkipRowsNRowsWithPolars:
         df = pl.from_arrow(table)
 
         assert df.shape[0] == 3
+        # With auto-inference, numeric columns are detected as int64
         ids = df["id"].to_list()
-        assert ids == ["0", "1", "2"]
+        assert ids == [0, 1, 2]
 
     def test_skip_rows_and_n_rows_combined_polars(self, larger_csv_for_arrow):
         """Test skip_rows and n_rows combined with Polars."""
@@ -789,5 +794,6 @@ class TestSkipRowsNRowsWithPolars:
         df = pl.from_arrow(table)
 
         assert df.shape[0] == 4
+        # With auto-inference, numeric columns are detected as int64
         ids = df["id"].to_list()
-        assert ids == ["2", "3", "4", "5"]
+        assert ids == [2, 3, 4, 5]


### PR DESCRIPTION
## Summary

Fixes two bugs discovered after #485 was merged:

1. **Type inference didn't respect skip_rows/n_rows**: The type inference was sampling from all rows in the CSV, not just the rows that would be returned after applying `skip_rows` and `n_rows`. This caused type inference to potentially infer wrong types when using these parameters.

2. **Boolean+integer mix fell back to string**: When a column contained values like 0, 1, 2, 3... the TypeDetector detected 0 and 1 as BOOLEAN and 2+ as INTEGER. This mix didn't meet the 90% threshold for either type, causing the column to fall back to STRING. Fixed by including boolean count in the integer dominance check since 0/1 are valid integers.

## Test plan

- [x] All 91 tests pass locally (7 skipped due to missing polars)
- [x] Existing test `test_skip_rows_arrow_table` now correctly gets int64 type
- [x] Existing test `test_n_rows_arrow_table` now correctly gets int64 type
- [x] Existing test `test_skip_rows_and_n_rows_combined_arrow` now correctly gets int64 type

## Changes

- `python/src/bindings.cpp`: Use `effective_num_rows()` and `translate_row_index()` in type inference loop
- `include/libvroom_types.h`: Include boolean count in integer and float dominance checks
- `python/tests/test_arrow.py`: Update test expectations for integer types