### PR TITLE
feat(python): Use setuptools-scm for dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ python/.venv/
 python/dist/
 python/build/
 python/src/vroom_csv/__pycache__/
+python/src/vroom_csv/_version.py
 python/tests/__pycache__/
 __pycache__/
 *.pyc

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11>=2.12"]
+requires = ["scikit-build-core>=0.10", "pybind11>=2.12", "setuptools-scm>=8"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "vroom-csv"
-version = "0.1.0"
+dynamic = ["version"]
 description = "High-performance CSV parser with SIMD acceleration"
 readme = "README.md"
 license = {text = "MIT"}
@@ -47,14 +47,20 @@ Issues = "https://github.com/jimhester/libvroom/issues"
 
 [tool.scikit-build]
 cmake.build-type = "Release"
-cmake.verbose = false
+build.verbose = false
 wheel.packages = ["src/vroom_csv"]
 build-dir = "build/{wheel_tag}"
 install.components = ["python"]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+sdist.include = ["src/vroom_csv/_version.py"]
 
 [tool.scikit-build.cmake.define]
 BUILD_TESTING = "OFF"
 BUILD_BENCHMARKS = "OFF"
+
+[tool.setuptools_scm]
+root = ".."
+write_to = "python/src/vroom_csv/_version.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/python/src/vroom_csv/__init__.py
+++ b/python/src/vroom_csv/__init__.py
@@ -46,9 +46,14 @@ from vroom_csv._core import (
     VroomError,
     ParseError,
     IOError,
-    __version__,
     LIBVROOM_VERSION,
 )
+
+# Version from setuptools-scm, with fallback to _core for editable installs
+try:
+    from vroom_csv._version import version as __version__
+except ImportError:
+    from vroom_csv._core import __version__
 
 
 def _format_bytes(num_bytes: int) -> str:


### PR DESCRIPTION
## Summary
- Switch from hard-coded version to setuptools-scm for automatic version derivation from git tags
- Fixes TestPyPI uploads which were failing with "400 Bad Request" because version 0.1.0 already existed

## Problem
The [TestPyPI publish step](https://github.com/jimhester/libvroom/actions/runs/20975956609/job/60292500122) was failing with:
```
WARNING Error during upload.
ERROR   HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
```

This is because version `0.1.0` already exists on TestPyPI, and PyPI doesn't allow re-uploading the same version.

## Solution
Instead of using `skip-existing: true` (which was suggested initially), this PR implements proper dynamic versioning using setuptools-scm. This approach:

1. Derives version automatically from git tags (e.g., `v0.1.0` → `0.1.0`)
2. Adds `.devN+gHASH` suffix for untagged commits (e.g., `0.1.0.dev3+g4d9ccc4`)
3. Ensures every push to main gets a unique version number

### Changes
- Add `setuptools-scm>=8` as build dependency
- Configure scikit-build-core to use `setuptools_scm` metadata provider
- Update `__init__.py` to import version from generated `_version.py`
- Add `_version.py` to `.gitignore` (auto-generated file)
- Fix deprecated `cmake.verbose` → `build.verbose` (bonus fix)

## References
- [scikit-build-core dynamic metadata docs](https://scikit-build-core.readthedocs.io/en/latest/configuration/dynamic.html)
- [setuptools-scm docs](https://setuptools-scm.readthedocs.io/)

Fixes #520

## Test plan
- [x] Local sdist build works: `vroom_csv-0.0.2.dev3+g4d9ccc4e5.d20260114.tar.gz`
- [ ] CI wheel builds succeed
- [ ] TestPyPI publish succeeds with dev version