### PR TITLE
feat(python): Add progress callback support to batch and row iterators

### DIFF
--- a/python/src/vroom_csv/_core.pyi
+++ b/python/src/vroom_csv/_core.pyi
@@ -242,3 +242,196 @@ def read_csv(
         If a column name in usecols is not found.
     """
     ...
+
+class RecordBatch:
+    """A batch of rows from batched CSV reading.
+
+    RecordBatch represents a subset of rows from a CSV file during batched
+    reading. It implements the Arrow PyCapsule interface for zero-copy
+    interoperability with PyArrow, Polars, DuckDB, and other Arrow-compatible
+    libraries.
+    """
+
+    @property
+    def num_rows(self) -> int:
+        """Number of rows in this batch."""
+        ...
+
+    @property
+    def num_columns(self) -> int:
+        """Number of columns."""
+        ...
+
+    @property
+    def column_names(self) -> list[str]:
+        """List of column names."""
+        ...
+
+    @overload
+    def column(self, index: int) -> list[str]:
+        """Get column by index as list of strings."""
+        ...
+
+    @overload
+    def column(self, name: str) -> list[str]:
+        """Get column by name as list of strings."""
+        ...
+
+    def column(self, index_or_name: int | str) -> list[str]:
+        """Get column by index or name as list of strings."""
+        ...
+
+    def row(self, index: int) -> list[str]:
+        """Get row by index as list of strings."""
+        ...
+
+    def __len__(self) -> int: ...
+    def __repr__(self) -> str: ...
+    def __arrow_c_schema__(self) -> Any:
+        """Export batch schema via Arrow C Data Interface."""
+        ...
+
+    def __arrow_c_stream__(self, requested_schema: Any = None) -> Any:
+        """Export batch data via Arrow C Stream Interface."""
+        ...
+
+class BatchedReader:
+    """Iterator for batched CSV reading.
+
+    Returned by read_csv_batched(), yields RecordBatch objects for
+    memory-efficient processing of large CSV files.
+    """
+
+    @property
+    def path(self) -> str:
+        """Path to the CSV file."""
+        ...
+
+    @property
+    def batch_size(self) -> int:
+        """Number of rows per batch."""
+        ...
+
+    @property
+    def column_names(self) -> list[str]:
+        """List of column names (available after first batch)."""
+        ...
+
+    def __iter__(self) -> "BatchedReader": ...
+    def __next__(self) -> RecordBatch: ...
+    def __repr__(self) -> str: ...
+
+class RowIterator:
+    """Iterator for row-by-row CSV streaming.
+
+    Returned by read_csv_rows(), yields dictionaries for each row
+    in the CSV file.
+    """
+
+    @property
+    def column_names(self) -> list[str]:
+        """List of column names."""
+        ...
+
+    def __iter__(self) -> "RowIterator": ...
+    def __next__(self) -> dict[str, Any]: ...
+
+def read_csv_batched(
+    path: str,
+    batch_size: int = 10000,
+    delimiter: str | None = None,
+    quote_char: str | None = None,
+    has_header: bool = True,
+    null_values: Sequence[str] | None = None,
+    empty_is_null: bool = True,
+    dtype: dict[str, str] | None = None,
+    progress: Callable[[int, int], None] | None = None,
+) -> BatchedReader:
+    """Read a CSV file in batches for memory-efficient processing.
+
+    Parameters
+    ----------
+    path : str
+        Path to the CSV file to read.
+    batch_size : int, default 10000
+        Number of rows per batch.
+    delimiter : str, optional
+        Field delimiter character. If not specified, defaults to comma (',').
+    quote_char : str, optional
+        Quote character for escaping fields. Default is '"'.
+    has_header : bool, default True
+        Whether the first row contains column headers.
+    null_values : sequence of str, optional
+        List of strings to interpret as null/missing values.
+    empty_is_null : bool, default True
+        If True, empty strings are treated as null values.
+    dtype : dict[str, str], optional
+        Dictionary mapping column names to data types.
+    progress : callable, optional
+        A callback function for progress reporting during parsing.
+        The callback receives two arguments: (bytes_read: int, total_bytes: int).
+        It is called after each batch is read.
+
+    Returns
+    -------
+    BatchedReader
+        An iterator yielding RecordBatch objects.
+
+    Raises
+    ------
+    ValueError
+        If the file cannot be opened or parameters are invalid.
+    """
+    ...
+
+def read_csv_rows(
+    path: str,
+    delimiter: str | None = None,
+    quote_char: str | None = None,
+    has_header: bool = True,
+    skip_rows: int = 0,
+    n_rows: int | None = None,
+    usecols: Sequence[str | int] | None = None,
+    dtype: dict[str, str] | None = None,
+    progress: Callable[[int, int], None] | None = None,
+) -> RowIterator:
+    """Read a CSV file and return an iterator for row-by-row streaming.
+
+    Parameters
+    ----------
+    path : str
+        Path to the CSV file to read.
+    delimiter : str, optional
+        Field delimiter character. If not specified, auto-detected.
+    quote_char : str, optional
+        Quote character for escaping fields. Default is '"'.
+    has_header : bool, default True
+        Whether the first row contains column headers.
+    skip_rows : int, default 0
+        Number of data rows to skip.
+    n_rows : int, optional
+        Maximum number of data rows to read.
+    usecols : sequence of str or int, optional
+        List of column names or indices to include.
+    dtype : dict[str, str], optional
+        Dictionary mapping column names to data types.
+    progress : callable, optional
+        A callback function for progress reporting during iteration.
+        The callback receives two arguments: (bytes_read: int, total_bytes: int).
+        It is called periodically (every 1000 rows) to minimize overhead.
+
+    Returns
+    -------
+    RowIterator
+        An iterator that yields dictionaries, one per row.
+
+    Raises
+    ------
+    ValueError
+        If the file cannot be read or parsed.
+    IndexError
+        If a column index in usecols is out of range.
+    KeyError
+        If a column name in usecols is not found.
+    """
+    ...

--- a/python/tests/test_batched.py
+++ b/python/tests/test_batched.py
@@ -676,3 +676,150 @@ class TestBatchedReaderEdgeCases:
         names = batch.column("name")
         assert names[0] == "Alice, Jr."
         assert names[1] == 'Bob "The Builder"'
+
+
+class TestBatchedReaderProgress:
+    """Tests for progress callback support in read_csv_batched."""
+
+    @pytest.fixture
+    def larger_csv(self):
+        """Create a larger CSV file for progress testing."""
+        lines = ["id,value,description"]
+        for i in range(5000):
+            lines.append(f"{i},{i * 10},description for row {i}")
+        content = "\n".join(lines) + "\n"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(content)
+            yield f.name
+
+    def test_progress_callback_is_called(self, larger_csv):
+        """Test that progress callback is invoked during batch reading."""
+        import vroom_csv
+
+        call_count = [0]
+        progress_values = []
+
+        def progress_callback(bytes_read, total_bytes):
+            call_count[0] += 1
+            progress_values.append((bytes_read, total_bytes))
+
+        batches = list(
+            vroom_csv.read_csv_batched(larger_csv, batch_size=1000, progress=progress_callback)
+        )
+
+        # Should have read 5000 rows in ~5 batches
+        assert len(batches) == 5
+        # Callback should have been called at least once per batch
+        assert call_count[0] >= 5
+        # All progress values should have consistent total_bytes
+        if progress_values:
+            total = progress_values[0][1]
+            for bytes_read, total_bytes in progress_values:
+                assert total_bytes == total
+
+    def test_progress_callback_total_bytes_matches_file_size(self, larger_csv):
+        """Test that total_bytes in callback matches actual file size."""
+        import os
+
+        import vroom_csv
+
+        file_size = os.path.getsize(larger_csv)
+        reported_total = [None]
+
+        def progress_callback(bytes_read, total_bytes):
+            reported_total[0] = total_bytes
+
+        list(vroom_csv.read_csv_batched(larger_csv, progress=progress_callback))
+
+        assert reported_total[0] == file_size
+
+    def test_progress_callback_reaches_100_percent(self, larger_csv):
+        """Test that progress callback reaches 100% at the end."""
+        import vroom_csv
+
+        final_progress = [None]
+
+        def progress_callback(bytes_read, total_bytes):
+            final_progress[0] = (bytes_read, total_bytes)
+
+        list(vroom_csv.read_csv_batched(larger_csv, progress=progress_callback))
+
+        # Final call should report bytes_read == total_bytes (100%)
+        assert final_progress[0] is not None
+        bytes_read, total_bytes = final_progress[0]
+        assert bytes_read == total_bytes
+
+    def test_progress_callback_monotonically_increasing(self, larger_csv):
+        """Test that bytes_read values are monotonically non-decreasing."""
+        import vroom_csv
+
+        bytes_values = []
+
+        def progress_callback(bytes_read, total_bytes):
+            bytes_values.append(bytes_read)
+
+        list(vroom_csv.read_csv_batched(larger_csv, batch_size=500, progress=progress_callback))
+
+        # Values should be non-decreasing
+        for i in range(1, len(bytes_values)):
+            assert bytes_values[i] >= bytes_values[i - 1]
+
+    def test_progress_callback_with_none(self, larger_csv):
+        """Test that None progress callback works (no callback)."""
+        import vroom_csv
+
+        # Should not raise any errors
+        batches = list(vroom_csv.read_csv_batched(larger_csv, progress=None))
+        assert len(batches) > 0
+
+    def test_progress_callback_exception_handling(self, larger_csv):
+        """Test that exceptions in progress callback are handled properly."""
+        import vroom_csv
+
+        def bad_callback(bytes_read, total_bytes):
+            raise ValueError("Callback error")
+
+        # Exception in callback should propagate to caller
+        with pytest.raises(ValueError, match="Callback error"):
+            list(vroom_csv.read_csv_batched(larger_csv, progress=bad_callback))
+
+    def test_progress_callback_preserves_data_integrity(self, larger_csv):
+        """Test that using progress callback doesn't affect parsed data."""
+        import vroom_csv
+
+        # Parse without callback
+        batches_without = list(vroom_csv.read_csv_batched(larger_csv, batch_size=1000))
+
+        # Parse with callback
+        def progress_callback(bytes_read, total_bytes):
+            pass
+
+        batches_with = list(
+            vroom_csv.read_csv_batched(larger_csv, batch_size=1000, progress=progress_callback)
+        )
+
+        # Data should be identical
+        assert len(batches_without) == len(batches_with)
+        for batch_a, batch_b in zip(batches_without, batches_with):
+            assert batch_a.num_rows == batch_b.num_rows
+            assert batch_a.column_names == batch_b.column_names
+
+    def test_default_progress_with_batched(self, larger_csv):
+        """Test that default_progress can be used with read_csv_batched."""
+        import io
+        import sys
+
+        import vroom_csv
+
+        # Capture stderr
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+
+        try:
+            list(vroom_csv.read_csv_batched(larger_csv, progress=vroom_csv.default_progress))
+            output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+
+        # Progress bar should have been printed
+        assert "%" in output

--- a/python/tests/test_streaming.py
+++ b/python/tests/test_streaming.py
@@ -381,3 +381,167 @@ class TestReadCsvRowsMemoryEfficiency:
 
         result = list(names_upper)
         assert result == ["ALICE", "BOB", "CHARLIE"]
+
+
+class TestReadCsvRowsProgress:
+    """Tests for progress callback support in read_csv_rows."""
+
+    @pytest.fixture
+    def larger_csv(self):
+        """Create a larger CSV file for progress testing."""
+        lines = ["id,value,description"]
+        for i in range(5000):
+            lines.append(f"{i},{i * 10},description for row {i}")
+        content = "\n".join(lines) + "\n"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(content)
+            yield f.name
+
+    def test_progress_callback_is_called(self, larger_csv):
+        """Test that progress callback is invoked during row iteration."""
+        import vroom_csv
+
+        call_count = [0]
+        progress_values = []
+
+        def progress_callback(bytes_read, total_bytes):
+            call_count[0] += 1
+            progress_values.append((bytes_read, total_bytes))
+
+        rows = list(vroom_csv.read_csv_rows(larger_csv, progress=progress_callback))
+
+        assert len(rows) == 5000
+        # Callback should have been called multiple times (every 1000 rows)
+        # 5000 rows / 1000 = 5 calls, plus final 100% call
+        assert call_count[0] >= 5
+        # All progress values should have consistent total_bytes
+        if progress_values:
+            total = progress_values[0][1]
+            for bytes_read, total_bytes in progress_values:
+                assert total_bytes == total
+
+    def test_progress_callback_total_bytes_matches_file_size(self, larger_csv):
+        """Test that total_bytes in callback matches actual file size."""
+        import os
+
+        import vroom_csv
+
+        file_size = os.path.getsize(larger_csv)
+        reported_total = [None]
+
+        def progress_callback(bytes_read, total_bytes):
+            reported_total[0] = total_bytes
+
+        list(vroom_csv.read_csv_rows(larger_csv, progress=progress_callback))
+
+        assert reported_total[0] == file_size
+
+    def test_progress_callback_reaches_100_percent(self, larger_csv):
+        """Test that progress callback reaches 100% at the end."""
+        import vroom_csv
+
+        final_progress = [None]
+
+        def progress_callback(bytes_read, total_bytes):
+            final_progress[0] = (bytes_read, total_bytes)
+
+        list(vroom_csv.read_csv_rows(larger_csv, progress=progress_callback))
+
+        # Final call should report bytes_read == total_bytes (100%)
+        assert final_progress[0] is not None
+        bytes_read, total_bytes = final_progress[0]
+        assert bytes_read == total_bytes
+
+    def test_progress_callback_monotonically_increasing(self, larger_csv):
+        """Test that bytes_read values are monotonically non-decreasing."""
+        import vroom_csv
+
+        bytes_values = []
+
+        def progress_callback(bytes_read, total_bytes):
+            bytes_values.append(bytes_read)
+
+        list(vroom_csv.read_csv_rows(larger_csv, progress=progress_callback))
+
+        # Values should be non-decreasing
+        for i in range(1, len(bytes_values)):
+            assert bytes_values[i] >= bytes_values[i - 1]
+
+    def test_progress_callback_with_none(self, larger_csv):
+        """Test that None progress callback works (no callback)."""
+        import vroom_csv
+
+        # Should not raise any errors
+        rows = list(vroom_csv.read_csv_rows(larger_csv, progress=None))
+        assert len(rows) == 5000
+
+    def test_progress_callback_exception_handling(self, larger_csv):
+        """Test that exceptions in progress callback are handled properly."""
+        import vroom_csv
+
+        call_count = [0]
+
+        def bad_callback(bytes_read, total_bytes):
+            call_count[0] += 1
+            if call_count[0] >= 2:  # Allow first call, fail on second
+                raise ValueError("Callback error")
+
+        # Exception in callback should propagate to caller
+        with pytest.raises(ValueError, match="Callback error"):
+            list(vroom_csv.read_csv_rows(larger_csv, progress=bad_callback))
+
+    def test_progress_callback_preserves_data_integrity(self, larger_csv):
+        """Test that using progress callback doesn't affect parsed data."""
+        import vroom_csv
+
+        # Parse without callback
+        rows_without = list(vroom_csv.read_csv_rows(larger_csv))
+
+        # Parse with callback
+        def progress_callback(bytes_read, total_bytes):
+            pass
+
+        rows_with = list(vroom_csv.read_csv_rows(larger_csv, progress=progress_callback))
+
+        # Data should be identical
+        assert len(rows_without) == len(rows_with)
+        for row_a, row_b in zip(rows_without, rows_with):
+            assert row_a == row_b
+
+    def test_progress_callback_with_n_rows_limit(self, larger_csv):
+        """Test progress callback with n_rows limit."""
+        import vroom_csv
+
+        final_progress = [None]
+
+        def progress_callback(bytes_read, total_bytes):
+            final_progress[0] = (bytes_read, total_bytes)
+
+        # Only read 2500 rows (half the file)
+        rows = list(vroom_csv.read_csv_rows(larger_csv, n_rows=2500, progress=progress_callback))
+
+        assert len(rows) == 2500
+        # Progress should still reach 100% of what was read
+        assert final_progress[0] is not None
+        bytes_read, total_bytes = final_progress[0]
+        assert bytes_read == total_bytes
+
+    def test_default_progress_with_rows(self, larger_csv):
+        """Test that default_progress can be used with read_csv_rows."""
+        import io
+        import sys
+
+        import vroom_csv
+
+        # Capture stderr
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+
+        try:
+            list(vroom_csv.read_csv_rows(larger_csv, progress=vroom_csv.default_progress))
+            output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+
+        # Progress bar should have been printed
+        assert "%" in output


### PR DESCRIPTION
## Summary
- Added `progress` parameter to `read_csv_batched()` for progress reporting during batch reading
- Added `progress` parameter to `read_csv_rows()` for progress reporting during row iteration  
- Added comprehensive type stubs in `_core.pyi` for `BatchedReader`, `RecordBatch`, `RowIterator`, `read_csv_batched`, and `read_csv_rows`

This brings feature parity with the progress callback already supported in `read_csv()`.

## Implementation Details

**For `read_csv_batched()`:**
- Progress is reported after each batch is read
- Reports `bytes_read` and `total_bytes` (file size)
- 100% progress reported when iteration completes

**For `read_csv_rows()`:**
- Progress is reported every 1000 rows to minimize overhead
- Reports `bytes_read` and `total_bytes` (file size)
- 100% progress reported when iteration completes (or when `n_rows` limit is reached)

## Test plan
- [x] Added comprehensive test coverage for progress callbacks in both functions
- [x] Tests verify callback invocation, file size accuracy, 100% completion, monotonicity
- [x] Tests verify exception handling and data integrity
- [x] All existing tests pass

Closes #501