### PR TITLE
fix(python): Use no-local-version scheme for PyPI compatibility

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -61,6 +61,9 @@ BUILD_BENCHMARKS = "OFF"
 [tool.setuptools_scm]
 root = ".."
 write_to = "python/src/vroom_csv/_version.py"
+# PyPI/TestPyPI reject local version identifiers (e.g., +g252d43bb0)
+# Using no-local-version produces versions like 0.1.dev1 instead of 0.1.dev1+g252d43bb0
+local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- Set `local_scheme = "no-local-version"` in setuptools_scm configuration to produce PyPI-compatible versions

## Problem
The previous setuptools-scm configuration (from PR #526) was still producing versions with local version identifiers like `0.1.dev1+g252d43bb0`. PyPI/TestPyPI reject these versions with:
```
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
```

Per [PEP 440](https://peps.python.org/pep-0440/#local-version-identifiers), local version identifiers (the `+XXX` suffix) cannot be uploaded to public package indexes.

## Solution
Set `local_scheme = "no-local-version"` in `[tool.setuptools_scm]` configuration. This produces versions like `0.1.dev9` instead of `0.1.dev9+g252d43bb0`.

Verified locally:
```
Successfully built vroom_csv-0.0.2.dev9.tar.gz
```

## References
- [setuptools-scm local_scheme docs](https://setuptools-scm.readthedocs.io/en/latest/usage/)
- [GitHub issue about this pattern](https://github.com/pypa/setuptools-scm/issues/478)

## Test plan
- [x] Local sdist build produces PyPI-compatible version (no `+` suffix)
- [ ] CI passes
- [ ] TestPyPI publish succeeds after merge