### PR TITLE
feat(python): Add read_csv_batched() for memory-efficient processing

### DIFF
--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -13,6 +13,7 @@
 #include "dialect.h"
 #include "error.h"
 #include "extraction_config.h"
+#include "streaming.h"
 #include "value_extraction.h"
 
 #include <algorithm>
@@ -984,6 +985,418 @@ private:
 };
 
 // =============================================================================
+// BatchedReader class - iterator for memory-efficient batch processing
+// =============================================================================
+
+// Holds data for a single batch
+struct BatchData {
+  std::vector<std::string> column_names;
+  std::vector<std::vector<std::string>> columns_data;
+  std::vector<ColumnType> column_types;
+  NullValueConfig null_config;
+
+  size_t num_rows() const { return columns_data.empty() ? 0 : columns_data[0].size(); }
+
+  size_t num_columns() const { return column_names.size(); }
+
+  ColumnType get_column_type(size_t col) const {
+    if (col < column_types.size()) {
+      return column_types[col];
+    }
+    return ColumnType::STRING;
+  }
+};
+
+// Build schema for batch (struct with column types)
+static void build_batch_schema(ArrowSchema* schema, const std::vector<std::string>& column_names,
+                               const std::vector<ColumnType>& column_types) {
+  // Reuse the existing struct schema builder
+  build_struct_schema(schema, column_names, column_types);
+}
+
+// Build Arrow array for batch
+static void build_batch_array(ArrowArray* array, std::shared_ptr<BatchData> batch_data) {
+  size_t n_cols = batch_data->columns_data.size();
+  size_t n_rows = batch_data->num_rows();
+
+  array->length = static_cast<int64_t>(n_rows);
+  array->null_count = 0;
+  array->offset = 0;
+  array->n_buffers = 1; // Just validity bitmap for struct
+  array->n_children = static_cast<int64_t>(n_cols);
+  array->buffers = new const void*[1];
+  array->buffers[0] = nullptr; // validity bitmap (all valid)
+  array->children = new ArrowArray*[n_cols];
+  array->dictionary = nullptr;
+  array->release = release_array;
+  array->private_data = nullptr;
+
+  for (size_t i = 0; i < n_cols; ++i) {
+    array->children[i] = new ArrowArray();
+    ColumnType type = batch_data->get_column_type(i);
+    build_column_array(array->children[i], batch_data->columns_data[i], type,
+                       batch_data->null_config);
+  }
+}
+
+// Stream private data for batch
+struct BatchStreamPrivateData {
+  std::shared_ptr<BatchData> batch_data;
+  bool schema_exported = false;
+  bool data_exported = false;
+  std::string last_error;
+};
+
+// Batch stream callbacks
+static int batch_stream_get_schema(ArrowArrayStream* stream, ArrowSchema* out) {
+  auto* priv = static_cast<BatchStreamPrivateData*>(stream->private_data);
+  if (!priv || !priv->batch_data) {
+    return -1;
+  }
+
+  build_batch_schema(out, priv->batch_data->column_names, priv->batch_data->column_types);
+  priv->schema_exported = true;
+  return 0;
+}
+
+static int batch_stream_get_next(ArrowArrayStream* stream, ArrowArray* out) {
+  auto* priv = static_cast<BatchStreamPrivateData*>(stream->private_data);
+  if (!priv || !priv->batch_data) {
+    return -1;
+  }
+
+  if (priv->data_exported) {
+    // No more batches - signal end of stream
+    out->release = nullptr;
+    return 0;
+  }
+
+  build_batch_array(out, priv->batch_data);
+  priv->data_exported = true;
+  return 0;
+}
+
+static const char* batch_stream_get_last_error(ArrowArrayStream* stream) {
+  auto* priv = static_cast<BatchStreamPrivateData*>(stream->private_data);
+  if (!priv) {
+    return "Invalid stream";
+  }
+  return priv->last_error.empty() ? nullptr : priv->last_error.c_str();
+}
+
+static void release_batch_stream(ArrowArrayStream* stream) {
+  if (stream->release == nullptr)
+    return;
+  if (stream->private_data) {
+    auto* data = static_cast<BatchStreamPrivateData*>(stream->private_data);
+    delete data;
+  }
+  stream->release = nullptr;
+}
+
+// RecordBatch class - represents a single batch from the iterator
+class RecordBatch {
+public:
+  RecordBatch(std::shared_ptr<BatchData> data) : data_(std::move(data)) {}
+
+  // Number of rows in this batch
+  size_t num_rows() const { return data_->num_rows(); }
+
+  // Number of columns
+  size_t num_columns() const { return data_->num_columns(); }
+
+  // Column names
+  std::vector<std::string> column_names() const { return data_->column_names; }
+
+  // Get a single column as list of strings
+  std::vector<std::string> column(size_t index) const {
+    if (index >= data_->columns_data.size()) {
+      throw py::index_error("Column index out of range");
+    }
+    return data_->columns_data[index];
+  }
+
+  // Get a column by name
+  std::vector<std::string> column_by_name(const std::string& name) const {
+    auto it = std::find(data_->column_names.begin(), data_->column_names.end(), name);
+    if (it == data_->column_names.end()) {
+      throw py::key_error("Column not found: " + name);
+    }
+    size_t idx = static_cast<size_t>(std::distance(data_->column_names.begin(), it));
+    return column(idx);
+  }
+
+  // Get a single row as list of strings
+  std::vector<std::string> row(size_t index) const {
+    if (index >= data_->num_rows()) {
+      throw py::index_error("Row index out of range");
+    }
+    std::vector<std::string> result;
+    result.reserve(data_->columns_data.size());
+    for (const auto& col : data_->columns_data) {
+      result.push_back(col[index]);
+    }
+    return result;
+  }
+
+  // Arrow PyCapsule interface: __arrow_c_schema__
+  py::object arrow_c_schema() const {
+    auto* schema = new ArrowSchema();
+    build_batch_schema(schema, data_->column_names, data_->column_types);
+
+    return py::capsule(schema, "arrow_schema", [](void* ptr) {
+      auto* s = static_cast<ArrowSchema*>(ptr);
+      if (s->release) {
+        s->release(s);
+      }
+      delete s;
+    });
+  }
+
+  // Arrow PyCapsule interface: __arrow_c_stream__
+  py::object arrow_c_stream(py::object requested_schema = py::none()) const {
+    (void)requested_schema;
+
+    auto* stream = new ArrowArrayStream();
+    auto* priv = new BatchStreamPrivateData();
+    priv->batch_data = data_;
+    priv->schema_exported = false;
+    priv->data_exported = false;
+
+    stream->get_schema = batch_stream_get_schema;
+    stream->get_next = batch_stream_get_next;
+    stream->get_last_error = batch_stream_get_last_error;
+    stream->release = release_batch_stream;
+    stream->private_data = priv;
+
+    return py::capsule(stream, "arrow_array_stream", [](void* ptr) {
+      auto* s = static_cast<ArrowArrayStream*>(ptr);
+      if (s->release) {
+        s->release(s);
+      }
+      delete s;
+    });
+  }
+
+  // String representation
+  std::string repr() const {
+    std::ostringstream ss;
+    ss << "RecordBatch(" << num_rows() << " rows, " << num_columns() << " columns)";
+    return ss.str();
+  }
+
+private:
+  std::shared_ptr<BatchData> data_;
+};
+
+// BatchedReader class - Python iterator over CSV batches
+class BatchedReader {
+public:
+  BatchedReader(const std::string& path, size_t batch_size,
+                std::optional<std::string> delimiter = std::nullopt,
+                std::optional<std::string> quote_char = std::nullopt, bool has_header = true,
+                std::optional<std::vector<std::string>> null_values = std::nullopt,
+                bool empty_is_null = true,
+                std::optional<std::unordered_map<std::string, std::string>> dtype = std::nullopt)
+      : path_(path), batch_size_(batch_size), has_header_(has_header), exhausted_(false) {
+    // Configure null value handling
+    if (null_values) {
+      null_config_.null_values = *null_values;
+    }
+    null_config_.empty_is_null = empty_is_null;
+
+    // Store dtype overrides for later
+    if (dtype) {
+      dtype_overrides_ = *dtype;
+    }
+
+    // Configure stream options
+    libvroom::StreamConfig config;
+    config.parse_header = has_header;
+
+    if (delimiter) {
+      if (delimiter->length() != 1) {
+        throw py::value_error("Delimiter must be a single character");
+      }
+      config.dialect.delimiter = (*delimiter)[0];
+    }
+
+    if (quote_char) {
+      if (quote_char->length() != 1) {
+        throw py::value_error("quote_char must be a single character");
+      }
+      config.dialect.quote_char = (*quote_char)[0];
+    }
+
+    // Create the stream reader
+    try {
+      reader_ = std::make_unique<libvroom::StreamReader>(path, config);
+    } catch (const std::runtime_error& e) {
+      throw py::value_error(std::string("Failed to open file: ") + e.what());
+    }
+
+    // Note: column names will be populated on first batch read
+    // The header is parsed lazily when the first row is read
+  }
+
+  // Return self for iterator protocol
+  BatchedReader& iter() { return *this; }
+
+  // Get next batch - returns RecordBatch or raises StopIteration
+  RecordBatch next() {
+    if (exhausted_) {
+      throw py::stop_iteration();
+    }
+
+    auto batch_data = std::make_shared<BatchData>();
+    batch_data->null_config = null_config_;
+
+    // Read rows into the batch
+    size_t rows_read = 0;
+    bool first_row_of_batch = true;
+    size_t n_cols = 0;
+
+    while (rows_read < batch_size_ && reader_->next_row()) {
+      const auto& row = reader_->row();
+
+      // On first row of first batch, get column names from header or generate them
+      if (first_row_of_batch && column_names_.empty()) {
+        // Try to get column names from the reader's header (if parse_header was enabled)
+        const auto& header = reader_->header();
+        if (!header.empty()) {
+          column_names_ = header;
+        } else {
+          // No header - generate column names from the first row's field count
+          size_t field_count = row.field_count();
+          column_names_.reserve(field_count);
+          for (size_t i = 0; i < field_count; ++i) {
+            column_names_.push_back("column_" + std::to_string(i));
+          }
+        }
+      }
+
+      // On first row of any batch, initialize column vectors
+      if (first_row_of_batch) {
+        n_cols = column_names_.size();
+        batch_data->columns_data.resize(n_cols);
+        for (auto& col : batch_data->columns_data) {
+          col.reserve(batch_size_);
+        }
+        first_row_of_batch = false;
+      }
+
+      // Extract field values
+      for (size_t i = 0; i < n_cols && i < row.field_count(); ++i) {
+        batch_data->columns_data[i].push_back(row[i].unescaped());
+      }
+      // Handle rows with fewer fields than expected
+      for (size_t i = row.field_count(); i < n_cols; ++i) {
+        batch_data->columns_data[i].push_back("");
+      }
+
+      ++rows_read;
+    }
+
+    // Check if we're done (no rows read means iterator is exhausted)
+    if (rows_read == 0) {
+      exhausted_ = true;
+      throw py::stop_iteration();
+    }
+
+    // Note: We don't check reader_->eof() here because the streaming reader
+    // might report eof while still having buffered rows. The only reliable
+    // way to know we're done is when next_row() returns false, which happens
+    // in the loop above and causes rows_read == 0 on the next call.
+
+    // Set column names
+    batch_data->column_names = column_names_;
+
+    // Perform type inference on the batch data
+    size_t num_cols = batch_data->columns_data.size();
+    batch_data->column_types.resize(num_cols, ColumnType::STRING);
+
+    if (rows_read > 0 && num_cols > 0) {
+      libvroom::ColumnTypeInference inference(num_cols);
+
+      // Sample rows for type inference (use all rows in small batches)
+      size_t rows_to_sample = std::min(rows_read, static_cast<size_t>(1000));
+      for (size_t row = 0; row < rows_to_sample; ++row) {
+        for (size_t col = 0; col < num_cols; ++col) {
+          const std::string& value = batch_data->columns_data[col][row];
+          inference.add_field(col, reinterpret_cast<const uint8_t*>(value.data()), value.size());
+        }
+      }
+
+      // Get inferred types
+      std::vector<libvroom::FieldType> inferred = inference.infer_types();
+      for (size_t col = 0; col < num_cols; ++col) {
+        batch_data->column_types[col] = field_type_to_column_type(inferred[col]);
+      }
+    }
+
+    // Apply dtype overrides
+    for (const auto& [col_name, type_str] : dtype_overrides_) {
+      auto it =
+          std::find(batch_data->column_names.begin(), batch_data->column_names.end(), col_name);
+      if (it == batch_data->column_names.end()) {
+        throw py::value_error("Column not found for dtype: " + col_name);
+      }
+      size_t col_idx = std::distance(batch_data->column_names.begin(), it);
+
+      auto col_type = parse_dtype_string(type_str);
+      if (!col_type) {
+        throw py::value_error("Unknown dtype '" + type_str + "' for column '" + col_name + "'");
+      }
+      batch_data->column_types[col_idx] = *col_type;
+    }
+
+    return RecordBatch(std::move(batch_data));
+  }
+
+  // Get column names (available after first batch or from header)
+  std::vector<std::string> column_names() const { return column_names_; }
+
+  // Get batch size
+  size_t batch_size() const { return batch_size_; }
+
+  // Get file path
+  std::string path() const { return path_; }
+
+  // Check if iterator is exhausted
+  bool is_exhausted() const { return exhausted_; }
+
+  // String representation
+  std::string repr() const {
+    std::ostringstream ss;
+    ss << "BatchedReader(path=" << py::repr(py::str(path_)).cast<std::string>()
+       << ", batch_size=" << batch_size_ << ")";
+    return ss.str();
+  }
+
+private:
+  std::string path_;
+  size_t batch_size_;
+  bool has_header_;
+  bool exhausted_;
+  std::unique_ptr<libvroom::StreamReader> reader_;
+  std::vector<std::string> column_names_;
+  NullValueConfig null_config_;
+  std::unordered_map<std::string, std::string> dtype_overrides_;
+};
+
+// Factory function for read_csv_batched
+BatchedReader
+read_csv_batched(const std::string& path, size_t batch_size = 10000,
+                 std::optional<std::string> delimiter = std::nullopt,
+                 std::optional<std::string> quote_char = std::nullopt, bool has_header = true,
+                 std::optional<std::vector<std::string>> null_values = std::nullopt,
+                 bool empty_is_null = true,
+                 std::optional<std::unordered_map<std::string, std::string>> dtype = std::nullopt) {
+  return BatchedReader(path, batch_size, delimiter, quote_char, has_header, null_values,
+                       empty_is_null, dtype);
+}
+
+// =============================================================================
 // detect_dialect function
 // =============================================================================
 
@@ -1444,6 +1857,161 @@ Examples
 >>> # Convert to Polars
 >>> import polars as pl
 >>> df = pl.from_arrow(table)
+)doc");
+
+  // RecordBatch class (for batched reading)
+  py::class_<RecordBatch>(m, "RecordBatch", R"doc(
+A single batch of rows from a batched CSV read operation.
+
+This class represents a single batch returned by BatchedReader iteration.
+It implements the Arrow PyCapsule interface for zero-copy interoperability
+with PyArrow, Polars, DuckDB, and other Arrow-compatible libraries.
+
+Examples
+--------
+>>> import vroom_csv
+>>> for batch in vroom_csv.read_csv_batched("data.csv", batch_size=1000):
+...     print(f"Batch has {batch.num_rows} rows")
+...     # Convert to Polars for processing
+...     import polars as pl
+...     df = pl.from_arrow(batch)
+...     # Process df...
+)doc")
+      .def_property_readonly("num_rows", &RecordBatch::num_rows, "Number of rows in this batch")
+      .def_property_readonly("num_columns", &RecordBatch::num_columns, "Number of columns")
+      .def_property_readonly("column_names", &RecordBatch::column_names, "List of column names")
+      .def("column", &RecordBatch::column, py::arg("index"),
+           "Get column by index as list of strings")
+      .def("column", &RecordBatch::column_by_name, py::arg("name"),
+           "Get column by name as list of strings")
+      .def("row", &RecordBatch::row, py::arg("index"), "Get row by index as list of strings")
+      .def("__repr__", &RecordBatch::repr)
+      .def("__len__", &RecordBatch::num_rows)
+      // Arrow PyCapsule interface
+      .def("__arrow_c_schema__", &RecordBatch::arrow_c_schema,
+           "Export batch schema via Arrow C Data Interface")
+      .def("__arrow_c_stream__", &RecordBatch::arrow_c_stream,
+           py::arg("requested_schema") = py::none(),
+           "Export batch data via Arrow C Stream Interface");
+
+  // BatchedReader class
+  py::class_<BatchedReader>(m, "BatchedReader", R"doc(
+Iterator for memory-efficient batch processing of large CSV files.
+
+This class provides an iterator that reads CSV files in batches, keeping only
+one batch in memory at a time. Each batch is a RecordBatch object that
+implements the Arrow PyCapsule interface.
+
+Use read_csv_batched() to create a BatchedReader.
+
+Attributes
+----------
+path : str
+    Path to the CSV file being read.
+batch_size : int
+    Number of rows per batch.
+column_names : list[str]
+    Column names from the CSV header (or generated names if no header).
+
+Examples
+--------
+>>> import vroom_csv
+>>> import polars as pl
+>>>
+>>> # Process large file in batches
+>>> for batch in vroom_csv.read_csv_batched("large.csv", batch_size=10000):
+...     df = pl.from_arrow(batch)
+...     # Process each batch without loading entire file
+...     process(df)
+>>>
+>>> # Early termination is safe
+>>> reader = vroom_csv.read_csv_batched("large.csv")
+>>> for batch in reader:
+...     if should_stop(batch):
+...         break  # Resources cleaned up automatically
+)doc")
+      .def_property_readonly("path", &BatchedReader::path, "Path to the CSV file")
+      .def_property_readonly("batch_size", &BatchedReader::batch_size, "Number of rows per batch")
+      .def_property_readonly("column_names", &BatchedReader::column_names, "List of column names")
+      .def("__repr__", &BatchedReader::repr)
+      .def("__iter__", &BatchedReader::iter, py::return_value_policy::reference)
+      .def("__next__", &BatchedReader::next);
+
+  // read_csv_batched function
+  m.def("read_csv_batched", &read_csv_batched, py::arg("path"), py::arg("batch_size") = 10000,
+        py::arg("delimiter") = py::none(), py::arg("quote_char") = py::none(),
+        py::arg("has_header") = true, py::arg("null_values") = py::none(),
+        py::arg("empty_is_null") = true, py::arg("dtype") = py::none(),
+        R"doc(
+Read a CSV file in batches for memory-efficient processing.
+
+This function returns an iterator that yields RecordBatch objects,
+each containing batch_size rows (except possibly the last batch).
+Only one batch is kept in memory at a time, making this suitable
+for processing files larger than available memory.
+
+Parameters
+----------
+path : str
+    Path to the CSV file to read.
+batch_size : int, default 10000
+    Number of rows per batch.
+delimiter : str, optional
+    Field delimiter character. If not specified, defaults to comma (',').
+quote_char : str, optional
+    Quote character for escaping fields. Default is '"'.
+has_header : bool, default True
+    Whether the first row contains column headers.
+null_values : list[str], optional
+    List of strings to interpret as null/missing values during Arrow export.
+    If not specified, defaults to ["", "NA", "N/A", "null", "NULL", "None", "NaN"].
+empty_is_null : bool, default True
+    If True, empty strings are treated as null values during Arrow export.
+dtype : dict[str, str], optional
+    Dictionary mapping column names to data types for Arrow export.
+    By default, column types are automatically inferred from the data.
+    Supported types: 'str', 'string', 'int', 'int64', 'float', 'float64',
+    'bool', 'boolean'.
+
+Returns
+-------
+BatchedReader
+    An iterator yielding RecordBatch objects.
+
+Raises
+------
+ValueError
+    If the file cannot be opened, delimiter/quote_char is not a single
+    character, or an unknown dtype is specified.
+
+Examples
+--------
+>>> import vroom_csv
+>>> import polars as pl
+>>>
+>>> # Basic usage - process file in batches
+>>> for batch in vroom_csv.read_csv_batched("large.csv"):
+...     df = pl.from_arrow(batch)
+...     print(f"Processing {df.shape[0]} rows")
+>>>
+>>> # Custom batch size
+>>> for batch in vroom_csv.read_csv_batched("large.csv", batch_size=50000):
+...     process(batch)
+>>>
+>>> # With explicit delimiter (TSV)
+>>> for batch in vroom_csv.read_csv_batched("data.tsv", delimiter="\\t"):
+...     process(batch)
+>>>
+>>> # Aggregate results across batches
+>>> total_sum = 0
+>>> for batch in vroom_csv.read_csv_batched("data.csv", dtype={"value": "int64"}):
+...     import pyarrow as pa
+...     arrow_table = pa.table(batch)
+...     total_sum += sum(v for v in arrow_table.column("value").to_pylist() if v is not None)
+>>>
+>>> # File without header
+>>> for batch in vroom_csv.read_csv_batched("no_header.csv", has_header=False):
+...     print(batch.column_names)  # ['column_0', 'column_1', ...]
 )doc");
 
   // Version info

--- a/python/src/vroom_csv/__init__.py
+++ b/python/src/vroom_csv/__init__.py
@@ -28,10 +28,13 @@ Arrow Interoperability
 """
 
 from vroom_csv._core import (
+    BatchedReader,
     Dialect,
+    RecordBatch,
     Table,
     detect_dialect,
     read_csv,
+    read_csv_batched,
     VroomError,
     ParseError,
     IOError,
@@ -40,10 +43,13 @@ from vroom_csv._core import (
 )
 
 __all__ = [
+    "BatchedReader",
     "Dialect",
+    "RecordBatch",
     "Table",
     "detect_dialect",
     "read_csv",
+    "read_csv_batched",
     "VroomError",
     "ParseError",
     "IOError",

--- a/python/tests/test_batched.py
+++ b/python/tests/test_batched.py
@@ -1,0 +1,678 @@
+"""Tests for read_csv_batched() and BatchedReader."""
+
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def simple_csv():
+    """Create a simple CSV file for testing."""
+    content = "name,age,city\nAlice,30,New York\nBob,25,Los Angeles\nCharlie,35,Chicago\n"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        f.write(content)
+        return f.name
+
+
+@pytest.fixture
+def larger_csv():
+    """Create a larger CSV file for batch testing."""
+    lines = ["id,value,category"]
+    for i in range(100):
+        lines.append(f"{i},{i * 10},cat_{i % 5}")
+    content = "\n".join(lines) + "\n"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        f.write(content)
+        return f.name
+
+
+@pytest.fixture
+def csv_with_nulls():
+    """Create a CSV file with null values."""
+    content = "name,value,status\nAlice,100,active\nBob,NA,inactive\nCharlie,,pending\n"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        f.write(content)
+        return f.name
+
+
+@pytest.fixture
+def tsv_file():
+    """Create a TSV file for delimiter testing."""
+    content = "name\tvalue\nAlice\t100\nBob\t200\n"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tsv", delete=False) as f:
+        f.write(content)
+        return f.name
+
+
+@pytest.fixture
+def no_header_csv():
+    """Create a CSV file without header."""
+    content = "Alice,30,New York\nBob,25,Los Angeles\n"
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        f.write(content)
+        return f.name
+
+
+class TestBatchedReaderBasic:
+    """Basic tests for read_csv_batched() functionality."""
+
+    def test_read_csv_batched_returns_iterator(self, simple_csv):
+        """Test that read_csv_batched returns an iterator."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        assert hasattr(reader, "__iter__")
+        assert hasattr(reader, "__next__")
+
+    def test_read_csv_batched_yields_record_batches(self, simple_csv):
+        """Test that iterating yields RecordBatch objects."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+        assert isinstance(batch, vroom_csv.RecordBatch)
+
+    def test_batch_has_correct_structure(self, simple_csv):
+        """Test that batches have the correct columns and data."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        assert batch.num_columns == 3
+        assert batch.column_names == ["name", "age", "city"]
+        assert batch.num_rows == 3
+
+    def test_batch_column_access_by_index(self, simple_csv):
+        """Test accessing columns by index."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        names = batch.column(0)
+        assert names == ["Alice", "Bob", "Charlie"]
+
+    def test_batch_column_access_by_name(self, simple_csv):
+        """Test accessing columns by name."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        names = batch.column("name")
+        assert names == ["Alice", "Bob", "Charlie"]
+
+    def test_batch_row_access(self, simple_csv):
+        """Test accessing rows by index."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        row = batch.row(0)
+        assert row == ["Alice", "30", "New York"]
+
+    def test_batch_len(self, simple_csv):
+        """Test that len() returns num_rows."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        assert len(batch) == 3
+
+    def test_batch_repr(self, simple_csv):
+        """Test the string representation of RecordBatch."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        repr_str = repr(batch)
+        assert "RecordBatch" in repr_str
+        assert "3 rows" in repr_str
+        assert "3 columns" in repr_str
+
+
+class TestBatchedReaderIterator:
+    """Tests for iterator behavior."""
+
+    def test_iteration_stops_at_end(self, simple_csv):
+        """Test that iteration raises StopIteration at end."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv, batch_size=10)
+        batches = list(reader)
+
+        # Small file should fit in one batch
+        assert len(batches) == 1
+
+    def test_multiple_batches(self, larger_csv):
+        """Test that large files are split into multiple batches."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(larger_csv, batch_size=25)
+        batches = list(reader)
+
+        # 100 rows / 25 per batch = 4 batches
+        assert len(batches) == 4
+
+        # Verify row counts
+        assert batches[0].num_rows == 25
+        assert batches[1].num_rows == 25
+        assert batches[2].num_rows == 25
+        assert batches[3].num_rows == 25
+
+    def test_last_batch_smaller(self, larger_csv):
+        """Test that last batch can be smaller than batch_size."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(larger_csv, batch_size=30)
+        batches = list(reader)
+
+        # 100 rows / 30 per batch = 4 batches (30, 30, 30, 10)
+        assert len(batches) == 4
+        assert batches[0].num_rows == 30
+        assert batches[1].num_rows == 30
+        assert batches[2].num_rows == 30
+        assert batches[3].num_rows == 10
+
+    def test_for_loop_iteration(self, larger_csv):
+        """Test that standard for loop works."""
+        import vroom_csv
+
+        total_rows = 0
+        for batch in vroom_csv.read_csv_batched(larger_csv, batch_size=25):
+            total_rows += batch.num_rows
+
+        assert total_rows == 100
+
+    def test_early_termination(self, larger_csv):
+        """Test that early termination works correctly."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(larger_csv, batch_size=25)
+        batch = next(reader)
+
+        assert batch.num_rows == 25
+        # Early termination - reader is dropped, should be safe
+
+
+class TestBatchedReaderOptions:
+    """Tests for read_csv_batched options."""
+
+    def test_custom_batch_size(self, larger_csv):
+        """Test custom batch_size parameter."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(larger_csv, batch_size=50)
+        batches = list(reader)
+
+        assert len(batches) == 2
+        assert batches[0].num_rows == 50
+        assert batches[1].num_rows == 50
+
+    def test_delimiter_option(self, tsv_file):
+        """Test delimiter parameter for TSV files."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(tsv_file, delimiter="\t")
+        batch = next(reader)
+
+        assert batch.column_names == ["name", "value"]
+        assert batch.column("name") == ["Alice", "Bob"]
+
+    def test_no_header_option(self, no_header_csv):
+        """Test has_header=False generates column names."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(no_header_csv, has_header=False)
+        batch = next(reader)
+
+        assert batch.column_names == ["column_0", "column_1", "column_2"]
+        assert batch.num_rows == 2
+
+    def test_reader_properties(self, simple_csv):
+        """Test BatchedReader properties."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv, batch_size=100)
+
+        assert reader.batch_size == 100
+        assert simple_csv in reader.path
+        # Note: column_names is empty until first batch is read
+        # (header is parsed lazily during first next_row call)
+        assert reader.column_names == []
+
+        # After reading first batch, column names become available
+        batch = next(reader)
+        assert reader.column_names == ["name", "age", "city"]
+
+    def test_reader_repr(self, simple_csv):
+        """Test the string representation of BatchedReader."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv, batch_size=100)
+
+        repr_str = repr(reader)
+        assert "BatchedReader" in repr_str
+        assert "batch_size=100" in repr_str
+
+
+class TestBatchedReaderErrors:
+    """Tests for error handling."""
+
+    def test_nonexistent_file_raises(self):
+        """Test that reading a nonexistent file raises ValueError."""
+        import vroom_csv
+
+        with pytest.raises(ValueError, match="Failed to open"):
+            vroom_csv.read_csv_batched("/nonexistent/path/file.csv")
+
+    def test_invalid_delimiter_raises(self, simple_csv):
+        """Test that multi-character delimiter raises ValueError."""
+        import vroom_csv
+
+        with pytest.raises(ValueError, match="single character"):
+            vroom_csv.read_csv_batched(simple_csv, delimiter=";;")
+
+    def test_invalid_quote_char_raises(self, simple_csv):
+        """Test that multi-character quote_char raises ValueError."""
+        import vroom_csv
+
+        with pytest.raises(ValueError, match="single character"):
+            vroom_csv.read_csv_batched(simple_csv, quote_char="''")
+
+    def test_column_index_out_of_range(self, simple_csv):
+        """Test that invalid column index raises IndexError."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        with pytest.raises(IndexError):
+            batch.column(100)
+
+    def test_column_name_not_found(self, simple_csv):
+        """Test that invalid column name raises KeyError."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        with pytest.raises(KeyError):
+            batch.column("nonexistent")
+
+    def test_row_index_out_of_range(self, simple_csv):
+        """Test that invalid row index raises IndexError."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        with pytest.raises(IndexError):
+            batch.row(100)
+
+
+class TestBatchedReaderArrowCapsule:
+    """Tests for Arrow PyCapsule interface on RecordBatch."""
+
+    def test_batch_has_arrow_c_schema(self, simple_csv):
+        """Test that __arrow_c_schema__ method exists."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        assert hasattr(batch, "__arrow_c_schema__")
+        capsule = batch.__arrow_c_schema__()
+        assert capsule is not None
+
+    def test_batch_has_arrow_c_stream(self, simple_csv):
+        """Test that __arrow_c_stream__ method exists."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+
+        assert hasattr(batch, "__arrow_c_stream__")
+        capsule = batch.__arrow_c_stream__()
+        assert capsule is not None
+
+
+# Try to import pyarrow, skip tests if not available
+try:
+    import pyarrow as pa
+    HAS_PYARROW = True
+except ImportError:
+    HAS_PYARROW = False
+
+
+@pytest.mark.skipif(not HAS_PYARROW, reason="pyarrow not installed")
+class TestBatchedReaderPyArrow:
+    """Tests for PyArrow interoperability."""
+
+    def test_batch_to_pyarrow_table(self, simple_csv):
+        """Test converting batch to PyArrow Table."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+        arrow_table = pa.table(batch)
+
+        assert arrow_table.num_rows == 3
+        assert arrow_table.num_columns == 3
+        assert arrow_table.column_names == ["name", "age", "city"]
+
+    def test_batch_data_values(self, simple_csv):
+        """Test that data values are correctly transferred."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+        arrow_table = pa.table(batch)
+
+        names = arrow_table.column("name").to_pylist()
+        assert names == ["Alice", "Bob", "Charlie"]
+
+        # age should be auto-inferred as int64
+        ages = arrow_table.column("age").to_pylist()
+        assert ages == [30, 25, 35]
+
+    def test_batch_type_inference(self, larger_csv):
+        """Test automatic type inference in batches."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(larger_csv, batch_size=25)
+        batch = next(reader)
+        arrow_table = pa.table(batch)
+
+        # id and value should be int64 (numeric)
+        assert pa.types.is_int64(arrow_table.column("id").type)
+        assert pa.types.is_int64(arrow_table.column("value").type)
+        # category should be string
+        assert pa.types.is_string(arrow_table.column("category").type)
+
+    def test_iterate_and_convert_all_batches(self, larger_csv):
+        """Test iterating and converting all batches to PyArrow."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        tables = []
+        for batch in vroom_csv.read_csv_batched(larger_csv, batch_size=25):
+            tables.append(pa.table(batch))
+
+        assert len(tables) == 4
+
+        # Combine all tables
+        combined = pa.concat_tables(tables)
+        assert combined.num_rows == 100
+
+
+# Try to import polars, skip tests if not available
+try:
+    import polars as pl
+    HAS_POLARS = True
+except ImportError:
+    HAS_POLARS = False
+
+
+@pytest.mark.skipif(not HAS_POLARS, reason="polars not installed")
+class TestBatchedReaderPolars:
+    """Tests for Polars interoperability."""
+
+    def test_batch_to_polars_dataframe(self, simple_csv):
+        """Test converting batch to Polars DataFrame."""
+        import polars as pl
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+        df = pl.from_arrow(batch)
+
+        assert df.shape == (3, 3)
+        assert df.columns == ["name", "age", "city"]
+
+    def test_batch_data_values_polars(self, simple_csv):
+        """Test that data values are correctly transferred to Polars."""
+        import polars as pl
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv)
+        batch = next(reader)
+        df = pl.from_arrow(batch)
+
+        names = df["name"].to_list()
+        assert names == ["Alice", "Bob", "Charlie"]
+
+        # age should be auto-inferred as int64
+        ages = df["age"].to_list()
+        assert ages == [30, 25, 35]
+
+    def test_process_large_file_in_batches(self, larger_csv):
+        """Test processing large file in batches with Polars."""
+        import polars as pl
+
+        import vroom_csv
+
+        total_value = 0
+        for batch in vroom_csv.read_csv_batched(larger_csv, batch_size=25):
+            df = pl.from_arrow(batch)
+            total_value += df["value"].sum()
+
+        # Sum of 0*10, 10*10, 20*10, ... 990*10 = 10 * (0 + 10 + 20 + ... + 990)
+        # = 10 * 10 * (0 + 1 + 2 + ... + 99) = 100 * (99 * 100 / 2) = 100 * 4950 = 495000
+        expected = sum(i * 10 for i in range(100))
+        assert total_value == expected
+
+
+@pytest.mark.skipif(not HAS_PYARROW, reason="pyarrow not installed")
+class TestBatchedReaderNullHandling:
+    """Tests for null value handling in batched reading."""
+
+    def test_default_null_values(self, csv_with_nulls):
+        """Test that default null values are recognized."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(csv_with_nulls)
+        batch = next(reader)
+        arrow_table = pa.table(batch)
+
+        values = arrow_table.column("value").to_pylist()
+        assert values[0] == "100"
+        assert values[1] is None  # NA
+        assert values[2] is None  # empty
+
+    def test_custom_null_values(self, csv_with_nulls):
+        """Test custom null_values parameter."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(csv_with_nulls, null_values=["NA", "inactive"])
+        batch = next(reader)
+        arrow_table = pa.table(batch)
+
+        # "NA" should be null
+        values = arrow_table.column("value").to_pylist()
+        assert values[1] is None
+
+        # "inactive" should be null
+        status = arrow_table.column("status").to_pylist()
+        assert status[1] is None
+
+
+@pytest.mark.skipif(not HAS_PYARROW, reason="pyarrow not installed")
+class TestBatchedReaderDtype:
+    """Tests for dtype parameter in batched reading."""
+
+    def test_dtype_override(self, larger_csv):
+        """Test that dtype parameter overrides type inference."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(larger_csv, dtype={"id": "string"})
+        batch = next(reader)
+        arrow_table = pa.table(batch)
+
+        # id should be string (overridden), not int64
+        assert pa.types.is_string(arrow_table.column("id").type)
+        ids = arrow_table.column("id").to_pylist()
+        assert ids[0] == "0"
+
+    def test_dtype_int64(self, simple_csv):
+        """Test int64 dtype conversion."""
+        import pyarrow as pa
+
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv, dtype={"age": "int64"})
+        batch = next(reader)
+        arrow_table = pa.table(batch)
+
+        assert pa.types.is_int64(arrow_table.column("age").type)
+        ages = arrow_table.column("age").to_pylist()
+        assert ages == [30, 25, 35]
+
+    def test_unknown_dtype_raises(self, simple_csv):
+        """Test that unknown dtype raises ValueError."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv, dtype={"age": "unknown_type"})
+
+        with pytest.raises(ValueError, match="Unknown dtype"):
+            next(reader)
+
+    def test_unknown_column_for_dtype_raises(self, simple_csv):
+        """Test that dtype for unknown column raises ValueError."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv, dtype={"nonexistent": "int64"})
+
+        with pytest.raises(ValueError, match="Column not found"):
+            next(reader)
+
+
+class TestBatchedReaderDataIntegrity:
+    """Tests for data integrity across batches."""
+
+    def test_all_rows_read(self, larger_csv):
+        """Test that all rows are read across batches."""
+        import vroom_csv
+
+        all_ids = []
+        for batch in vroom_csv.read_csv_batched(larger_csv, batch_size=25):
+            # Get ids as strings and convert to int
+            ids = batch.column("id")
+            all_ids.extend(int(id_) for id_ in ids)
+
+        assert len(all_ids) == 100
+        assert all_ids == list(range(100))
+
+    def test_row_order_preserved(self, larger_csv):
+        """Test that row order is preserved across batches."""
+        import vroom_csv
+
+        all_values = []
+        for batch in vroom_csv.read_csv_batched(larger_csv, batch_size=30):
+            values = batch.column("value")
+            all_values.extend(int(v) for v in values)
+
+        expected = [i * 10 for i in range(100)]
+        assert all_values == expected
+
+    def test_column_consistency(self, larger_csv):
+        """Test that column names are consistent across batches."""
+        import vroom_csv
+
+        expected_columns = ["id", "value", "category"]
+        for batch in vroom_csv.read_csv_batched(larger_csv, batch_size=25):
+            assert batch.column_names == expected_columns
+
+
+class TestBatchedReaderEdgeCases:
+    """Tests for edge cases."""
+
+    def test_empty_file(self):
+        """Test reading an empty file."""
+        import vroom_csv
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("")
+            empty_path = f.name
+
+        reader = vroom_csv.read_csv_batched(empty_path)
+        batches = list(reader)
+        assert len(batches) == 0
+
+    def test_header_only_file(self):
+        """Test reading a file with only header."""
+        import vroom_csv
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("a,b,c\n")
+            path = f.name
+
+        reader = vroom_csv.read_csv_batched(path)
+        batches = list(reader)
+        assert len(batches) == 0
+
+    def test_single_row_file(self):
+        """Test reading a file with a single data row."""
+        import vroom_csv
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("a,b,c\n1,2,3\n")
+            path = f.name
+
+        reader = vroom_csv.read_csv_batched(path)
+        batches = list(reader)
+        assert len(batches) == 1
+        assert batches[0].num_rows == 1
+
+    def test_batch_size_equals_rows(self, larger_csv):
+        """Test when batch_size equals total rows."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(larger_csv, batch_size=100)
+        batches = list(reader)
+        assert len(batches) == 1
+        assert batches[0].num_rows == 100
+
+    def test_batch_size_larger_than_rows(self, simple_csv):
+        """Test when batch_size is larger than total rows."""
+        import vroom_csv
+
+        reader = vroom_csv.read_csv_batched(simple_csv, batch_size=10000)
+        batches = list(reader)
+        assert len(batches) == 1
+        assert batches[0].num_rows == 3
+
+    def test_quoted_fields(self):
+        """Test handling of quoted fields with special characters."""
+        import vroom_csv
+
+        content = 'name,value\n"Alice, Jr.",100\n"Bob ""The Builder""",200\n'
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(content)
+            path = f.name
+
+        reader = vroom_csv.read_csv_batched(path)
+        batch = next(reader)
+
+        names = batch.column("name")
+        assert names[0] == "Alice, Jr."
+        assert names[1] == 'Bob "The Builder"'


### PR DESCRIPTION
## Summary
- Add `read_csv_batched()` function that returns a `BatchedReader` iterator for memory-efficient batch processing
- Each batch is a `RecordBatch` object that implements the Arrow PyCapsule interface
- Support all standard options (delimiter, quote_char, has_header, null_values, empty_is_null, dtype)
- Automatic type inference per batch

## Implementation Details
The `BatchedReader` class wraps the existing `libvroom::StreamReader` to provide Python iterator semantics. Each `RecordBatch` holds a configurable number of rows (default 10000) and can be efficiently converted to PyArrow or Polars DataFrames via the Arrow C Data Interface.

Key design decisions:
- Column names are lazily populated on first batch read (header is parsed during first `next_row()` call)
- Type inference is performed per-batch rather than globally, which allows consistent types within batches
- Memory is released after each batch is processed, enabling files larger than RAM

## Test plan
- [x] Basic functionality: returns iterator, yields RecordBatch objects
- [x] Correct structure: column names, num_rows, num_columns
- [x] Column/row access by index and name
- [x] Multiple batches: correct splitting, last batch smaller
- [x] Options: batch_size, delimiter, quote_char, has_header
- [x] Error handling: nonexistent file, invalid parameters, out of range access
- [x] Arrow PyCapsule interface: __arrow_c_schema__, __arrow_c_stream__
- [x] PyArrow interop: convert batches, concatenate tables
- [x] Null value handling: default nulls, custom null_values
- [x] dtype parameter: type overrides, error on unknown dtype
- [x] Data integrity: all rows read, order preserved
- [x] Edge cases: empty file, header-only, single row, quoted fields

Closes #493