### PR TITLE
fix(windows): Use cross-platform prefetch macro for MSVC compatibility

### DIFF
--- a/include/branchless_state_machine.h
+++ b/include/branchless_state_machine.h
@@ -610,7 +610,7 @@ second_pass_simd_branchless_with_state(const BranchlessStateMachine& sm, const u
 
   // Process 64-byte blocks
   for (; pos + 64 <= len; pos += 64) {
-    __builtin_prefetch(data + pos + 128);
+    libvroom_prefetch(data + pos + 128);
 
     simd_input in = fill_input(data + pos);
     count += process_block_simd_branchless(sm, in, 64, prev_quote_state, prev_escape_carry,


### PR DESCRIPTION
## Summary
- Replace direct `__builtin_prefetch` call with cross-platform `libvroom_prefetch` macro in `branchless_state_machine.h`
- The GCC/Clang-specific intrinsic was causing MSVC build failures during Python wheel builds on Windows

## Details
The `libvroom_prefetch` macro in `common_defs.h` already handles cross-platform prefetching:
- **MSVC**: Maps to `_mm_prefetch(addr, _MM_HINT_T0)`
- **GCC/Clang**: Maps to `__builtin_prefetch(addr)`

Fixes #538

## Test plan
- [x] Build passes locally (Linux, GCC)
- [x] All 2416 tests pass
- [ ] Windows CI (cibuildwheel) should now succeed