### PR TITLE
docs(python): Add Python package documentation with quartodoc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Jupyter dependencies
-        run: pip install jupyter nbformat nbclient
+      - name: Install Jupyter and quartodoc dependencies
+        run: pip install jupyter nbformat nbclient quartodoc
 
       - name: Install Doxygen
         run: sudo apt-get update && sudo apt-get install -y doxygen
@@ -51,6 +51,9 @@ jobs:
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target vroom-cli
+
+      - name: Install vroom-csv Python package
+        run: pip install ./python
 
       - name: Build documentation
         working-directory: docs

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ Thumbs.db
 # Documentation build output
 docs/_site/
 docs/api/
+docs/api-reference/
+docs/python-reference/
+docs/objects.json
 docs/.quarto/
 
 # Python

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -4,6 +4,10 @@ project:
   render:
     - "*.qmd"
     - "api-reference/**/*.qmd"
+    - "python-reference/**/*.qmd"
+
+metadata-files:
+  - python-reference/_sidebar.yml
 
 website:
   title: "libvroom"
@@ -27,20 +31,26 @@ website:
         href: caching.qmd
       - text: "C API"
         href: c-api.qmd
+      - text: "Python"
+        menu:
+          - text: "Python Package"
+            href: python.qmd
+          - text: "Python API Reference"
+            href: python-reference/index.qmd
       - text: "Architecture"
         href: architecture.qmd
       - text: "Error Handling"
         href: error-handling.qmd
       - text: "Benchmarks"
         href: benchmarks.qmd
-      - text: "API Reference"
+      - text: "C++ API Reference"
         href: api-reference/index.qmd
     right:
       - icon: github
         href: https://github.com/jimhester/libvroom
 
   page-footer:
-    center: "Built with [Quarto](https://quarto.org/) and [Doxygen](https://doxygen.nl/)"
+    center: "Built with [Quarto](https://quarto.org/), [Doxygen](https://doxygen.nl/), and [quartodoc](https://machow.github.io/quartodoc/)"
 
 format:
   html:
@@ -48,3 +58,40 @@ format:
     toc: true
     code-copy: true
     code-overflow: wrap
+
+quartodoc:
+  package: vroom_csv
+  dir: python-reference
+  title: Python API Reference
+  style: pkgdown
+  parser: numpy
+  sidebar: python-reference/_sidebar.yml
+  sections:
+    - title: Reading CSV Files
+      desc: Functions for reading CSV files
+      contents:
+        - read_csv
+        - read_csv_batched
+        - read_csv_rows
+    - title: Dialect Detection
+      desc: Detect CSV format automatically
+      contents:
+        - detect_dialect
+    - title: Data Classes
+      desc: Classes representing parsed CSV data
+      contents:
+        - Table
+        - RecordBatch
+        - BatchedReader
+        - RowIterator
+        - Dialect
+    - title: Utilities
+      desc: Utility functions and classes
+      contents:
+        - default_progress
+    - title: Exceptions
+      desc: Exception classes for error handling
+      contents:
+        - VroomError
+        - ParseError
+        - IOError

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build documentation: Doxygen -> doxybook2 -> Quarto
+# Build documentation: Doxygen -> doxybook2 -> quartodoc -> Quarto
 set -e
 
 cd "$(dirname "$0")"
@@ -16,10 +16,10 @@ doxybook2 --input api/xml --output api-reference --config .doxybook/config.json
 # Create index.qmd for API reference landing page
 cat > api-reference/index.qmd << 'EOF'
 ---
-title: "API Reference"
+title: "C++ API Reference"
 ---
 
-Complete API documentation for libvroom, generated from source code comments.
+Complete C++ API documentation for libvroom, generated from source code comments.
 
 ## Quick Links
 
@@ -46,6 +46,10 @@ Complete API documentation for libvroom, generated from source code comments.
 - [Namespaces](index_namespaces.qmd)
 - [Examples](index_examples.qmd)
 EOF
+
+echo "==> Running quartodoc (Python API)..."
+rm -rf python-reference
+quartodoc build
 
 echo "==> Running Quarto..."
 quarto render

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -36,6 +36,27 @@ The parser achieves **4+ GB/s throughput** on modern hardware using a speculativ
 
 ## Quick Start
 
+### Python
+
+```bash
+pip install vroom-csv
+```
+
+```python
+import vroom_csv
+
+table = vroom_csv.read_csv("data.csv")
+print(f"Loaded {table.num_rows} rows, {table.num_columns} columns")
+
+# Zero-copy export to PyArrow, Polars, DuckDB
+import polars as pl
+df = pl.from_arrow(table)
+```
+
+See the [Python Package](python.qmd) documentation for complete usage.
+
+### C++ / CLI
+
 ```bash
 # Clone and build
 git clone https://github.com/jimhester/libvroom.git
@@ -117,6 +138,7 @@ Learn more in the [Architecture](architecture.qmd) documentation.
 | [Streaming Parser](streaming.qmd) | Memory-efficient parsing for large files |
 | [Index Caching](caching.qmd) | Speed up repeated file reads |
 | [C API Reference](c-api.qmd) | C bindings for FFI integration |
+| [Python Package](python.qmd) | Python bindings with Arrow support |
 | [Architecture](architecture.qmd) | Two-pass algorithm details |
 | [Error Handling](error-handling.qmd) | Error modes and recovery |
 | [Integration Guide](integration-guide.qmd) | CMake integration and build options |

--- a/docs/python.qmd
+++ b/docs/python.qmd
@@ -1,0 +1,233 @@
+---
+title: "Python Package"
+subtitle: "vroom-csv: High-performance CSV parsing for Python"
+---
+
+## Overview
+
+The `vroom-csv` Python package provides Python bindings for the libvroom CSV parser, featuring:
+
+- **SIMD-accelerated parsing** using Google Highway
+- **Multi-threaded parsing** for large files
+- **Automatic dialect detection** (delimiter, quoting, line endings)
+- **Arrow PyCapsule interface** for zero-copy interoperability with PyArrow, Polars, DuckDB
+
+## Installation
+
+```bash
+pip install vroom-csv
+```
+
+### Optional Dependencies
+
+Install with Arrow support for zero-copy DataFrame interoperability:
+
+```bash
+pip install vroom-csv[arrow]    # PyArrow integration
+pip install vroom-csv[polars]   # Polars integration
+pip install vroom-csv[all]      # All optional dependencies
+```
+
+## Quick Start
+
+### Basic Usage
+
+```python
+import vroom_csv
+
+# Read a CSV file
+table = vroom_csv.read_csv("data.csv")
+print(f"Loaded {table.num_rows} rows, {table.num_columns} columns")
+
+# Access column names
+print(table.column_names)
+
+# Get a column by name or index
+col = table.column("name")
+col = table.column(0)
+
+# Get a row by index
+row = table.row(0)
+```
+
+### Dialect Detection
+
+```python
+# Detect CSV dialect (delimiter, quoting, etc.)
+dialect = vroom_csv.detect_dialect("data.csv")
+print(f"Delimiter: {dialect.delimiter!r}")
+print(f"Quote char: {dialect.quote_char!r}")
+print(f"Has header: {dialect.has_header}")
+print(f"Line ending: {dialect.line_ending!r}")
+print(f"Confidence: {dialect.confidence:.2f}")
+```
+
+### Progress Reporting
+
+```python
+# Show progress for large files
+table = vroom_csv.read_csv("large.csv", progress=vroom_csv.default_progress)
+```
+
+## Arrow Interoperability
+
+The `vroom-csv` package implements the [Arrow PyCapsule interface](https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html) for zero-copy data sharing with other Arrow-compatible libraries.
+
+### PyArrow
+
+```python
+import pyarrow as pa
+import vroom_csv
+
+# Zero-copy conversion to PyArrow Table
+table = vroom_csv.read_csv("data.csv")
+arrow_table = pa.table(table)
+
+# Export to Parquet
+import pyarrow.parquet as pq
+pq.write_table(arrow_table, "data.parquet")
+```
+
+### Polars
+
+```python
+import polars as pl
+import vroom_csv
+
+# Zero-copy conversion to Polars DataFrame
+table = vroom_csv.read_csv("data.csv")
+df = pl.from_arrow(table)
+
+# Use Polars operations
+result = df.select(["name", "value"]).filter(pl.col("value") > 100)
+```
+
+### DuckDB
+
+```python
+import duckdb
+import vroom_csv
+
+# Query CSV data with DuckDB
+table = vroom_csv.read_csv("data.csv")
+result = duckdb.query("SELECT * FROM table WHERE value > 100")
+```
+
+## Memory-Efficient Processing
+
+### Batched Reading
+
+For files too large to fit in memory, use batched reading:
+
+```python
+import vroom_csv
+
+# Process in batches of 10,000 rows
+for batch in vroom_csv.read_csv_batched("huge.csv", batch_size=10000):
+    print(f"Processing batch with {batch.num_rows} rows")
+    # Each batch supports Arrow interface
+    # df = pl.from_arrow(batch)
+```
+
+### Row-by-Row Streaming
+
+For minimal memory usage, iterate row by row:
+
+```python
+import vroom_csv
+
+# Stream rows one at a time
+for row in vroom_csv.read_csv_rows("huge.csv"):
+    # row is a dict: {"col1": "value1", "col2": "value2", ...}
+    print(row)
+```
+
+## Common Options
+
+### Column Selection
+
+```python
+# Read only specific columns (by name or index)
+table = vroom_csv.read_csv("data.csv", usecols=["name", "value"])
+table = vroom_csv.read_csv("data.csv", usecols=[0, 2, 5])
+```
+
+### Row Limits
+
+```python
+# Skip header rows and limit row count
+table = vroom_csv.read_csv("data.csv", skip_rows=2, n_rows=1000)
+```
+
+### Null Value Handling
+
+```python
+# Custom null value strings
+table = vroom_csv.read_csv(
+    "data.csv",
+    null_values=["NA", "NULL", "N/A", ""],
+    empty_is_null=True
+)
+```
+
+### Multi-threaded Parsing
+
+```python
+# Use multiple threads for faster parsing
+table = vroom_csv.read_csv("large.csv", num_threads=4)
+```
+
+### Memory Mapping
+
+```python
+# Force memory mapping for large files
+table = vroom_csv.read_csv("huge.csv", memory_map=True)
+
+# Disable memory mapping (loads entire file into memory)
+table = vroom_csv.read_csv("data.csv", memory_map=False)
+```
+
+## Error Handling
+
+```python
+import vroom_csv
+
+try:
+    table = vroom_csv.read_csv("data.csv")
+except vroom_csv.ParseError as e:
+    print(f"Parse error: {e}")
+except vroom_csv.IOError as e:
+    print(f"I/O error: {e}")
+except vroom_csv.VroomError as e:
+    print(f"General error: {e}")
+
+# Check for non-fatal parse errors
+if table.has_errors():
+    print(table.error_summary())
+    for error in table.errors():
+        print(f"  - {error}")
+```
+
+## API Reference
+
+See the [Python API Reference](python-reference/index.qmd) for complete documentation of all functions and classes.
+
+## Performance
+
+The `vroom-csv` package achieves high performance through:
+
+- **SIMD acceleration**: Uses AVX2/NEON instructions for parallel processing
+- **Multi-threaded parsing**: Divides large files across CPU cores
+- **Memory mapping**: Avoids copying file data when possible
+- **Zero-copy Arrow**: Shares data with other libraries without copying
+
+Typical throughput on modern hardware:
+
+| File Size | Single-threaded | Multi-threaded (4 cores) |
+|-----------|-----------------|--------------------------|
+| 10 MB | 3+ GB/s | 5+ GB/s |
+| 100 MB | 4+ GB/s | 6+ GB/s |
+
+## Source Code
+
+The Python package source is in the [`python/`](https://github.com/jimhester/libvroom/tree/main/python) directory of the libvroom repository.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 test = ["pytest>=7.0", "pytest-cov>=4.0", "pyarrow>=14.0"]
 arrow = ["pyarrow>=14.0"]
 polars = ["polars>=0.20"]
+all = ["pyarrow>=14.0", "polars>=0.20"]
 benchmark = ["pandas>=2.0", "polars>=0.20", "pyarrow>=14.0", "duckdb>=0.9"]
 dev = ["pytest>=7.0", "pyarrow>=14.0", "polars>=0.20", "ruff", "mypy"]
 


### PR DESCRIPTION
## Summary

- Integrates Python API documentation into the libvroom documentation site using quartodoc
- Adds Python package getting started guide at `docs/python.qmd`
- Updates navbar with Python dropdown menu (Package guide + API reference)
- Updates home page with Python quick start example
- Adds `all` optional dependency to pyproject.toml for convenience

## Changes

1. **CI workflow** (`.github/workflows/docs.yml`): Installs quartodoc and vroom-csv package before building docs
2. **Quarto config** (`docs/_quarto.yml`): Adds quartodoc configuration and Python nav menu
3. **Build script** (`docs/build.sh`): Runs quartodoc before Quarto render
4. **Home page** (`docs/index.qmd`): Adds Python quick start section
5. **New file** (`docs/python.qmd`): Comprehensive Python package documentation
6. **Python package** (`python/pyproject.toml`): Adds `all` optional dependency

## Test plan

- [ ] CI passes (docs workflow builds successfully)
- [ ] Python API reference pages are generated correctly
- [ ] Navigation includes Python dropdown with package guide and API reference
- [ ] Links in documentation work correctly

Closes #512