### PR TITLE
feat(index): Add column-major index layout for ALTREP/Arrow access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -622,6 +622,23 @@ target_include_directories(quote_mask_test PRIVATE
 
 gtest_discover_tests(quote_mask_test)
 
+# Column-major index test executable
+add_executable(column_major_test
+    test/column_major_test.cpp
+)
+
+target_link_libraries(column_major_test PRIVATE
+    vroom
+    GTest::gtest_main
+    pthread
+)
+
+target_include_directories(column_major_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+gtest_discover_tests(column_major_test)
+
 # Value extraction test executable
 add_executable(value_extraction_test
     test/value_extraction_test.cpp

--- a/benchmark/transpose_benchmarks.cpp
+++ b/benchmark/transpose_benchmarks.cpp
@@ -16,6 +16,15 @@
 #include <thread>
 #include <vector>
 
+// SIMD headers
+#ifdef __x86_64__
+#include <immintrin.h>
+#endif
+
+#ifdef __aarch64__
+#include <arm_neon.h>
+#endif
+
 /**
  * @brief Single-threaded transpose from row-major to column-major.
  *
@@ -143,6 +152,213 @@ static void transpose_blocked_multi_threaded(const uint64_t* row_major, uint64_t
     t.join();
   }
 }
+
+// =============================================================================
+// SIMD Transpose Implementations
+// =============================================================================
+
+/**
+ * @brief Column-first scalar transpose (sequential writes, strided reads).
+ *
+ * This is the opposite loop order from transpose_single_threaded().
+ * Hypothesis: Sequential writes are more important than sequential reads
+ * because write buffers can coalesce and memory write bandwidth is the bottleneck.
+ */
+static void transpose_column_first_scalar(const uint64_t* row_major, uint64_t* col_major,
+                                          size_t rows, size_t cols) {
+  for (size_t col = 0; col < cols; ++col) {
+    for (size_t row = 0; row < rows; ++row) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+  }
+}
+
+#ifdef __x86_64__
+/**
+ * @brief SIMD 4x4 block transpose using AVX2.
+ *
+ * Processes 4 rows x 4 columns at a time using AVX2 intrinsics.
+ * Uses unpack and permute instructions to transpose in registers.
+ */
+static void transpose_simd_4x4_block(const uint64_t* row_major, uint64_t* col_major, size_t rows,
+                                     size_t cols) {
+  // Process 4x4 blocks
+  size_t row_blocks = rows / 4;
+  size_t col_blocks = cols / 4;
+
+  for (size_t rb = 0; rb < row_blocks; ++rb) {
+    for (size_t cb = 0; cb < col_blocks; ++cb) {
+      size_t row_base = rb * 4;
+      size_t col_base = cb * 4;
+
+      // Load 4 rows (each row has 4 contiguous elements for these columns)
+      __m256i r0 = _mm256_loadu_si256(
+          reinterpret_cast<const __m256i*>(&row_major[(row_base + 0) * cols + col_base]));
+      __m256i r1 = _mm256_loadu_si256(
+          reinterpret_cast<const __m256i*>(&row_major[(row_base + 1) * cols + col_base]));
+      __m256i r2 = _mm256_loadu_si256(
+          reinterpret_cast<const __m256i*>(&row_major[(row_base + 2) * cols + col_base]));
+      __m256i r3 = _mm256_loadu_si256(
+          reinterpret_cast<const __m256i*>(&row_major[(row_base + 3) * cols + col_base]));
+
+      // Step 1: Interleave within 128-bit lanes
+      __m256i t0 = _mm256_unpacklo_epi64(r0, r1); // [a00, a10, a02, a12]
+      __m256i t1 = _mm256_unpackhi_epi64(r0, r1); // [a01, a11, a03, a13]
+      __m256i t2 = _mm256_unpacklo_epi64(r2, r3); // [a20, a30, a22, a32]
+      __m256i t3 = _mm256_unpackhi_epi64(r2, r3); // [a21, a31, a23, a33]
+
+      // Step 2: Permute across 128-bit lanes
+      __m256i o0 = _mm256_permute2x128_si256(t0, t2, 0x20); // [a00, a10, a20, a30]
+      __m256i o1 = _mm256_permute2x128_si256(t1, t3, 0x20); // [a01, a11, a21, a31]
+      __m256i o2 = _mm256_permute2x128_si256(t0, t2, 0x31); // [a02, a12, a22, a32]
+      __m256i o3 = _mm256_permute2x128_si256(t1, t3, 0x31); // [a03, a13, a23, a33]
+
+      // Store 4 columns (each column has 4 contiguous elements for these rows)
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(&col_major[(col_base + 0) * rows + row_base]),
+                          o0);
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(&col_major[(col_base + 1) * rows + row_base]),
+                          o1);
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(&col_major[(col_base + 2) * rows + row_base]),
+                          o2);
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(&col_major[(col_base + 3) * rows + row_base]),
+                          o3);
+    }
+  }
+
+  // Handle remaining columns (not divisible by 4)
+  for (size_t col = col_blocks * 4; col < cols; ++col) {
+    for (size_t row = 0; row < rows; ++row) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+  }
+
+  // Handle remaining rows (not divisible by 4)
+  for (size_t row = row_blocks * 4; row < rows; ++row) {
+    for (size_t col = 0; col < col_blocks * 4; ++col) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+  }
+}
+
+/**
+ * @brief Scalar gather + SIMD store.
+ *
+ * Load 4 scalars from strided positions, pack into SIMD register, store sequentially.
+ * Hypothesis: Sequential stores are the bottleneck, so optimize stores even if
+ * loads are scalar.
+ */
+static void transpose_scalar_gather_simd_store(const uint64_t* row_major, uint64_t* col_major,
+                                               size_t rows, size_t cols) {
+  for (size_t col = 0; col < cols; ++col) {
+    size_t row = 0;
+
+    // Process 4 rows at a time with SIMD stores
+    for (; row + 4 <= rows; row += 4) {
+      // Scalar gather from strided positions
+      uint64_t v0 = row_major[(row + 0) * cols + col];
+      uint64_t v1 = row_major[(row + 1) * cols + col];
+      uint64_t v2 = row_major[(row + 2) * cols + col];
+      uint64_t v3 = row_major[(row + 3) * cols + col];
+
+      // Pack into SIMD register and store sequentially
+      __m256i v = _mm256_set_epi64x(static_cast<long long>(v3), static_cast<long long>(v2),
+                                    static_cast<long long>(v1), static_cast<long long>(v0));
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(&col_major[col * rows + row]), v);
+    }
+
+    // Handle remaining rows
+    for (; row < rows; ++row) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+  }
+}
+
+/**
+ * @brief Scalar gather + SIMD store + software prefetch.
+ *
+ * Same as above but with software prefetching for the strided reads.
+ */
+static void transpose_scalar_gather_simd_store_prefetch(const uint64_t* row_major,
+                                                        uint64_t* col_major, size_t rows,
+                                                        size_t cols) {
+  constexpr size_t PREFETCH_DISTANCE = 16; // Prefetch 16 rows ahead
+
+  for (size_t col = 0; col < cols; ++col) {
+    size_t row = 0;
+
+    // Process 4 rows at a time with SIMD stores
+    for (; row + 4 <= rows; row += 4) {
+      // Prefetch future rows for this column
+      if (row + PREFETCH_DISTANCE < rows) {
+        _mm_prefetch(
+            reinterpret_cast<const char*>(&row_major[(row + PREFETCH_DISTANCE) * cols + col]),
+            _MM_HINT_T0);
+      }
+
+      // Scalar gather from strided positions
+      uint64_t v0 = row_major[(row + 0) * cols + col];
+      uint64_t v1 = row_major[(row + 1) * cols + col];
+      uint64_t v2 = row_major[(row + 2) * cols + col];
+      uint64_t v3 = row_major[(row + 3) * cols + col];
+
+      // Pack into SIMD register and store sequentially
+      __m256i v = _mm256_set_epi64x(static_cast<long long>(v3), static_cast<long long>(v2),
+                                    static_cast<long long>(v1), static_cast<long long>(v0));
+      _mm256_storeu_si256(reinterpret_cast<__m256i*>(&col_major[col * rows + row]), v);
+    }
+
+    // Handle remaining rows
+    for (; row < rows; ++row) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+  }
+}
+
+/**
+ * @brief Non-temporal (streaming) stores.
+ *
+ * Uses _mm256_stream_si256 to bypass cache on writes.
+ * Good for large arrays that won't be read again soon.
+ * Requires 32-byte aligned destination.
+ */
+static void transpose_nontemporal_store(const uint64_t* row_major, uint64_t* col_major, size_t rows,
+                                        size_t cols) {
+  for (size_t col = 0; col < cols; ++col) {
+    size_t row = 0;
+
+    // Find aligned start position for this column
+    uint64_t* col_ptr = &col_major[col * rows];
+    size_t aligned_start = (reinterpret_cast<uintptr_t>(col_ptr) % 32 == 0)
+                               ? 0
+                               : (32 - (reinterpret_cast<uintptr_t>(col_ptr) % 32)) / 8;
+
+    // Handle unaligned prefix with scalar stores
+    for (; row < aligned_start && row < rows; ++row) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+
+    // Process aligned portion with non-temporal stores
+    for (; row + 4 <= rows; row += 4) {
+      uint64_t v0 = row_major[(row + 0) * cols + col];
+      uint64_t v1 = row_major[(row + 1) * cols + col];
+      uint64_t v2 = row_major[(row + 2) * cols + col];
+      uint64_t v3 = row_major[(row + 3) * cols + col];
+
+      __m256i v = _mm256_set_epi64x(static_cast<long long>(v3), static_cast<long long>(v2),
+                                    static_cast<long long>(v1), static_cast<long long>(v0));
+      _mm256_stream_si256(reinterpret_cast<__m256i*>(&col_major[col * rows + row]), v);
+    }
+
+    // Handle remaining rows
+    for (; row < rows; ++row) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+  }
+
+  // Memory fence to ensure all streaming stores are visible
+  _mm_sfence();
+}
+#endif // __x86_64__
 
 // =============================================================================
 // Benchmarks
@@ -478,4 +694,404 @@ BENCHMARK(BM_TransposeScaling)
     ->Args({1000000, 500, 1})
     ->Args({1000000, 500, 2})
     ->Args({1000000, 500, 3})
+    ->Unit(benchmark::kMillisecond);
+
+// =============================================================================
+// Multi-threaded SIMD Implementations
+// =============================================================================
+
+/**
+ * @brief Multi-threaded row-first scalar transpose.
+ * Each thread handles a range of rows.
+ */
+static void transpose_row_first_mt(const uint64_t* row_major, uint64_t* col_major, size_t rows,
+                                   size_t cols, size_t n_threads) {
+  if (n_threads <= 1) {
+    transpose_single_threaded(row_major, col_major, rows, cols);
+    return;
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(n_threads);
+
+  size_t rows_per_thread = (rows + n_threads - 1) / n_threads;
+
+  for (size_t t = 0; t < n_threads; ++t) {
+    size_t row_start = t * rows_per_thread;
+    size_t row_end = std::min(row_start + rows_per_thread, rows);
+
+    if (row_start >= rows)
+      break;
+
+    threads.emplace_back([=]() {
+      for (size_t row = row_start; row < row_end; ++row) {
+        for (size_t col = 0; col < cols; ++col) {
+          col_major[col * rows + row] = row_major[row * cols + col];
+        }
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+/**
+ * @brief Multi-threaded column-first scalar transpose.
+ * Each thread handles a range of columns (better write locality per thread).
+ */
+static void transpose_col_first_mt(const uint64_t* row_major, uint64_t* col_major, size_t rows,
+                                   size_t cols, size_t n_threads) {
+  if (n_threads <= 1) {
+    transpose_column_first_scalar(row_major, col_major, rows, cols);
+    return;
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(n_threads);
+
+  size_t cols_per_thread = (cols + n_threads - 1) / n_threads;
+
+  for (size_t t = 0; t < n_threads; ++t) {
+    size_t col_start = t * cols_per_thread;
+    size_t col_end = std::min(col_start + cols_per_thread, cols);
+
+    if (col_start >= cols)
+      break;
+
+    threads.emplace_back([=]() {
+      for (size_t col = col_start; col < col_end; ++col) {
+        for (size_t row = 0; row < rows; ++row) {
+          col_major[col * rows + row] = row_major[row * cols + col];
+        }
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+#ifdef __x86_64__
+/**
+ * @brief Multi-threaded SIMD 4x4 block transpose.
+ * Each thread handles a range of row blocks.
+ */
+static void transpose_simd_4x4_mt(const uint64_t* row_major, uint64_t* col_major, size_t rows,
+                                  size_t cols, size_t n_threads) {
+  if (n_threads <= 1) {
+    transpose_simd_4x4_block(row_major, col_major, rows, cols);
+    return;
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(n_threads);
+
+  size_t row_blocks = rows / 4;
+  size_t col_blocks = cols / 4;
+  size_t blocks_per_thread = (row_blocks + n_threads - 1) / n_threads;
+
+  for (size_t t = 0; t < n_threads; ++t) {
+    size_t rb_start = t * blocks_per_thread;
+    size_t rb_end = std::min(rb_start + blocks_per_thread, row_blocks);
+
+    if (rb_start >= row_blocks)
+      break;
+
+    threads.emplace_back([=]() {
+      for (size_t rb = rb_start; rb < rb_end; ++rb) {
+        for (size_t cb = 0; cb < col_blocks; ++cb) {
+          size_t row_base = rb * 4;
+          size_t col_base = cb * 4;
+
+          __m256i r0 = _mm256_loadu_si256(
+              reinterpret_cast<const __m256i*>(&row_major[(row_base + 0) * cols + col_base]));
+          __m256i r1 = _mm256_loadu_si256(
+              reinterpret_cast<const __m256i*>(&row_major[(row_base + 1) * cols + col_base]));
+          __m256i r2 = _mm256_loadu_si256(
+              reinterpret_cast<const __m256i*>(&row_major[(row_base + 2) * cols + col_base]));
+          __m256i r3 = _mm256_loadu_si256(
+              reinterpret_cast<const __m256i*>(&row_major[(row_base + 3) * cols + col_base]));
+
+          __m256i t0 = _mm256_unpacklo_epi64(r0, r1);
+          __m256i t1 = _mm256_unpackhi_epi64(r0, r1);
+          __m256i t2 = _mm256_unpacklo_epi64(r2, r3);
+          __m256i t3 = _mm256_unpackhi_epi64(r2, r3);
+
+          __m256i o0 = _mm256_permute2x128_si256(t0, t2, 0x20);
+          __m256i o1 = _mm256_permute2x128_si256(t1, t3, 0x20);
+          __m256i o2 = _mm256_permute2x128_si256(t0, t2, 0x31);
+          __m256i o3 = _mm256_permute2x128_si256(t1, t3, 0x31);
+
+          _mm256_storeu_si256(
+              reinterpret_cast<__m256i*>(&col_major[(col_base + 0) * rows + row_base]), o0);
+          _mm256_storeu_si256(
+              reinterpret_cast<__m256i*>(&col_major[(col_base + 1) * rows + row_base]), o1);
+          _mm256_storeu_si256(
+              reinterpret_cast<__m256i*>(&col_major[(col_base + 2) * rows + row_base]), o2);
+          _mm256_storeu_si256(
+              reinterpret_cast<__m256i*>(&col_major[(col_base + 3) * rows + row_base]), o3);
+        }
+      }
+
+      // Handle remaining columns for this thread's rows
+      size_t row_start = rb_start * 4;
+      size_t row_end = std::min(rb_end * 4, rows);
+      for (size_t col = col_blocks * 4; col < cols; ++col) {
+        for (size_t row = row_start; row < row_end; ++row) {
+          col_major[col * rows + row] = row_major[row * cols + col];
+        }
+      }
+    });
+  }
+
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  // Handle remaining rows (not divisible by 4) - single threaded for simplicity
+  for (size_t row = row_blocks * 4; row < rows; ++row) {
+    for (size_t col = 0; col < cols; ++col) {
+      col_major[col * rows + row] = row_major[row * cols + col];
+    }
+  }
+}
+#endif // __x86_64__
+
+// =============================================================================
+// SIMD Benchmarks
+// =============================================================================
+
+/**
+ * @brief BM_TransposeSIMD - Compare SIMD transpose methods.
+ *
+ * Parameters: state.range(0) = rows, state.range(1) = cols, state.range(2) = method
+ * Methods:
+ *   0 = Row-first scalar (baseline, sequential reads, strided writes)
+ *   1 = Column-first scalar (strided reads, sequential writes)
+ *   2 = SIMD 4x4 block transpose (AVX2)
+ *   3 = Scalar gather + SIMD store
+ *   4 = Scalar gather + SIMD store + prefetch
+ *   5 = Non-temporal stores
+ */
+static void BM_TransposeSIMD(benchmark::State& state) {
+  size_t rows = static_cast<size_t>(state.range(0));
+  size_t cols = static_cast<size_t>(state.range(1));
+  int method = static_cast<int>(state.range(2));
+  size_t total_elements = rows * cols;
+
+  auto row_major = static_cast<uint64_t*>(aligned_malloc(64, total_elements * sizeof(uint64_t)));
+  auto col_major = static_cast<uint64_t*>(aligned_malloc(64, total_elements * sizeof(uint64_t)));
+
+  if (!row_major || !col_major) {
+    state.SkipWithError("Failed to allocate memory");
+    aligned_free(row_major);
+    aligned_free(col_major);
+    return;
+  }
+
+  for (size_t i = 0; i < total_elements; ++i) {
+    row_major[i] = i * 10;
+  }
+
+  const char* method_name = "unknown";
+  for (auto _ : state) {
+    switch (method) {
+    case 0:
+      transpose_single_threaded(row_major, col_major, rows, cols);
+      method_name = "row_first_scalar";
+      break;
+    case 1:
+      transpose_column_first_scalar(row_major, col_major, rows, cols);
+      method_name = "col_first_scalar";
+      break;
+#ifdef __x86_64__
+    case 2:
+      transpose_simd_4x4_block(row_major, col_major, rows, cols);
+      method_name = "simd_4x4_block";
+      break;
+    case 3:
+      transpose_scalar_gather_simd_store(row_major, col_major, rows, cols);
+      method_name = "scalar_gather_simd_store";
+      break;
+    case 4:
+      transpose_scalar_gather_simd_store_prefetch(row_major, col_major, rows, cols);
+      method_name = "scalar_gather_simd_store_prefetch";
+      break;
+    case 5:
+      transpose_nontemporal_store(row_major, col_major, rows, cols);
+      method_name = "nontemporal_store";
+      break;
+#endif
+    default:
+      // Fallback for non-x86 or unknown method
+      transpose_single_threaded(row_major, col_major, rows, cols);
+      method_name = "fallback";
+      break;
+    }
+    benchmark::DoNotOptimize(col_major);
+    benchmark::ClobberMemory();
+  }
+
+  // Suppress unused variable warning
+  (void)method_name;
+
+  size_t bytes_processed = total_elements * sizeof(uint64_t) * 2;
+  state.SetBytesProcessed(static_cast<int64_t>(bytes_processed * state.iterations()));
+  state.counters["Rows"] = static_cast<double>(rows);
+  state.counters["Cols"] = static_cast<double>(cols);
+  state.counters["Method"] = static_cast<double>(method);
+  state.counters["Elements"] = static_cast<double>(total_elements);
+  state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
+                                                    benchmark::Counter::kIsIterationInvariantRate);
+
+  aligned_free(row_major);
+  aligned_free(col_major);
+}
+
+// SIMD method comparison at key sizes
+// Methods: 0=row_first, 1=col_first, 2=simd_4x4, 3=gather_store, 4=gather_prefetch, 5=nontemporal
+BENCHMARK(BM_TransposeSIMD)
+    // 100K x 100 - all methods
+    ->Args({100000, 100, 0}) // row-first scalar
+    ->Args({100000, 100, 1}) // col-first scalar
+    ->Args({100000, 100, 2}) // simd 4x4 block
+    ->Args({100000, 100, 3}) // scalar gather + simd store
+    ->Args({100000, 100, 4}) // + prefetch
+    ->Args({100000, 100, 5}) // non-temporal
+    // 1M x 100 - all methods
+    ->Args({1000000, 100, 0})
+    ->Args({1000000, 100, 1})
+    ->Args({1000000, 100, 2})
+    ->Args({1000000, 100, 3})
+    ->Args({1000000, 100, 4})
+    ->Args({1000000, 100, 5})
+    // 1M x 500 - all methods (wide matrix)
+    ->Args({1000000, 500, 0})
+    ->Args({1000000, 500, 1})
+    ->Args({1000000, 500, 2})
+    ->Args({1000000, 500, 3})
+    ->Args({1000000, 500, 4})
+    ->Args({1000000, 500, 5})
+    // 10M x 10 - all methods (tall narrow matrix)
+    ->Args({10000000, 10, 0})
+    ->Args({10000000, 10, 1})
+    ->Args({10000000, 10, 2})
+    ->Args({10000000, 10, 3})
+    ->Args({10000000, 10, 4})
+    ->Args({10000000, 10, 5})
+    ->Unit(benchmark::kMillisecond);
+
+/**
+ * @brief BM_TransposeSIMD_MT - Compare multi-threaded transpose methods.
+ *
+ * Parameters: state.range(0) = rows, state.range(1) = cols,
+ *             state.range(2) = method, state.range(3) = threads
+ * Methods:
+ *   0 = Row-first scalar MT
+ *   1 = Column-first scalar MT
+ *   2 = SIMD 4x4 block MT
+ */
+static void BM_TransposeSIMD_MT(benchmark::State& state) {
+  size_t rows = static_cast<size_t>(state.range(0));
+  size_t cols = static_cast<size_t>(state.range(1));
+  int method = static_cast<int>(state.range(2));
+  size_t n_threads = static_cast<size_t>(state.range(3));
+  size_t total_elements = rows * cols;
+
+  auto row_major = static_cast<uint64_t*>(aligned_malloc(64, total_elements * sizeof(uint64_t)));
+  auto col_major = static_cast<uint64_t*>(aligned_malloc(64, total_elements * sizeof(uint64_t)));
+
+  if (!row_major || !col_major) {
+    state.SkipWithError("Failed to allocate memory");
+    aligned_free(row_major);
+    aligned_free(col_major);
+    return;
+  }
+
+  for (size_t i = 0; i < total_elements; ++i) {
+    row_major[i] = i * 10;
+  }
+
+  const char* method_name = "unknown";
+  for (auto _ : state) {
+    switch (method) {
+    case 0:
+      transpose_row_first_mt(row_major, col_major, rows, cols, n_threads);
+      method_name = "row_first_mt";
+      break;
+    case 1:
+      transpose_col_first_mt(row_major, col_major, rows, cols, n_threads);
+      method_name = "col_first_mt";
+      break;
+#ifdef __x86_64__
+    case 2:
+      transpose_simd_4x4_mt(row_major, col_major, rows, cols, n_threads);
+      method_name = "simd_4x4_mt";
+      break;
+#endif
+    default:
+      transpose_row_first_mt(row_major, col_major, rows, cols, n_threads);
+      method_name = "fallback";
+      break;
+    }
+    benchmark::DoNotOptimize(col_major);
+    benchmark::ClobberMemory();
+  }
+
+  (void)method_name;
+
+  size_t bytes_processed = total_elements * sizeof(uint64_t) * 2;
+  state.SetBytesProcessed(static_cast<int64_t>(bytes_processed * state.iterations()));
+  state.counters["Rows"] = static_cast<double>(rows);
+  state.counters["Cols"] = static_cast<double>(cols);
+  state.counters["Method"] = static_cast<double>(method);
+  state.counters["Threads"] = static_cast<double>(n_threads);
+  state.counters["Elements"] = static_cast<double>(total_elements);
+  state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
+                                                    benchmark::Counter::kIsIterationInvariantRate);
+
+  aligned_free(row_major);
+  aligned_free(col_major);
+}
+
+// Multi-threaded comparison
+// Methods: 0=row_first_mt, 1=col_first_mt, 2=simd_4x4_mt
+// Args: rows, cols, method, threads
+BENCHMARK(BM_TransposeSIMD_MT)
+    // 1M x 100 - compare methods at different thread counts
+    ->Args({1000000, 100, 0, 1}) // row-first, 1 thread (baseline)
+    ->Args({1000000, 100, 0, 2})
+    ->Args({1000000, 100, 0, 4})
+    ->Args({1000000, 100, 0, 8})
+    ->Args({1000000, 100, 1, 1}) // col-first, 1 thread
+    ->Args({1000000, 100, 1, 2})
+    ->Args({1000000, 100, 1, 4})
+    ->Args({1000000, 100, 1, 8})
+    ->Args({1000000, 100, 2, 1}) // simd 4x4, 1 thread
+    ->Args({1000000, 100, 2, 2})
+    ->Args({1000000, 100, 2, 4})
+    ->Args({1000000, 100, 2, 8})
+    // 1M x 500 - wide matrix
+    ->Args({1000000, 500, 0, 1})
+    ->Args({1000000, 500, 0, 4})
+    ->Args({1000000, 500, 0, 8})
+    ->Args({1000000, 500, 1, 1})
+    ->Args({1000000, 500, 1, 4})
+    ->Args({1000000, 500, 1, 8})
+    ->Args({1000000, 500, 2, 1})
+    ->Args({1000000, 500, 2, 4})
+    ->Args({1000000, 500, 2, 8})
+    // 10M x 10 - narrow matrix
+    ->Args({10000000, 10, 0, 1})
+    ->Args({10000000, 10, 0, 4})
+    ->Args({10000000, 10, 0, 8})
+    ->Args({10000000, 10, 1, 1})
+    ->Args({10000000, 10, 1, 4})
+    ->Args({10000000, 10, 1, 8})
+    ->Args({10000000, 10, 2, 1})
+    ->Args({10000000, 10, 2, 4})
+    ->Args({10000000, 10, 2, 8})
     ->Unit(benchmark::kMillisecond);

--- a/test/column_major_test.cpp
+++ b/test/column_major_test.cpp
@@ -1,0 +1,411 @@
+/**
+ * @file column_major_test.cpp
+ * @brief Tests for column-major index layout (compact_column_major).
+ *
+ * Tests the column-major transpose functionality added for ALTREP/Arrow
+ * access patterns. Verifies correctness of transpose, column access,
+ * and row reconstruction.
+ */
+
+#include "libvroom.h"
+
+#include "two_pass.h"
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace libvroom;
+
+class ColumnMajorTest : public ::testing::Test {
+protected:
+  // Helper to create CSV content with known values
+  std::string makeCSV(size_t rows, size_t cols) {
+    std::string csv;
+    for (size_t r = 0; r < rows; ++r) {
+      for (size_t c = 0; c < cols; ++c) {
+        if (c > 0)
+          csv += ",";
+        csv += std::to_string(r * cols + c);
+      }
+      csv += "\n";
+    }
+    return csv;
+  }
+
+  // Parse CSV and return the index
+  ParseIndex parseCSV(const std::string& content, size_t n_threads = 1) {
+    Parser parser(n_threads);
+    ParseOptions opts;
+    opts.dialect = Dialect::csv();
+    auto result =
+        parser.parse(reinterpret_cast<const uint8_t*>(content.data()), content.size(), opts);
+    EXPECT_TRUE(result.successful);
+    return std::move(result.idx);
+  }
+};
+
+// Basic functionality tests
+
+TEST_F(ColumnMajorTest, CompactColumnMajor_BasicFunctionality) {
+  std::string csv = makeCSV(10, 5);
+  auto idx = parseCSV(csv);
+
+  EXPECT_FALSE(idx.is_column_major());
+  idx.compact_column_major();
+  EXPECT_TRUE(idx.is_column_major());
+
+  // After compact_column_major, flat_indexes should be freed
+  EXPECT_FALSE(idx.is_flat());
+}
+
+TEST_F(ColumnMajorTest, CompactColumnMajor_Idempotent) {
+  std::string csv = makeCSV(10, 5);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+  uint64_t* first_ptr = idx.col_indexes;
+
+  idx.compact_column_major(); // Second call should be no-op
+  EXPECT_EQ(first_ptr, idx.col_indexes);
+}
+
+TEST_F(ColumnMajorTest, NumRows_ReturnsCorrectCount) {
+  std::string csv = makeCSV(100, 10);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+  EXPECT_EQ(100u, idx.num_rows());
+  EXPECT_EQ(10u, idx.columns);
+}
+
+TEST_F(ColumnMajorTest, Column_ReturnsValidPointer) {
+  std::string csv = makeCSV(10, 5);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+
+  for (size_t col = 0; col < 5; ++col) {
+    const uint64_t* col_data = idx.column(col);
+    ASSERT_NE(nullptr, col_data) << "Column " << col << " returned nullptr";
+  }
+
+  // Out of bounds should return nullptr
+  EXPECT_EQ(nullptr, idx.column(5));
+  EXPECT_EQ(nullptr, idx.column(100));
+}
+
+TEST_F(ColumnMajorTest, Column_ReturnsNullBeforeCompact) {
+  std::string csv = makeCSV(10, 5);
+  auto idx = parseCSV(csv);
+
+  // Before compact_column_major, column() should return nullptr
+  EXPECT_EQ(nullptr, idx.column(0));
+}
+
+// Correctness tests - verify transpose is correct
+
+TEST_F(ColumnMajorTest, TransposeCorrectness_SmallMatrix) {
+  std::string csv = makeCSV(5, 3);
+  auto idx = parseCSV(csv);
+
+  // First compact to row-major to get expected values
+  idx.compact();
+  ASSERT_TRUE(idx.is_flat());
+
+  // Store expected row-major values
+  std::vector<uint64_t> row_major(idx.flat_indexes, idx.flat_indexes + idx.flat_indexes_count);
+
+  // Now compact to column-major (this will free flat_indexes)
+  idx.compact_column_major();
+  ASSERT_TRUE(idx.is_column_major());
+
+  // Verify transpose: col_indexes[col * nrows + row] == row_major[row * ncols + col]
+  uint64_t nrows = idx.num_rows();
+  uint64_t ncols = idx.columns;
+
+  for (uint64_t row = 0; row < nrows; ++row) {
+    for (uint64_t col = 0; col < ncols; ++col) {
+      uint64_t row_major_idx = row * ncols + col;
+      uint64_t col_major_idx = col * nrows + row;
+
+      EXPECT_EQ(row_major[row_major_idx], idx.col_indexes[col_major_idx])
+          << "Mismatch at row=" << row << ", col=" << col;
+    }
+  }
+}
+
+TEST_F(ColumnMajorTest, TransposeCorrectness_LargerMatrix) {
+  std::string csv = makeCSV(100, 20);
+  auto idx = parseCSV(csv);
+
+  idx.compact();
+  std::vector<uint64_t> row_major(idx.flat_indexes, idx.flat_indexes + idx.flat_indexes_count);
+
+  idx.compact_column_major();
+
+  uint64_t nrows = idx.num_rows();
+  uint64_t ncols = idx.columns;
+
+  // Sample some positions to verify
+  std::vector<std::pair<uint64_t, uint64_t>> test_positions = {{0, 0},   {0, 19}, {99, 0}, {99, 19},
+                                                               {50, 10}, {25, 5}, {75, 15}};
+
+  for (const auto& [row, col] : test_positions) {
+    uint64_t row_major_idx = row * ncols + col;
+    uint64_t col_major_idx = col * nrows + row;
+
+    EXPECT_EQ(row_major[row_major_idx], idx.col_indexes[col_major_idx])
+        << "Mismatch at row=" << row << ", col=" << col;
+  }
+}
+
+// Column access tests
+
+TEST_F(ColumnMajorTest, ColumnAccess_SequentialMemory) {
+  std::string csv = makeCSV(100, 10);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+
+  // Each column's data should be at contiguous memory locations
+  for (size_t col = 0; col < idx.columns; ++col) {
+    const uint64_t* col_data = idx.column(col);
+    uint64_t expected_offset = col * idx.num_rows();
+
+    EXPECT_EQ(&idx.col_indexes[expected_offset], col_data)
+        << "Column " << col << " not at expected offset";
+  }
+}
+
+// Row reconstruction tests
+
+TEST_F(ColumnMajorTest, GetRowFields_ReturnsCorrectValues) {
+  std::string csv = makeCSV(10, 5);
+  auto idx = parseCSV(csv);
+
+  idx.compact();
+  std::vector<uint64_t> row_major(idx.flat_indexes, idx.flat_indexes + idx.flat_indexes_count);
+
+  idx.compact_column_major();
+
+  std::vector<uint64_t> row_fields;
+
+  for (size_t row = 0; row < idx.num_rows(); ++row) {
+    ASSERT_TRUE(idx.get_row_fields(row, row_fields));
+    ASSERT_EQ(idx.columns, row_fields.size());
+
+    for (size_t col = 0; col < idx.columns; ++col) {
+      uint64_t expected = row_major[row * idx.columns + col];
+      EXPECT_EQ(expected, row_fields[col]) << "Row " << row << ", col " << col;
+    }
+  }
+}
+
+TEST_F(ColumnMajorTest, GetRowFields_OutOfBounds) {
+  std::string csv = makeCSV(10, 5);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+
+  std::vector<uint64_t> row_fields;
+
+  EXPECT_FALSE(idx.get_row_fields(10, row_fields));  // Out of bounds
+  EXPECT_FALSE(idx.get_row_fields(100, row_fields)); // Way out of bounds
+}
+
+TEST_F(ColumnMajorTest, GetRowFields_ReturnsFalseBeforeCompact) {
+  std::string csv = makeCSV(10, 5);
+  auto idx = parseCSV(csv);
+
+  std::vector<uint64_t> row_fields;
+  EXPECT_FALSE(idx.get_row_fields(0, row_fields));
+}
+
+// Multi-threaded tests
+
+TEST_F(ColumnMajorTest, MultiThreaded_CorrectTranspose) {
+  std::string csv = makeCSV(1000, 50);
+  auto idx = parseCSV(csv, 4); // Parse with 4 threads
+
+  idx.compact();
+  std::vector<uint64_t> row_major(idx.flat_indexes, idx.flat_indexes + idx.flat_indexes_count);
+
+  // Transpose with multiple threads
+  idx.compact_column_major(4);
+
+  uint64_t nrows = idx.num_rows();
+  uint64_t ncols = idx.columns;
+
+  // Verify all positions
+  for (uint64_t row = 0; row < nrows; ++row) {
+    for (uint64_t col = 0; col < ncols; ++col) {
+      uint64_t row_major_idx = row * ncols + col;
+      uint64_t col_major_idx = col * nrows + row;
+
+      EXPECT_EQ(row_major[row_major_idx], idx.col_indexes[col_major_idx])
+          << "Mismatch at row=" << row << ", col=" << col;
+    }
+  }
+}
+
+TEST_F(ColumnMajorTest, MultiThreaded_VariousThreadCounts) {
+  std::string csv = makeCSV(500, 20);
+
+  for (size_t threads : {1, 2, 4, 8}) {
+    auto idx = parseCSV(csv, threads);
+
+    idx.compact();
+    std::vector<uint64_t> row_major(idx.flat_indexes, idx.flat_indexes + idx.flat_indexes_count);
+
+    idx.compact_column_major(threads);
+
+    // Spot check
+    uint64_t nrows = idx.num_rows();
+    EXPECT_EQ(row_major[0], idx.col_indexes[0]);                            // (0,0)
+    EXPECT_EQ(row_major[19], idx.col_indexes[19 * nrows]);                  // (0,19)
+    EXPECT_EQ(row_major[499 * 20], idx.col_indexes[499]);                   // (499,0)
+    EXPECT_EQ(row_major[499 * 20 + 19], idx.col_indexes[19 * nrows + 499]); // (499,19)
+  }
+}
+
+// Edge cases
+
+TEST_F(ColumnMajorTest, SingleRow) {
+  std::string csv = "a,b,c,d,e\n";
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+
+  EXPECT_EQ(1u, idx.num_rows());
+  EXPECT_EQ(5u, idx.columns);
+  EXPECT_TRUE(idx.is_column_major());
+
+  // All columns should be accessible
+  for (size_t col = 0; col < 5; ++col) {
+    EXPECT_NE(nullptr, idx.column(col));
+  }
+}
+
+TEST_F(ColumnMajorTest, SingleColumn) {
+  std::string csv = "a\nb\nc\nd\ne\n";
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+
+  EXPECT_EQ(5u, idx.num_rows());
+  EXPECT_EQ(1u, idx.columns);
+  EXPECT_TRUE(idx.is_column_major());
+
+  EXPECT_NE(nullptr, idx.column(0));
+  EXPECT_EQ(nullptr, idx.column(1));
+}
+
+TEST_F(ColumnMajorTest, EmptyCSV) {
+  std::string csv = "";
+  Parser parser(1);
+  ParseOptions opts;
+  opts.dialect = Dialect::csv();
+  auto result = parser.parse(reinterpret_cast<const uint8_t*>(csv.data()), csv.size(), opts);
+
+  // Empty CSV - compact_column_major should handle gracefully
+  result.idx.compact_column_major();
+
+  // Should not crash, and is_column_major should be false (no data)
+  EXPECT_FALSE(result.idx.is_column_major());
+}
+
+// Memory tests
+
+TEST_F(ColumnMajorTest, FlatIndexFreedAfterColumnMajor) {
+  std::string csv = makeCSV(100, 10);
+  auto idx = parseCSV(csv);
+
+  idx.compact();
+  EXPECT_TRUE(idx.is_flat());
+  EXPECT_NE(nullptr, idx.flat_indexes);
+
+  idx.compact_column_major();
+
+  // flat_indexes should be null after column-major compaction
+  EXPECT_EQ(nullptr, idx.flat_indexes);
+  EXPECT_EQ(0u, idx.flat_indexes_count);
+  EXPECT_FALSE(idx.is_flat());
+}
+
+// Move semantics
+
+TEST_F(ColumnMajorTest, MoveConstructor_PreservesColumnMajor) {
+  std::string csv = makeCSV(50, 10);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+  uint64_t* original_ptr = idx.col_indexes;
+  uint64_t original_count = idx.col_indexes_count;
+
+  ParseIndex moved(std::move(idx));
+
+  EXPECT_EQ(original_ptr, moved.col_indexes);
+  EXPECT_EQ(original_count, moved.col_indexes_count);
+  EXPECT_TRUE(moved.is_column_major());
+
+  // Original should be empty
+  EXPECT_EQ(nullptr, idx.col_indexes);
+  EXPECT_EQ(0u, idx.col_indexes_count);
+}
+
+TEST_F(ColumnMajorTest, MoveAssignment_PreservesColumnMajor) {
+  std::string csv = makeCSV(50, 10);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+  uint64_t* original_ptr = idx.col_indexes;
+
+  ParseIndex moved;
+  moved = std::move(idx);
+
+  EXPECT_EQ(original_ptr, moved.col_indexes);
+  EXPECT_TRUE(moved.is_column_major());
+}
+
+// Shared ownership tests
+
+TEST_F(ColumnMajorTest, Share_PreservesColumnMajor) {
+  std::string csv = makeCSV(50, 10);
+  auto idx = parseCSV(csv);
+
+  idx.compact_column_major();
+  uint64_t* original_ptr = idx.col_indexes;
+  uint64_t original_count = idx.col_indexes_count;
+
+  auto shared = idx.share();
+
+  EXPECT_EQ(original_ptr, shared->col_indexes);
+  EXPECT_EQ(original_count, shared->col_indexes_count);
+  EXPECT_TRUE(shared->is_column_major());
+
+  // Verify column access works on shared index
+  for (size_t col = 0; col < 10; ++col) {
+    EXPECT_NE(nullptr, shared->column(col));
+  }
+}
+
+TEST_F(ColumnMajorTest, Share_ColumnMajorAfterShare) {
+  std::string csv = makeCSV(50, 10);
+  auto idx = parseCSV(csv);
+
+  // First share, then compact_column_major
+  auto shared1 = idx.share();
+  idx.compact_column_major();
+
+  // Share again after column-major compaction
+  auto shared2 = idx.share();
+
+  EXPECT_TRUE(idx.is_column_major());
+  EXPECT_TRUE(shared2->is_column_major());
+
+  // Original shared index should not have column-major (was shared before compaction)
+  EXPECT_FALSE(shared1->is_column_major());
+}


### PR DESCRIPTION
## Summary

Adds column-major index layout support to `ParseIndex` for efficient ALTREP/Arrow column access patterns. This implements the transpose functionality benchmarked in #599.

- Add `compact_column_major()` method using row-first multi-threaded transpose (~1.3 GB/s at 4 threads)
- Add column access methods: `column(col)` returns contiguous column data, `get_row_fields(row)` for row reconstruction
- Memory efficient: frees row-major index after transpose (1x peak memory, not 2x)
- Update `share()` to properly handle column-major ownership
- Comprehensive test suite with 21 tests covering correctness, edge cases, move semantics, and shared ownership

### Benchmark Results (from #599)

Row-first scalar transpose achieves ~350 MB/s single-threaded, scaling to ~1.3 GB/s at 4 threads. This approach was chosen because:
- Sequential reads + strided writes outperforms column-first by 3-5x
- Multi-threaded row-first nearly matches SIMD single-threaded at 4+ threads
- Simpler implementation without SIMD dependencies

### API

```cpp
ParseIndex idx = parser.parse(...).idx;
idx.compact_column_major(4);  // Transpose with 4 threads

// Column access (O(1) - returns pointer to contiguous column data)
const uint64_t* col0 = idx.column(0);

// Row reconstruction (O(cols) - for CLI/type detection)
std::vector<uint64_t> row_fields;
idx.get_row_fields(row, row_fields);
```

Closes #599

## Test plan

- [x] All 21 column-major tests pass
- [x] All 2628 existing tests pass
- [x] Verify transpose correctness against row-major reference
- [x] Verify multi-threaded transpose produces same results
- [x] Test edge cases: single row, single column, empty CSV
- [x] Test move semantics preserve column-major state
- [x] Test share() preserves column-major ownership