### PR TITLE
feat(api): Add byte_offset_to_location to C API and Python bindings

### DIFF
--- a/include/libvroom_c.h
+++ b/include/libvroom_c.h
@@ -456,6 +456,23 @@ typedef struct libvroom_field_span {
   uint64_t end;
 } libvroom_field_span_t;
 
+/**
+ * @brief Result of byte offset to location conversion.
+ *
+ * Contains the row and column indices corresponding to a byte offset,
+ * and a flag indicating whether the location was found.
+ */
+typedef struct libvroom_location {
+  /** @brief 0-based row index. */
+  size_t row;
+
+  /** @brief 0-based column index. */
+  size_t column;
+
+  /** @brief true if the byte offset was found within a valid field. */
+  bool found;
+} libvroom_location_t;
+
 /** @} */ /* end of structs group */
 
 /**
@@ -1015,6 +1032,36 @@ libvroom_field_span_t libvroom_index_get_field_span(const libvroom_index_t* inde
  */
 libvroom_field_span_t libvroom_index_get_field_span_rc(const libvroom_index_t* index, uint64_t row,
                                                        uint64_t col);
+
+/**
+ * @brief Convert a byte offset to row/column location.
+ *
+ * Given a byte offset into the CSV data, finds which row and column
+ * contain that byte offset. This is useful for error reporting, where
+ * you have a byte position and need to report the logical location.
+ *
+ * @param index The index to query. Must not be NULL and must be populated.
+ * @param byte_offset Byte offset into the CSV data.
+ * @return libvroom_location_t with row, column, and found flag.
+ *         If the byte offset is beyond all indexed fields, found will be false.
+ *
+ * @note Complexity: O(n) where n is the total number of fields. This is
+ *       designed for occasional use (e.g., error reporting), not for
+ *       high-frequency access patterns.
+ *
+ * @example
+ * @code
+ * // Find which row/column contains byte offset 150
+ * libvroom_location_t loc = libvroom_index_byte_offset_to_location(index, 150);
+ * if (loc.found) {
+ *     printf("Byte 150 is at row %zu, column %zu\n", loc.row, loc.column);
+ * } else {
+ *     printf("Byte 150 is beyond the indexed data\n");
+ * }
+ * @endcode
+ */
+libvroom_location_t libvroom_index_byte_offset_to_location(const libvroom_index_t* index,
+                                                            size_t byte_offset);
 
 /** @} */ /* end of index group */
 

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -1122,6 +1122,15 @@ public:
   // Check if the index is compacted for O(1) access
   bool is_flat() const { return data_->result.is_flat(); }
 
+  // Convert byte offset to row/column location
+  py::object byte_offset_to_location(size_t byte_offset) const {
+    auto loc = data_->result.byte_offset_to_location(byte_offset);
+    if (loc.found) {
+      return py::make_tuple(loc.row, loc.column);
+    }
+    return py::none();
+  }
+
 private:
   std::shared_ptr<TableData> data_;
 };
@@ -2614,6 +2623,33 @@ Returns
 -------
 bool
     True if the index has O(1) field access, False otherwise.
+)doc")
+      .def("byte_offset_to_location", &Table::byte_offset_to_location, py::arg("byte_offset"),
+           R"doc(
+Convert a byte offset to row/column location.
+
+Given a byte offset into the CSV data, returns the row and column indices
+of the field containing that byte offset. This is useful for mapping error
+positions (reported as byte offsets) back to logical row/column locations.
+
+Parameters
+----------
+byte_offset : int
+    Byte offset into the CSV data.
+
+Returns
+-------
+tuple[int, int] or None
+    A tuple of (row, column) if the byte offset is within the indexed data,
+    or None if the byte offset is beyond all indexed fields.
+
+Examples
+--------
+>>> table = vroom_csv.read_csv("data.csv")
+>>> loc = table.byte_offset_to_location(150)
+>>> if loc:
+...     row, col = loc
+...     print(f"Byte 150 is at row {row}, column {col}")
 )doc");
 
   // RowIterator class for streaming row-by-row iteration

--- a/src/libvroom_c.cpp
+++ b/src/libvroom_c.cpp
@@ -1395,6 +1395,44 @@ libvroom_field_span_t libvroom_index_get_field_span_rc(const libvroom_index_t* i
   return result;
 }
 
+libvroom_location_t libvroom_index_byte_offset_to_location(const libvroom_index_t* index,
+                                                            size_t byte_offset) {
+  libvroom_location_t not_found = {0, 0, false};
+
+  if (!index) {
+    return not_found;
+  }
+
+  // Use the ValueExtractor's byte_offset_to_location logic directly
+  // Since we don't have a ValueExtractor here, implement the logic inline
+  uint64_t total_indexes = index->idx.total_indexes();
+  size_t num_columns = index->idx.columns;
+
+  if (total_indexes == 0 || num_columns == 0) {
+    return not_found;
+  }
+
+  // Linear search through fields to find which one contains the byte offset
+  for (uint64_t i = 0; i < total_indexes; ++i) {
+    libvroom::FieldSpan span = index->idx.get_field_span(i);
+    if (!span.is_valid())
+      continue;
+
+    // Check if byte_offset falls within this field's bounds
+    if (byte_offset <= span.end) {
+      // Found the field containing this byte offset
+      libvroom_location_t result;
+      result.row = i / num_columns;
+      result.column = i % num_columns;
+      result.found = true;
+      return result;
+    }
+  }
+
+  // Byte offset is beyond the last field
+  return not_found;
+}
+
 // ============================================================================
 // Lazy Column Functions
 // ============================================================================


### PR DESCRIPTION
Expose the existing byte_offset_to_location functionality from the C++
Parser::Result class to both the C API and Python bindings. This enables
FFI consumers to convert byte offsets (from error messages) to logical
row/column positions.

C API changes:
- Add libvroom_location_t struct with row, column, and found fields
- Add libvroom_index_byte_offset_to_location() function

Python changes:
- Add Table.byte_offset_to_location() method returning tuple or None

Closes #570