### PR TITLE
perf(benchmark): Add sequential vs strided write pattern benchmarks

### DIFF
--- a/benchmark/basic_benchmarks.cpp
+++ b/benchmark/basic_benchmarks.cpp
@@ -162,3 +162,129 @@ static void BM_IndexCreationCounted(benchmark::State& state) {
 BENCHMARK(BM_IndexCreationCounted)
     ->Ranges({{1024, 1024 * 1024 * 100}, {1, 16}}) // File sizes 1KB-100MB, threads 1-16
     ->Unit(benchmark::kMicrosecond);
+
+// ============================================================================
+// Write Pattern Benchmarks: Sequential vs Strided
+// ============================================================================
+// These benchmarks measure the cache penalty of different memory access patterns
+// when writing index data during CSV parsing.
+//
+// Context: When parsing CSV, we need to store field offsets. Two layouts:
+// - Row-major (current): fields stored sequentially per row [r0c0, r0c1, r0c2, r1c0, ...]
+// - Column-major (ALTREP): fields stored by column [r0c0, r1c0, r2c0, ..., r0c1, r1c1, ...]
+//
+// Row-major writes sequentially during parsing (cache-friendly).
+// Column-major requires strided writes during parsing (potentially cache-hostile).
+
+// Write to contiguous memory (simulates row-major index construction)
+// This is the current approach: fields are written sequentially as rows are parsed
+static void BM_WriteSequential(benchmark::State& state) {
+  const size_t rows = static_cast<size_t>(state.range(0));
+  const size_t cols = static_cast<size_t>(state.range(1));
+  const size_t total_elements = rows * cols;
+  const size_t total_bytes = total_elements * sizeof(uint64_t);
+
+  // Allocate aligned memory
+  auto* data = static_cast<uint64_t*>(aligned_malloc(64, total_bytes));
+  if (!data) {
+    state.SkipWithError("Failed to allocate memory");
+    return;
+  }
+
+  for (auto _ : state) {
+    // Sequential write: iterate through memory linearly
+    // Simulates writing field offsets as we parse row-by-row
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = i; // Simple value to avoid optimizer removing the write
+    }
+    benchmark::ClobberMemory();
+  }
+
+  aligned_free(data);
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_bytes * state.iterations()));
+  state.counters["Rows"] = static_cast<double>(rows);
+  state.counters["Cols"] = static_cast<double>(cols);
+  state.counters["TotalMB"] = static_cast<double>(total_bytes) / (1024.0 * 1024.0);
+  state.counters["GB/s"] = benchmark::Counter(static_cast<double>(total_bytes),
+                                              benchmark::Counter::kIsIterationInvariantRate,
+                                              benchmark::Counter::kIs1024);
+}
+
+// Write with stride (simulates column-major index construction during parsing)
+// When parsing row-by-row but storing column-major, each field write jumps by stride
+// Stride = rows * sizeof(uint64_t) bytes between consecutive fields in a row
+static void BM_WriteStrided(benchmark::State& state) {
+  const size_t rows = static_cast<size_t>(state.range(0));
+  const size_t cols = static_cast<size_t>(state.range(1));
+  const size_t total_elements = rows * cols;
+  const size_t total_bytes = total_elements * sizeof(uint64_t);
+  const size_t stride = rows; // In elements (stride in bytes = rows * 8)
+
+  // Allocate aligned memory
+  auto* data = static_cast<uint64_t*>(aligned_malloc(64, total_bytes));
+  if (!data) {
+    state.SkipWithError("Failed to allocate memory");
+    return;
+  }
+
+  for (auto _ : state) {
+    // Strided write: for each row, write fields with stride between columns
+    // Memory layout is column-major: [col0: r0,r1,r2,...][col1: r0,r1,r2,...]
+    // But we parse row-by-row, so row 0 writes to positions 0, stride, 2*stride, ...
+    for (size_t row = 0; row < rows; ++row) {
+      for (size_t col = 0; col < cols; ++col) {
+        // Column-major index: col * rows + row
+        data[col * stride + row] = row * cols + col;
+      }
+    }
+    benchmark::ClobberMemory();
+  }
+
+  aligned_free(data);
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_bytes * state.iterations()));
+  state.counters["Rows"] = static_cast<double>(rows);
+  state.counters["Cols"] = static_cast<double>(cols);
+  state.counters["TotalMB"] = static_cast<double>(total_bytes) / (1024.0 * 1024.0);
+  state.counters["StrideBytes"] = static_cast<double>(stride * sizeof(uint64_t));
+  state.counters["GB/s"] = benchmark::Counter(static_cast<double>(total_bytes),
+                                              benchmark::Counter::kIsIterationInvariantRate,
+                                              benchmark::Counter::kIs1024);
+}
+
+// Test matrix: Rows x Cols
+// Rows: 10K, 100K, 1M (to see how working set size affects cache behavior)
+// Cols: 10, 100, 500 (typical CSV column counts)
+//
+// Working set sizes:
+// - 10K rows × 10 cols = 800KB (fits in L3)
+// - 10K rows × 100 cols = 8MB (borderline L3)
+// - 10K rows × 500 cols = 40MB (exceeds L3)
+// - 100K rows × 10 cols = 8MB (borderline L3)
+// - 100K rows × 100 cols = 80MB (exceeds L3)
+// - 100K rows × 500 cols = 400MB (way exceeds L3)
+// - 1M rows × 10 cols = 80MB (exceeds L3)
+// - 1M rows × 100 cols = 800MB (way exceeds L3)
+// - 1M rows × 500 cols = 4GB (very large)
+
+static void WriteSequentialArgs(benchmark::internal::Benchmark* b) {
+  // Rows: 10K, 100K, 1M; Cols: 10, 100, 500
+  for (int64_t rows : {10000, 100000, 1000000}) {
+    for (int64_t cols : {10, 100, 500}) {
+      b->Args({rows, cols});
+    }
+  }
+}
+
+static void WriteStridedArgs(benchmark::internal::Benchmark* b) {
+  // Same matrix as sequential for direct comparison
+  for (int64_t rows : {10000, 100000, 1000000}) {
+    for (int64_t cols : {10, 100, 500}) {
+      b->Args({rows, cols});
+    }
+  }
+}
+
+BENCHMARK(BM_WriteSequential)->Apply(WriteSequentialArgs)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_WriteStrided)->Apply(WriteStridedArgs)->Unit(benchmark::kMillisecond);


### PR DESCRIPTION
## Summary
- Add `BM_WriteSequential` benchmark measuring contiguous memory writes (current row-major approach)
- Add `BM_WriteStrided` benchmark measuring strided writes (simulating column-major construction during parsing)
- Test matrix: rows (10K, 100K, 1M) × cols (10, 100, 500) covering working sets from 800KB to 4GB

## Context

Part of #599 - evaluating index layout strategies for ALTREP integration.

When parsing CSV row-by-row:
- **Row-major index**: writes are sequential (cache-friendly)
- **Column-major index**: writes are strided by `rows × 8 bytes` (potentially cache-hostile)

## Initial Results

| Rows | Cols | Sequential | Strided | Slowdown |
|------|------|------------|---------|----------|
| 10K  | 10   | 60 GB/s    | 24 GB/s | 2.5x     |
| 10K  | 100  | 38 GB/s    | 17 GB/s | 2.3x     |
| 10K  | 500  | 17 GB/s    | 3.2 GB/s| **5.3x** |
| 100K | 10   | 37 GB/s    | 21 GB/s | 1.8x     |
| 100K | 100  | 15 GB/s    | 12 GB/s | 1.2x     |
| 100K | 500  | 11 GB/s    | 2.6 GB/s| **4.3x** |
| 1M   | 10   | 13 GB/s    | 16 GB/s | 0.9x ⚡  |
| 1M   | 100  | 9 GB/s     | 4.2 GB/s| 2.2x     |
| 1M   | 500  | 2.2 GB/s   | 1.5 GB/s| 1.5x     |

**Key findings:**
- Slowdown is 1.2x-5.3x, more moderate than hypothesized 10-50x
- Penalty is highest with many columns (500 cols)
- With 1M rows × 10 cols, strided is actually faster (better cache line utilization)

## Test plan
- [x] Benchmarks compile and run
- [x] Results show clear comparison between write patterns
- [ ] Add results summary to #599

Closes #601