### PR TITLE
perf(benchmark): Increase data size for stable regression detection

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,7 +36,7 @@ jobs:
       timeout-minutes: 5
       run: |
         # Run benchmarks from parser_overhead_benchmarks.cpp which use generated data
-        # (100K rows x 10 cols) - avoids file path issues and provides meaningful sizes
+        # (500K rows x 10 cols, ~32MB) - larger size for stable timing (see issue #508)
         #
         # Selected benchmarks:
         # - BM_RawFirstPass: Raw SIMD scanning performance


### PR DESCRIPTION
## Summary
- Increases benchmark dataset from 100K to 500K rows (~6MB to ~32MB) for more stable benchmark timings
- Adds named constants `kDefaultRows` and `kDefaultCols` for better maintainability
- Updates workflow comment to reflect new data size

## Problem
The performance regression benchmarks were completing in under 3ms, which led to:
- Measurement noise from timing overhead
- Unreliable regression detection
- CV (coefficient of variation) values that suggest timing instability

## Solution
Increased the generated test data by 5x to produce benchmark iterations in the 2-60ms range:

| Benchmark | Before | After |
|-----------|--------|-------|
| BM_RawFirstPass | ~0.6ms | ~2.7ms |
| BM_ParserWithExplicitDialect | ~2.8ms | ~22ms |
| BM_ParserMultiThread/1 | ~2.8ms | ~22ms |
| BM_ParserMultiThread/4 | ~2.8ms | ~58ms |

These longer iteration times provide more stable measurements while keeping total CI benchmark time well within the 5-minute timeout.

## Test plan
- [x] Build succeeds with `cmake --build build -j$(nproc)`
- [x] All 2402 tests pass with `ctest --output-on-failure -j$(nproc)`
- [x] Benchmarks produce expected timing improvements (verified locally)

Closes #508