### PR TITLE
feat: Add progress callback support during parsing

### DIFF
--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -1851,3 +1851,257 @@ TEST_F(UnifiedErrorHandlingTest, ParseMalformedAndIterate) {
   }
   EXPECT_TRUE(found_error);
 }
+
+// ============================================================================
+// Tests for Progress Callback API
+// ============================================================================
+
+class ProgressCallbackTest : public ::testing::Test {
+protected:
+  static std::pair<uint8_t*, size_t> make_buffer(const std::string& content) {
+    size_t len = content.size();
+    uint8_t* buf = allocate_padded_buffer(len, 64);
+    std::memcpy(buf, content.data(), len);
+    return {buf, len};
+  }
+};
+
+// Test: Progress callback is called during parsing
+TEST_F(ProgressCallbackTest, CallbackIsCalled) {
+  auto [data, len] = make_buffer("a,b,c\n1,2,3\n4,5,6\n7,8,9\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  int call_count = 0;
+  size_t last_processed = 0;
+  size_t reported_total = 0;
+
+  libvroom::ParseOptions opts;
+  opts.progress_callback = [&](size_t processed, size_t total) {
+    ++call_count;
+    last_processed = processed;
+    reported_total = total;
+    return true; // continue parsing
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(call_count, 0);       // Callback was called at least once
+  EXPECT_EQ(reported_total, len); // Total matches buffer size
+  EXPECT_EQ(last_processed, len); // Final call reports 100%
+}
+
+// Test: Progress callback receives correct total size
+TEST_F(ProgressCallbackTest, CorrectTotalSize) {
+  std::string csv = "name,age\n";
+  for (int i = 0; i < 100; ++i) {
+    csv += "Person" + std::to_string(i) + "," + std::to_string(20 + i) + "\n";
+  }
+
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  size_t reported_total = 0;
+
+  libvroom::ParseOptions opts;
+  opts.progress_callback = [&](size_t, size_t total) {
+    reported_total = total;
+    return true;
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_EQ(reported_total, len);
+}
+
+// Test: Progress callback can cancel parsing
+TEST_F(ProgressCallbackTest, CancellationSupport) {
+  auto [data, len] = make_buffer("a,b,c\n1,2,3\n4,5,6\n7,8,9\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  int call_count = 0;
+
+  libvroom::ParseOptions opts;
+  opts.progress_callback = [&](size_t, size_t) {
+    ++call_count;
+    return false; // Cancel after first callback
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_FALSE(result.success()); // Parsing was cancelled
+  EXPECT_EQ(call_count, 1);       // Callback was called once before cancellation
+}
+
+// Test: Progress callback works with different dialects
+TEST_F(ProgressCallbackTest, WorksWithDifferentDialects) {
+  auto [data, len] = make_buffer("a;b;c\n1;2;3\n4;5;6\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  bool callback_called = false;
+
+  libvroom::ParseOptions opts;
+  opts.dialect = libvroom::Dialect::semicolon();
+  opts.progress_callback = [&](size_t, size_t) {
+    callback_called = true;
+    return true;
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_TRUE(callback_called);
+}
+
+// Test: Progress callback works with auto-detection
+TEST_F(ProgressCallbackTest, WorksWithAutoDetection) {
+  auto [data, len] = make_buffer("name;age;city\nJohn;25;NYC\nJane;30;LA\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  bool callback_called = false;
+
+  libvroom::ParseOptions opts;
+  // No dialect set - auto-detection will be used
+  opts.progress_callback = [&](size_t, size_t) {
+    callback_called = true;
+    return true;
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_TRUE(callback_called);
+  EXPECT_EQ(result.dialect.delimiter, ';'); // Should auto-detect semicolon
+}
+
+// Test: Progress callback works with error collection
+TEST_F(ProgressCallbackTest, WorksWithErrorCollection) {
+  // CSV with inconsistent field count
+  auto [data, len] = make_buffer("a,b,c\n1,2,3\n4,5\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  bool callback_called = false;
+  libvroom::ErrorCollector errors(libvroom::ErrorMode::PERMISSIVE);
+
+  libvroom::ParseOptions opts;
+  opts.errors = &errors;
+  opts.progress_callback = [&](size_t, size_t) {
+    callback_called = true;
+    return true;
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_TRUE(callback_called);
+  EXPECT_TRUE(errors.has_errors());
+}
+
+// Test: Progress callback with null callback is ignored
+TEST_F(ProgressCallbackTest, NullCallbackIsIgnored) {
+  auto [data, len] = make_buffer("a,b,c\n1,2,3\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  libvroom::ParseOptions opts;
+  opts.progress_callback = nullptr;
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+}
+
+// Test: ParseOptions::with_progress() factory
+TEST_F(ProgressCallbackTest, WithProgressFactory) {
+  auto [data, len] = make_buffer("a,b,c\n1,2,3\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  bool callback_called = false;
+
+  auto result = parser.parse(buffer.data(), buffer.size(),
+                             libvroom::ParseOptions::with_progress([&](size_t, size_t) {
+                               callback_called = true;
+                               return true;
+                             }));
+
+  EXPECT_TRUE(result.success());
+  EXPECT_TRUE(callback_called);
+}
+
+// Test: Progress reports monotonically increasing values
+TEST_F(ProgressCallbackTest, MonotonicallyIncreasing) {
+  std::string csv = "name,age\n";
+  for (int i = 0; i < 50; ++i) {
+    csv += "Person" + std::to_string(i) + "," + std::to_string(20 + i) + "\n";
+  }
+
+  auto [data, len] = make_buffer(csv);
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser;
+
+  std::vector<size_t> progress_values;
+
+  libvroom::ParseOptions opts;
+  opts.progress_callback = [&](size_t processed, size_t) {
+    progress_values.push_back(processed);
+    return true;
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(progress_values.size(), 0);
+
+  // Values should be monotonically non-decreasing
+  for (size_t i = 1; i < progress_values.size(); ++i) {
+    EXPECT_GE(progress_values[i], progress_values[i - 1]);
+  }
+}
+
+// Test: Progress callback with single-threaded parser
+TEST_F(ProgressCallbackTest, SingleThreaded) {
+  auto [data, len] = make_buffer("a,b,c\n1,2,3\n4,5,6\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser(1); // Single thread
+
+  int call_count = 0;
+
+  libvroom::ParseOptions opts;
+  opts.progress_callback = [&](size_t, size_t) {
+    ++call_count;
+    return true;
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(call_count, 0);
+}
+
+// Test: Progress callback with multi-threaded parser
+TEST_F(ProgressCallbackTest, MultiThreaded) {
+  auto [data, len] = make_buffer("a,b,c\n1,2,3\n4,5,6\n7,8,9\n");
+  libvroom::FileBuffer buffer(data, len);
+  libvroom::Parser parser(4); // Multiple threads
+
+  int call_count = 0;
+
+  libvroom::ParseOptions opts;
+  opts.progress_callback = [&](size_t, size_t) {
+    ++call_count;
+    return true;
+  };
+
+  auto result = parser.parse(buffer.data(), buffer.size(), opts);
+
+  EXPECT_TRUE(result.success());
+  EXPECT_GT(call_count, 0);
+}


### PR DESCRIPTION
## Summary

Implements progress callback support for CSV parsing operations to enable:
- **Progress bars and UI updates** for long-running parse operations
- **Cancellation support** by returning `false` from the callback

This addresses issue #445.

## Changes

### C++ API (`include/libvroom.h`)
- Add `ProgressCallback` type: `std::function<bool(size_t bytes_processed, size_t total_bytes)>`
- Add `progress_callback` field to `ParseOptions`
- Add `ParseOptions::with_progress()` factory method
- Callback invoked at: start (0%), after first pass (~25%), and completion (100%)

### C API (`include/libvroom_c.h`)
- Add `libvroom_progress_callback_t` typedef
- Add `libvroom_parse_with_progress()` function
- Add `LIBVROOM_ERROR_CANCELLED` error code (104)

### CLI (`src/cli.cpp`)
- Add `ProgressBar` class for TTY-based progress display: `[========>           ] 25%`
- Add `-p/--progress` and `--no-progress` flags
- Auto-enable progress for TTY stderr when parsing files (not stdin)
- Progress shown for `head`, `sample`, `select`, `info`, `pretty` commands

### Tests
- Add 11 new tests in `ProgressCallbackTest` suite covering:
  - Basic callback invocation and correct total size reporting
  - Cancellation support (return false to abort)
  - Compatibility with different dialects and auto-detection
  - Error collection compatibility
  - Factory method usage
  - Monotonically increasing progress values
  - Single and multi-threaded parsing

## Test Plan

- [x] All 2401 existing tests pass
- [x] 11 new progress callback tests pass
- [x] Manual testing with CLI progress bar on large files
- [x] Build succeeds with no warnings

## Example Usage

### C++ API
```cpp
auto progress = [](size_t processed, size_t total) {
    int percent = total > 0 ? (processed * 100 / total) : 0;
    std::cerr << "\rProgress: " << percent << "%" << std::flush;
    return true;  // continue parsing
};

ParseOptions opts;
opts.progress_callback = progress;
auto result = parser.parse(buf, len, opts);
```

### CLI
```bash
# Progress auto-enabled when stderr is TTY
vroom head large_file.csv

# Explicitly enable/disable
vroom --progress head large_file.csv
vroom --no-progress head large_file.csv
```

Closes #445