### PR TITLE
feat(index): Add column-major index layout for ALTREP-style access

### DIFF
--- a/include/libvroom.h
+++ b/include/libvroom.h
@@ -2100,6 +2100,42 @@ public:
      */
     bool is_flat() const { return idx.is_flat(); }
 
+    /**
+     * @brief Build a column-major index for cache-friendly column iteration.
+     *
+     * Reorganizes the field positions into column-major order for optimal cache
+     * locality when iterating through columns sequentially (ALTREP-style access).
+     *
+     * @param n_threads Number of threads to use for building (default: 1).
+     *
+     * @see is_column_major() to check if the column-major index is available
+     * @see column_data() for O(1) access to column separator positions
+     */
+    void build_column_index(size_t n_threads = 1) { idx.build_column_index(n_threads); }
+
+    /**
+     * @brief Check if the index has a column-major layout for cache-friendly iteration.
+     *
+     * Returns true if the column-major index has been built via build_column_index().
+     *
+     * @return true if the index has column-major layout, false otherwise.
+     *
+     * @see build_column_index() to build the column-major layout
+     */
+    bool is_column_major() const { return idx.is_column_major(); }
+
+    /**
+     * @brief Get the number of data rows from the index.
+     *
+     * Returns the number of rows computed during build_column_index().
+     * This is calculated as total_indexes / columns.
+     *
+     * @return Number of data rows, or 0 if column-major index not built.
+     *
+     * @note This is distinct from num_rows() which applies row filtering.
+     */
+    uint64_t index_nrows() const { return idx.nrows; }
+
     // =====================================================================
     // Row/Column Iteration API
     // =====================================================================

--- a/src/libvroom_c.cpp
+++ b/src/libvroom_c.cpp
@@ -511,6 +511,24 @@ bool libvroom_index_is_flat(const libvroom_index_t* index) {
   return index->idx.is_flat();
 }
 
+void libvroom_index_build_column_index(libvroom_index_t* index, size_t n_threads) {
+  if (index) {
+    index->idx.build_column_index(n_threads);
+  }
+}
+
+bool libvroom_index_is_column_major(const libvroom_index_t* index) {
+  if (!index)
+    return false;
+  return index->idx.is_column_major();
+}
+
+uint64_t libvroom_index_get_nrows(const libvroom_index_t* index) {
+  if (!index)
+    return 0;
+  return index->idx.nrows;
+}
+
 libvroom_error_t libvroom_index_write(const libvroom_index_t* index, const char* filename) {
   if (!index || !filename)
     return LIBVROOM_ERROR_NULL_POINTER;


### PR DESCRIPTION
## Summary

Adds a column-major index layout optimized for cache-friendly sequential column iteration, which is the primary access pattern for R's ALTREP lazy columns.

- The row-major flat index (from #593) provides O(1) random field access but has poor cache locality when iterating through all values in a column
- The new column-major layout stores separator positions grouped by column: `col_indexes[col * nrows + row] = separator position`
- Build operation is parallelizable by columns with no write contention

Key additions:
- `ParseIndex::build_column_index(n_threads)` - builds column-major layout
- `ParseIndex::is_column_major()` - checks if column-major index available  
- `ParseIndex::column_data(col)` - returns IndexView for a column
- `ParseIndex::nrows` - number of data rows

API coverage:
- C++ core in `two_pass.h`
- C API: `libvroom_index_build_column_index()`, `libvroom_index_is_column_major()`, `libvroom_index_get_nrows()`
- Python: `Table.build_column_index()`, `Table.is_column_major()`, `Table.nrows()`
- Parser::Result delegation methods in `libvroom.h`

Closes #592

## Test plan

- [x] 9 new unit tests for column-major index functionality
- [x] All 2616 existing tests pass
- [x] Tests cover single/multi-threaded builds, idempotency, edge cases, move semantics, and data consistency