### PR TITLE
cleanup: Remove unused scalar branchless state machine functions

### DIFF
--- a/src/branchless_state_machine.cpp
+++ b/src/branchless_state_machine.cpp
@@ -1,17 +1,15 @@
 /**
  * @file branchless_state_machine.cpp
- * @brief Implementation of non-performance-critical branchless state machine functions.
+ * @brief Implementation of branchless state machine functions.
  *
- * This file contains the implementations that were moved from the header to reduce
- * header size and improve compilation times. The performance-critical SIMD functions
- * remain in the header as inline functions.
+ * This file contains implementations that were moved from the header to reduce
+ * header size and improve compilation times. The performance-critical SIMD inline
+ * functions remain in the header.
  *
  * Functions in this file:
- * - process_block_branchless() - scalar fallback implementation
- * - second_pass_branchless() - scalar variant
- * - second_pass_branchless_with_errors() - error handling logic
+ * - second_pass_simd_branchless_with_errors() - SIMD second pass with error collection
  * - get_error_context(), get_error_line_column() - diagnostic utilities
- * - branchless_error_to_error_code() - conversion logic
+ * - branchless_error_to_error_code() - error code conversion
  */
 
 #include "branchless_state_machine.h"
@@ -19,48 +17,6 @@
 #include <algorithm>
 
 namespace libvroom {
-
-size_t process_block_branchless(const BranchlessStateMachine& sm, const uint8_t* buf, size_t len,
-                                BranchlessState& state, uint64_t* indexes, uint64_t base,
-                                size_t& idx, size_t stride) {
-  size_t count = 0;
-
-  for (size_t i = 0; i < len; ++i) {
-    PackedResult result = sm.process(state, buf[i]);
-    state = result.state();
-
-    // Write separator position if this is a field/record separator
-    // This is still a branch but it's highly predictable since
-    // separators are relatively rare
-    if (result.is_separator()) {
-      indexes[idx * stride] = base + i;
-      idx++;
-      count++;
-    }
-  }
-
-  return count;
-}
-
-uint64_t second_pass_branchless(const BranchlessStateMachine& sm, const uint8_t* buf, size_t start,
-                                size_t end, uint64_t* indexes, size_t thread_id, size_t n_threads) {
-  BranchlessState state = STATE_RECORD_START;
-  size_t idx = thread_id;
-  uint64_t count = 0;
-
-  for (size_t pos = start; pos < end; ++pos) {
-    PackedResult result = sm.process(state, buf[pos]);
-    state = result.state();
-
-    if (result.is_separator()) {
-      indexes[idx] = pos;
-      idx += n_threads;
-      count++;
-    }
-  }
-
-  return count;
-}
 
 ErrorCode branchless_error_to_error_code(BranchlessError err) {
   switch (err) {
@@ -114,101 +70,6 @@ void get_error_line_column(const uint8_t* buf, size_t buf_len, size_t offset, si
       ++column;
     }
   }
-}
-
-uint64_t second_pass_branchless_with_errors(const BranchlessStateMachine& sm, const uint8_t* buf,
-                                            size_t start, size_t end, uint64_t* indexes,
-                                            size_t thread_id, size_t n_threads,
-                                            ErrorCollector* errors, size_t total_len) {
-  BranchlessState state = STATE_RECORD_START;
-  size_t idx = thread_id;
-  uint64_t count = 0;
-
-  // Use effective buffer length for bounds checking
-  size_t buf_len = total_len > 0 ? total_len : end;
-  char quote_char = sm.quote_char();
-
-  for (size_t pos = start; pos < end; ++pos) {
-    uint8_t value = buf[pos];
-
-    // Check for null bytes
-    if (value == '\0' && errors) {
-      size_t line, col;
-      get_error_line_column(buf, buf_len, pos, line, col);
-      errors->add_error(ErrorCode::NULL_BYTE, ErrorSeverity::ERROR, line, col, pos,
-                        "Null byte in data", get_error_context(buf, buf_len, pos));
-      if (errors->should_stop())
-        return count;
-      continue;
-    }
-
-    PackedResult result = sm.process(state, value);
-    BranchlessState new_state = result.state();
-    BranchlessError err = result.error();
-
-    // Handle errors
-    if (err != ERR_NONE && errors) {
-      size_t line, col;
-      get_error_line_column(buf, buf_len, pos, line, col);
-      ErrorCode error_code = branchless_error_to_error_code(err);
-
-      std::string msg;
-      if (err == ERR_QUOTE_IN_UNQUOTED) {
-        msg = "Quote character '";
-        msg += quote_char;
-        msg += "' in unquoted field";
-      } else if (err == ERR_INVALID_AFTER_QUOTE) {
-        msg = "Invalid character after closing quote '";
-        msg += quote_char;
-        msg += "'";
-      }
-
-      errors->add_error(error_code, ErrorSeverity::ERROR, line, col, pos, msg,
-                        get_error_context(buf, buf_len, pos));
-      if (errors->should_stop())
-        return count;
-    }
-
-    // Handle CR specially for CRLF sequences
-    if (value == '\r') {
-      // CR is a line ending only if not followed by LF
-      // Check both end and buf_len bounds to prevent out-of-bounds read
-      bool is_line_ending = (pos + 1 >= end || pos + 1 >= buf_len || buf[pos + 1] != '\n');
-      if (is_line_ending && state != STATE_QUOTED_FIELD) {
-        indexes[idx] = pos;
-        idx += n_threads;
-        count++;
-        state = STATE_RECORD_START;
-        continue;
-      }
-      // If CR is followed by LF (CRLF), treat CR as regular character
-      // The LF will be the line ending
-      state = new_state;
-      continue;
-    }
-
-    state = new_state;
-
-    if (result.is_separator()) {
-      indexes[idx] = pos;
-      idx += n_threads;
-      count++;
-    }
-  }
-
-  // Check for unclosed quote at end of chunk
-  if (state == STATE_QUOTED_FIELD && errors && end == buf_len) {
-    size_t line, col;
-    size_t error_pos = end > 0 ? end - 1 : 0;
-    get_error_line_column(buf, buf_len, error_pos, line, col);
-    std::string msg = "Unclosed quote '";
-    msg += quote_char;
-    msg += "' at end of file";
-    errors->add_error(ErrorCode::UNCLOSED_QUOTE, ErrorSeverity::FATAL, line, col, end, msg,
-                      get_error_context(buf, buf_len, error_pos > 20 ? error_pos - 20 : 0));
-  }
-
-  return count;
 }
 
 uint64_t second_pass_simd_branchless_with_errors(const BranchlessStateMachine& sm,


### PR DESCRIPTION
## Summary
- Remove dead code functions that were superseded by SIMD implementations
- Functions removed: `process_block_branchless`, `second_pass_branchless`, `second_pass_branchless_with_errors`
- 213 lines removed, 7 lines added (file header comment updates)

## Background
As identified in #509, code coverage reports showed these three scalar functions had zero coverage. Investigation confirmed they were never called anywhere in the codebase - the SIMD versions (`second_pass_simd_branchless` and `second_pass_simd_branchless_with_errors`) are used exclusively. Highway provides automatic scalar fallback on platforms without SIMD support, making these manual scalar implementations unnecessary.

## Test plan
- [x] Build completes successfully
- [x] All 2402 tests pass
- [x] No merge conflicts with main

Closes #509