### PR TITLE
feat(python): Add progress callback support to read_csv

### DIFF
--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -19,9 +19,11 @@
 #include <climits>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <set>
@@ -1014,6 +1016,9 @@ Dialect detect_dialect(const std::string& path) {
 // read_csv function with full options
 // =============================================================================
 
+// Type alias for Python progress callback: (bytes_read: int, total_bytes: int) -> None
+using PyProgressCallback = std::function<void(size_t, size_t)>;
+
 Table read_csv(const std::string& path, std::optional<std::string> delimiter = std::nullopt,
                std::optional<std::string> quote_char = std::nullopt, bool has_header = true,
                std::optional<std::string> encoding = std::nullopt, size_t skip_rows = 0,
@@ -1022,7 +1027,7 @@ Table read_csv(const std::string& path, std::optional<std::string> delimiter = s
                std::optional<std::vector<std::string>> null_values = std::nullopt,
                bool empty_is_null = true,
                std::optional<std::unordered_map<std::string, std::string>> dtype = std::nullopt,
-               size_t num_threads = 1) {
+               size_t num_threads = 1, std::optional<PyProgressCallback> progress = std::nullopt) {
   auto data = std::make_shared<TableData>();
 
   // Configure null value handling
@@ -1065,6 +1070,31 @@ Table read_csv(const std::string& path, std::optional<std::string> delimiter = s
   // If any dialect option was specified, ensure we use explicit dialect
   if (delimiter || quote_char) {
     options.dialect = dialect;
+  }
+
+  // Set up progress callback if provided
+  // The Python callback has signature (bytes_read: int, total_bytes: int) -> None
+  // The C++ callback expects (bytes_processed: size_t, total_bytes: size_t) -> bool
+  // We wrap the Python callback to handle:
+  // 1. GIL acquisition for thread safety
+  // 2. Python exception handling
+  // 3. Return value (Python returns None, C++ expects bool for cancellation)
+  if (progress) {
+    options.progress_callback = [py_callback = *progress](size_t bytes_processed,
+                                                          size_t total_bytes) -> bool {
+      // Acquire GIL before calling Python code
+      py::gil_scoped_acquire acquire;
+      try {
+        py_callback(bytes_processed, total_bytes);
+        return true; // Continue parsing
+      } catch (py::error_already_set& e) {
+        // Re-throw Python exceptions to be handled by pybind11
+        throw;
+      } catch (...) {
+        // For any other exception, abort parsing
+        return false;
+      }
+    };
   }
 
   // Parse
@@ -1345,6 +1375,7 @@ Examples
         py::arg("encoding") = py::none(), py::arg("skip_rows") = 0, py::arg("n_rows") = py::none(),
         py::arg("usecols") = py::none(), py::arg("null_values") = py::none(),
         py::arg("empty_is_null") = true, py::arg("dtype") = py::none(), py::arg("num_threads") = 1,
+        py::arg("progress") = py::none(),
         R"doc(
 Read a CSV file and return a Table object.
 
@@ -1390,6 +1421,11 @@ dtype : dict[str, str], optional
     Values that cannot be converted to the specified type become null.
 num_threads : int, default 1
     Number of threads to use for parsing.
+progress : callable, optional
+    A callback function for progress reporting during parsing.
+    The callback receives two arguments: (bytes_read: int, total_bytes: int).
+    It is called periodically during parsing at chunk boundaries (typically
+    every 1-4MB). Use this to display progress bars or update UIs.
 
 Returns
 -------
@@ -1440,6 +1476,13 @@ Examples
 
 >>> # Treat empty strings as null (default behavior)
 >>> table = vroom_csv.read_csv("data.csv", empty_is_null=True)
+
+>>> # With progress callback
+>>> def show_progress(bytes_read, total_bytes):
+...     pct = bytes_read / total_bytes * 100 if total_bytes > 0 else 0
+...     print(f"\r{pct:.1f}%", end="", flush=True)
+>>> table = vroom_csv.read_csv("huge.csv", progress=show_progress)
+>>> print()  # newline after progress
 
 >>> # Convert to Polars
 >>> import polars as pl

--- a/python/src/vroom_csv/_core.pyi
+++ b/python/src/vroom_csv/_core.pyi
@@ -1,5 +1,6 @@
 """Type stubs for vroom_csv._core module."""
 
+from collections.abc import Callable
 from typing import Any, Sequence, overload
 
 __version__: str
@@ -178,6 +179,7 @@ def read_csv(
     empty_is_null: bool = True,
     dtype: dict[str, str] | None = None,
     num_threads: int = 1,
+    progress: Callable[[int, int], None] | None = None,
 ) -> Table:
     """Read a CSV file and return a Table object.
 
@@ -197,24 +199,24 @@ def read_csv(
         Currently accepted but not fully implemented.
     skip_rows : int, default 0
         Number of rows to skip at the start of the file.
-        Currently accepted but not fully implemented.
     n_rows : int, optional
         Maximum number of rows to read. If not specified, reads all rows.
-        Currently accepted but not fully implemented.
     usecols : sequence of str or int, optional
         List of column names or indices to read. If not specified, reads
         all columns.
     null_values : sequence of str, optional
         List of strings to treat as null/NA values.
-        Currently accepted but not fully implemented.
     empty_is_null : bool, default True
         Whether to treat empty strings as null values.
-        Currently accepted but not fully implemented.
     dtype : dict, optional
         Dictionary mapping column names to data types.
-        Currently accepted but not fully implemented.
     num_threads : int, default 1
         Number of threads to use for parsing.
+    progress : callable, optional
+        A callback function for progress reporting during parsing.
+        The callback receives two arguments: (bytes_read: int, total_bytes: int).
+        It is called periodically during parsing at chunk boundaries (typically
+        every 1-4MB). Use this to display progress bars or update UIs.
 
     Returns
     -------


### PR DESCRIPTION
## Summary

- Add a `progress` parameter to `read_csv()` that accepts a callable for tracking parsing progress
- The callback receives `(bytes_read: int, total_bytes: int)` and is called periodically during parsing
- Wrap Python callbacks with GIL acquisition for thread safety

## Example

```python
def show_progress(bytes_read, total_bytes):
    pct = bytes_read / total_bytes * 100 if total_bytes > 0 else 0
    print(f"\r{pct:.1f}%", end="", flush=True)

table = vroom_csv.read_csv("huge.csv", progress=show_progress)
```

## Implementation Details

- Uses `pybind11/functional.h` to wrap Python callables as C++ `std::function`
- Acquires GIL before calling Python callback from C++ (thread safety)
- Properly propagates Python exceptions thrown in callbacks
- Works with both single-threaded and multi-threaded parsing

## Test plan

- [x] Test that callback is invoked during parsing
- [x] Test that total_bytes matches actual file size
- [x] Test that progress reaches 100% at the end
- [x] Test monotonically increasing bytes_read values
- [x] Test with None (no callback)
- [x] Test with multi-threaded parsing
- [x] Test Python exception handling in callbacks
- [x] Test with larger files
- [x] Test that callback doesn't affect parsed data integrity
- [x] All existing Python tests continue to pass
- [x] All C++ tests continue to pass

Closes #495