### PR TITLE
fix(ci): Skip existing packages in TestPyPI publish

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -131,3 +131,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true


### PR DESCRIPTION
## Summary
- Add `skip-existing: true` to the TestPyPI publish step to prevent failures when the same version already exists

## Problem
The TestPyPI publish step was failing with `HTTPError: 400 Bad Request` because version `0.1.0` already exists on TestPyPI, and PyPI/TestPyPI doesn't allow re-uploading the same version.

From the [failed CI run](https://github.com/jimhester/libvroom/actions/runs/20975956609/job/60292500122):
```
WARNING Error during upload.
ERROR   HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
```

## Solution
Adding `skip-existing: true` is the standard approach for TestPyPI uploads, where the same version number may be pushed multiple times during development. This option tells twine to skip packages that already exist instead of failing.

Fixes #520

## Test plan
- [x] Verify the workflow file syntax is valid
- [ ] CI will validate the change on merge to main