### PR TITLE
feat(api): Add byte_offset_to_location for O(log n) reverse lookup

### DIFF
--- a/include/libvroom.h
+++ b/include/libvroom.h
@@ -1824,6 +1824,64 @@ public:
      * @return Const reference to the internal ErrorCollector.
      */
     const ErrorCollector& error_collector() const { return error_collector_; }
+
+    // =====================================================================
+    // Byte Offset Lookup API
+    // =====================================================================
+
+    /**
+     * @brief Result of a byte offset to (row, column) lookup.
+     *
+     * Location represents the result of finding which CSV cell contains
+     * a given byte offset. This enables efficient error reporting by
+     * converting internal byte positions to human-readable row/column
+     * coordinates.
+     */
+    struct Location {
+      size_t row;    ///< 0-based row index (row 0 = header if present, else first data row)
+      size_t column; ///< 0-based column index
+      bool found;    ///< true if byte offset is within valid CSV data
+
+      /// @return true if the location is valid (found == true)
+      explicit operator bool() const { return found; }
+    };
+
+    /**
+     * @brief Convert a byte offset to (row, column) coordinates.
+     *
+     * Uses binary search on the internal index for O(log n) lookup instead of
+     * O(n) linear scan. This is useful for error reporting when you have a
+     * byte offset from parsing and need to display the location to users.
+     *
+     * The row number returned is 0-based and includes the header row (if present).
+     * So row 0 is the header (if has_header() is true), row 1 is the first data row.
+     * If has_header() is false, row 0 is the first data row.
+     *
+     * @param byte_offset Byte offset into the CSV buffer
+     * @return Location with row/column if found, or {0, 0, false} if offset is
+     *         out of range or no data exists
+     *
+     * @note Complexity: O(log n) where n is the number of fields in the CSV
+     *
+     * @example
+     * @code
+     * auto result = parser.parse(buf, len);
+     *
+     * // Convert byte offset 150 to row/column
+     * auto loc = result.byte_offset_to_location(150);
+     * if (loc) {
+     *     std::cout << "Row " << loc.row << ", Column " << loc.column << std::endl;
+     * }
+     * @endcode
+     */
+    Location byte_offset_to_location(size_t byte_offset) const {
+      ensure_extractor();
+      if (!extractor_) {
+        return {0, 0, false};
+      }
+      auto ve_loc = extractor_->byte_offset_to_location(byte_offset);
+      return {ve_loc.row, ve_loc.column, ve_loc.found};
+    }
   };
 
   /**

--- a/include/value_extraction.h
+++ b/include/value_extraction.h
@@ -313,6 +313,54 @@ public:
   const ExtractionConfig& config() const { return config_; }
   void set_config(const ExtractionConfig& config) { config_ = config; }
 
+  /**
+   * @brief Result of a byte offset to (row, column) lookup.
+   *
+   * Location represents the result of finding which CSV cell contains
+   * a given byte offset. This enables efficient error reporting by
+   * converting internal byte positions to human-readable row/column
+   * coordinates.
+   */
+  struct Location {
+    size_t row;    ///< 0-based row index (data rows, header is row 0 if present)
+    size_t column; ///< 0-based column index
+    bool found;    ///< true if byte offset is within valid CSV data
+
+    /// @return true if the location is valid (found == true)
+    explicit operator bool() const { return found; }
+  };
+
+  /**
+   * @brief Convert a byte offset to (row, column) coordinates.
+   *
+   * Uses binary search on the internal index for O(log n) lookup instead of
+   * O(n) linear scan. This is useful for error reporting when you have a
+   * byte offset from parsing and need to display the location to users.
+   *
+   * The row number returned is 0-based and includes the header row (if present).
+   * So row 0 is the header (if has_header() is true), row 1 is the first data row.
+   * If has_header() is false, row 0 is the first data row.
+   *
+   * @param byte_offset Byte offset into the CSV buffer
+   * @return Location with row/column if found, or {0, 0, false} if offset is
+   *         out of range or no data exists
+   *
+   * @note Complexity: O(log n) where n is the number of fields in the CSV
+   *
+   * @example
+   * @code
+   * auto result = parser.parse(buf, len);
+   * ValueExtractor extractor(buf, len, result.idx);
+   *
+   * // Convert byte offset 150 to row/column
+   * auto loc = extractor.byte_offset_to_location(150);
+   * if (loc) {
+   *     std::cout << "Row " << loc.row << ", Column " << loc.column << std::endl;
+   * }
+   * @endcode
+   */
+  Location byte_offset_to_location(size_t byte_offset) const;
+
 private:
   const uint8_t* buf_;
   size_t len_;

--- a/src/value_extraction.cpp
+++ b/src/value_extraction.cpp
@@ -249,4 +249,32 @@ bool ValueExtractor::get_field_bounds(size_t row, size_t col, size_t& start, siz
   return true;
 }
 
+ValueExtractor::Location ValueExtractor::byte_offset_to_location(size_t byte_offset) const {
+  // Handle edge cases
+  if (linear_indexes_.empty() || num_columns_ == 0) {
+    return {0, 0, false};
+  }
+
+  // If byte_offset is beyond the last separator, it's out of range
+  if (byte_offset > linear_indexes_.back()) {
+    return {0, 0, false};
+  }
+
+  // Binary search to find the first separator >= byte_offset
+  // This is the separator that ends the field containing byte_offset
+  auto it = std::lower_bound(linear_indexes_.begin(), linear_indexes_.end(), byte_offset);
+
+  // If byte_offset equals a separator position, it's at a field boundary
+  // We consider the separator to belong to the field it ends
+  size_t field_index = static_cast<size_t>(it - linear_indexes_.begin());
+
+  // Convert field index to row/column
+  // linear_indexes_ contains all separators in row-major order
+  // Each row has num_columns_ fields (and therefore num_columns_ separators)
+  size_t row = field_index / num_columns_;
+  size_t col = field_index % num_columns_;
+
+  return {row, col, true};
+}
+
 } // namespace libvroom


### PR DESCRIPTION
## Summary

- Adds efficient byte offset to (row, column) coordinate conversion using binary search on the internal field index
- Enables error reporting to convert internal byte positions to human-readable row/column coordinates without O(n) linear scan
- Uses `std::lower_bound` on `linear_indexes_` for O(log n) lookup complexity
- Returns a `Location` struct with `row`, `column`, and `found` status for safe handling
- Exposed at both `ValueExtractor` and `Parser::Result` levels for flexibility

## Test plan

- [x] Added 10 comprehensive unit tests in `ByteOffsetToLocationTest` covering:
  - Simple CSV with header and data rows
  - Multiple rows and columns
  - Beyond-end offsets returning not-found
  - Separator positions
  - Empty CSV edge case
  - Single field CSV
  - Quoted fields
  - Boolean conversion operator
  - Result API access
  - Larger CSV (100 rows × 5 columns) for binary search effectiveness
- [x] All 2454 existing tests pass
- [x] Build passes with no warnings

Closes #564