### PR TITLE
ci(python): Add Python coverage to Codecov report

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,3 +47,44 @@ jobs:
       working-directory: python
       run: |
         python -m pytest tests/ -v --tb=short
+
+  # Coverage job - run on single configuration to upload to Codecov
+  python-coverage:
+    name: Python Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential
+
+    - name: Install Python package with test dependencies
+      working-directory: python
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .[test]
+
+    - name: Run tests with coverage
+      working-directory: python
+      run: |
+        python -m pytest tests/ -v --tb=short --cov=vroom_csv --cov-report=xml --cov-report=term
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      if: github.repository == 'jimhester/libvroom'
+      continue-on-error: true
+      with:
+        files: ./python/coverage.xml
+        flags: python
+        fail_ci_if_error: false
+        verbose: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -69,3 +69,9 @@ flags:
       - src/
       - include/
     carryforward: true
+
+  python:
+    # Python bindings test coverage (pytest-cov)
+    paths:
+      - python/src/
+    carryforward: true

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=7.0", "pyarrow>=14.0"]
+test = ["pytest>=7.0", "pytest-cov>=4.0", "pyarrow>=14.0"]
 arrow = ["pyarrow>=14.0"]
 polars = ["polars>=0.20"]
 benchmark = ["pandas>=2.0", "polars>=0.20", "pyarrow>=14.0", "duckdb>=0.9"]


### PR DESCRIPTION
## Summary
- Add Python coverage collection and upload to Codecov alongside existing C++ coverage
- Run coverage on a single configuration (Python 3.12 / Ubuntu) to avoid duplicate uploads
- Configure Codecov with a `python` flag for Python coverage tracking

## Changes
- **python/pyproject.toml**: Add `pytest-cov>=4.0` to test dependencies
- **.github/workflows/python.yml**: Add `python-coverage` job that runs tests with coverage and uploads to Codecov
- **codecov.yml**: Add `python` flag configuration for Python coverage paths

## Test plan
- [ ] CI passes on this PR
- [ ] Python coverage job runs successfully
- [ ] Coverage data appears in Codecov with the `python` flag

Closes #510