### PR TITLE
feat(python): Add default_progress callback function

### DIFF
--- a/python/src/vroom_csv/__init__.py
+++ b/python/src/vroom_csv/__init__.py
@@ -18,6 +18,10 @@ Dialect Detection
 >>> dialect = vroom_csv.detect_dialect("data.csv")
 >>> print(f"Delimiter: {dialect.delimiter!r}, Has header: {dialect.has_header}")
 
+Progress Reporting
+------------------
+>>> table = vroom_csv.read_csv("large.csv", progress=vroom_csv.default_progress)
+
 Arrow Interoperability
 ----------------------
 >>> import pyarrow as pa
@@ -26,6 +30,8 @@ Arrow Interoperability
 >>> import polars as pl
 >>> df = pl.from_arrow(vroom_csv.read_csv("data.csv"))
 """
+
+import sys
 
 from vroom_csv._core import (
     BatchedReader,
@@ -44,12 +50,62 @@ from vroom_csv._core import (
     LIBVROOM_VERSION,
 )
 
+
+def _format_bytes(num_bytes: int) -> str:
+    """Format bytes as human-readable string."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(num_bytes) < 1024:
+            return f"{num_bytes:.1f}{unit}"
+        num_bytes /= 1024  # type: ignore[assignment]
+    return f"{num_bytes:.1f}PB"
+
+
+def default_progress(bytes_read: int, total_bytes: int) -> None:
+    """Default progress callback that displays a progress bar.
+
+    Displays a progress bar to stderr showing percentage complete and
+    bytes processed. Suitable for terminal output.
+
+    Parameters
+    ----------
+    bytes_read : int
+        Number of bytes processed so far.
+    total_bytes : int
+        Total number of bytes to process.
+
+    Examples
+    --------
+    >>> import vroom_csv
+    >>> table = vroom_csv.read_csv("large.csv", progress=vroom_csv.default_progress)
+    [=========>          ] 50.0% (512.0MB / 1.0GB)
+    """
+    if total_bytes == 0:
+        return
+
+    pct = bytes_read / total_bytes
+    bar_width = 30
+    filled = int(bar_width * pct)
+    bar = "=" * filled + (">" if filled < bar_width else "") + " " * (bar_width - filled - 1)
+
+    bytes_str = _format_bytes(bytes_read)
+    total_str = _format_bytes(total_bytes)
+
+    sys.stderr.write(f"\r[{bar}] {pct * 100:5.1f}% ({bytes_str} / {total_str})")
+    sys.stderr.flush()
+
+    # Print newline when complete
+    if bytes_read >= total_bytes:
+        sys.stderr.write("\n")
+        sys.stderr.flush()
+
+
 __all__ = [
     "BatchedReader",
     "Dialect",
     "RecordBatch",
     "RowIterator",
     "Table",
+    "default_progress",
     "detect_dialect",
     "read_csv",
     "read_csv_batched",

--- a/python/src/vroom_csv/_core.pyi
+++ b/python/src/vroom_csv/_core.pyi
@@ -6,6 +6,7 @@ from typing import Any, Sequence, overload
 __version__: str
 LIBVROOM_VERSION: str
 
+
 class VroomError(RuntimeError):
     """Base exception for vroom-csv errors."""
 


### PR DESCRIPTION
## Summary

Add a convenient `default_progress` function that users can use directly with `read_csv()` for progress reporting, eliminating the need to write their own progress callback.

## Example Usage

```python
import vroom_csv

# Simple one-liner for progress reporting
table = vroom_csv.read_csv("large.csv", progress=vroom_csv.default_progress)
```

## Output Format

```
[===============>              ] 50.0% (512.0MB / 1.0GB)
```

## Features

- ASCII progress bar with `=` and `>` characters
- Percentage display (0.0% to 100.0%)
- Human-readable byte counts (B, KB, MB, GB, TB, PB)
- Writes to stderr (doesn't interfere with stdout)
- Handles edge cases (zero total bytes)
- Prints newline when parsing completes

## Test plan

- [x] Test that `default_progress` is exported from `vroom_csv`
- [x] Test that `default_progress` works with `read_csv()`
- [x] Test output format contains progress bar, percentage, and bytes
- [x] Test zero total bytes edge case
- [x] All existing tests pass

Follow-up to PR #497