### PR TITLE
fix: rewrite fuzz targets for libvroom2 API

### DIFF
--- a/fuzz/fuzz_dialect_detection.cpp
+++ b/fuzz/fuzz_dialect_detection.cpp
@@ -3,8 +3,7 @@
  * @brief LibFuzzer target for fuzz testing dialect detection.
  */
 
-#include "dialect.h"
-#include "mem_util.h"
+#include "libvroom.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -19,17 +18,18 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (size > MAX_INPUT_SIZE)
     size = MAX_INPUT_SIZE;
 
-  // Use immediate RAII to prevent leaks if an exception occurs
-  AlignedPtr guard = make_aligned_ptr(size, 64);
-  if (!guard)
-    return 0;
-  uint8_t* buf = guard.get();
-  std::memcpy(buf, data, size);
-  std::memset(buf + size, 0, 64);
+  try {
+    libvroom::AlignedBuffer buf = libvroom::AlignedBuffer::allocate(size);
+    std::memcpy(buf.data(), data, size);
 
-  libvroom::DialectDetector detector;
-  libvroom::DetectionResult result = detector.detect(buf, size);
-  (void)result.success();
+    libvroom::DialectDetector detector;
+    libvroom::DetectionResult result = detector.detect(buf.data(), size);
+    (void)result.success();
+    (void)result.detected_columns;
+    (void)result.confidence;
+  } catch (...) {
+    // Exceptions are valid behavior for malformed input
+  }
 
   return 0;
 }


### PR DESCRIPTION
## Summary

- Rewrites all three fuzz targets (`fuzz_csv_parser`, `fuzz_dialect_detection`, `fuzz_parse_auto`) to use the libvroom2 API
- Replaces removed headers (`mem_util.h`, `two_pass.h`) with `libvroom.h` umbrella include
- Replaces removed classes (`AlignedPtr`, `TwoPass`, `ParseIndex`) with new equivalents (`AlignedBuffer`, `CsvReader`, `DialectDetector`)

### Changes per target

| Target | What changed |
|--------|-------------|
| `fuzz_dialect_detection` | Uses `AlignedBuffer::allocate()` + `DialectDetector::detect()` |
| `fuzz_csv_parser` | Uses `CsvReader::open_from_buffer()` + `read_all()` in two modes (default + permissive error) |
| `fuzz_parse_auto` | Detects dialect first, then parses with detected settings (replaces old `parse_auto()`) |

### All targets now:
- Use `AlignedBuffer` for SIMD-aligned memory (replaces `AlignedPtr`/`make_aligned_ptr`)
- Wrap parsing in `try/catch` for exception safety
- Exercise error collection paths via `ErrorMode::PERMISSIVE`

## Test plan

- [x] All three fuzz targets compile with `-DENABLE_FUZZING=ON` (clang 18)
- [x] All 194 existing tests pass (`ctest --output-on-failure`)
- [x] Each fuzzer runs for 2s without crashes (smoke-tested locally on ramdisk)
- [ ] CI fuzz workflow passes

Closes #625