### PR TITLE
fix(fuzz): Fix build error and improve local fuzzing experience

### DIFF
--- a/fuzz/fuzz_csv_parser.cpp
+++ b/fuzz/fuzz_csv_parser.cpp
@@ -10,14 +10,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <memory>
-
-struct AlignedDeleter {
-  void operator()(uint8_t* ptr) const {
-    if (ptr)
-      aligned_free(ptr);
-  }
-};
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (size == 0)
@@ -29,8 +21,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     size = MAX_INPUT_SIZE;
 
   // Use immediate RAII to prevent leaks if an exception occurs
-  std::unique_ptr<uint8_t, AlignedDeleter> guard(
-      static_cast<uint8_t*>(aligned_malloc(64, size + 64)));
+  AlignedPtr guard = make_aligned_ptr(size, 64);
   if (!guard)
     return 0;
   uint8_t* buf = guard.get();

--- a/fuzz/fuzz_dialect_detection.cpp
+++ b/fuzz/fuzz_dialect_detection.cpp
@@ -3,36 +3,33 @@
  * @brief LibFuzzer target for fuzz testing dialect detection.
  */
 
-#include <cstdint>
-#include <cstddef>
-#include <cstring>
-#include <memory>
-
 #include "dialect.h"
 #include "mem_util.h"
 
-struct AlignedDeleter {
-    void operator()(uint8_t* ptr) const { if (ptr) aligned_free(ptr); }
-};
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-    if (size == 0) return 0;
-    // 16KB limit: Dialect detection only examines the first portion of data,
-    // so a smaller limit allows faster fuzzing without losing coverage
-    constexpr size_t MAX_INPUT_SIZE = 16 * 1024;
-    if (size > MAX_INPUT_SIZE) size = MAX_INPUT_SIZE;
-
-    // Use immediate RAII to prevent leaks if an exception occurs
-    std::unique_ptr<uint8_t, AlignedDeleter> guard(
-        static_cast<uint8_t*>(aligned_malloc(64, size + 64)));
-    if (!guard) return 0;
-    uint8_t* buf = guard.get();
-    std::memcpy(buf, data, size);
-    std::memset(buf + size, 0, 64);
-
-    libvroom::DialectDetector detector;
-    libvroom::DetectionResult result = detector.detect(buf, size);
-    (void)result.success();
-
+  if (size == 0)
     return 0;
+  // 16KB limit: Dialect detection only examines the first portion of data,
+  // so a smaller limit allows faster fuzzing without losing coverage
+  constexpr size_t MAX_INPUT_SIZE = 16 * 1024;
+  if (size > MAX_INPUT_SIZE)
+    size = MAX_INPUT_SIZE;
+
+  // Use immediate RAII to prevent leaks if an exception occurs
+  AlignedPtr guard = make_aligned_ptr(size, 64);
+  if (!guard)
+    return 0;
+  uint8_t* buf = guard.get();
+  std::memcpy(buf, data, size);
+  std::memset(buf + size, 0, 64);
+
+  libvroom::DialectDetector detector;
+  libvroom::DetectionResult result = detector.detect(buf, size);
+  (void)result.success();
+
+  return 0;
 }

--- a/fuzz/fuzz_parse_auto.cpp
+++ b/fuzz/fuzz_parse_auto.cpp
@@ -11,14 +11,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <memory>
-
-struct AlignedDeleter {
-  void operator()(uint8_t* ptr) const {
-    if (ptr)
-      aligned_free(ptr);
-  }
-};
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (size == 0)
@@ -30,8 +22,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     size = MAX_INPUT_SIZE;
 
   // Use immediate RAII to prevent leaks if an exception occurs
-  std::unique_ptr<uint8_t, AlignedDeleter> guard(
-      static_cast<uint8_t*>(aligned_malloc(64, size + 64)));
+  AlignedPtr guard = make_aligned_ptr(size, 64);
   if (!guard)
     return 0;
   uint8_t* buf = guard.get();


### PR DESCRIPTION
## Summary

- Fix build error: Remove duplicate `AlignedDeleter` definitions from fuzz targets that conflicted with `mem_util.h`'s `AlignedDeleter`
- Use `make_aligned_ptr()` helper from `mem_util.h` instead of custom allocation code
- Update fuzz README to recommend `/dev/shm` for RAM-backed fuzzing to avoid SSD wear during local testing

## Fuzz Testing Results

Ran extensive fuzz testing across all three targets:

| Target | Executions | Crashes |
|--------|------------|---------|
| `fuzz_csv_parser` | ~10M | 0 |
| `fuzz_dialect_detection` | ~14M | 0 |
| `fuzz_parse_auto` | ~6M | 0 |

**Total: ~30 million fuzzing iterations with no crashes found.**

### Validation

Introduced a deliberate crash bug to verify the fuzzing infrastructure catches real issues:
- Bug: Null pointer dereference when input contains "FUZZCRASH"
- Result: Fuzzer found crash in **236 iterations** and saved artifact
- Confirmed infrastructure is working correctly

## Test plan

- [x] All 2416 unit tests pass
- [x] Fuzz targets build successfully with Clang + ASan + UBSan
- [x] Fuzz testing runs without crashes
- [x] Validated fuzzer catches real bugs (deliberate bug test)

Fixes #511