### PR TITLE
feat: Add streaming parser API for chunked CSV input (#633)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,7 @@ set(VROOM_SOURCES
     src/simd/statistics_simd.cpp
     src/writer/arrow_ipc_writer.cpp
     src/table.cpp
+    src/reader/streaming_parser.cpp
 )
 
 add_library(vroom ${VROOM_SOURCES})
@@ -647,6 +648,12 @@ if(BUILD_TESTING)
     target_include_directories(arrow_conversion_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     add_dependencies(arrow_conversion_test copy_test_data)
     gtest_discover_tests(arrow_conversion_test)
+
+    # Streaming parser tests (Issue #633)
+    add_executable(streaming_test test/streaming_test.cpp)
+    target_link_libraries(streaming_test PRIVATE vroom GTest::gtest_main pthread)
+    target_include_directories(streaming_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    gtest_discover_tests(streaming_test)
 
 endif() # BUILD_TESTING
 

--- a/include/libvroom.h
+++ b/include/libvroom.h
@@ -38,6 +38,9 @@
 // Table (multi-batch Arrow stream export)
 #include "libvroom/table.h"
 
+// Streaming parser
+#include "libvroom/streaming.h"
+
 // Output formats
 #include "libvroom/arrow_ipc_writer.h"
 

--- a/include/libvroom/parse_utils.h
+++ b/include/libvroom/parse_utils.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "options.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace libvroom {
+
+// Helper function to unescape doubled quotes in a quoted field
+// Converts "" to " as per CSV specification (RFC 4180)
+// If has_invalid_escape is non-null, sets it to true when a lone quote is found
+inline std::string unescape_quotes(std::string_view value, char quote,
+                                   bool* has_invalid_escape = nullptr) {
+  // Fast path: no escaped quotes
+  if (value.find(quote) == std::string_view::npos) {
+    return std::string(value);
+  }
+
+  std::string result;
+  result.reserve(value.size());
+
+  for (size_t i = 0; i < value.size(); ++i) {
+    if (value[i] == quote && i + 1 < value.size() && value[i + 1] == quote) {
+      // Escaped quote (doubled) - output single quote
+      result += quote;
+      ++i; // Skip next quote
+    } else if (value[i] == quote) {
+      // Lone quote - invalid escape
+      if (has_invalid_escape) {
+        *has_invalid_escape = true;
+      }
+      result += value[i];
+    } else {
+      result += value[i];
+    }
+  }
+
+  return result;
+}
+
+// Helper class for fast null value checking
+// Pre-parses the null values string once. Uses simple linear search since
+// the number of null values is typically very small (3-5 items).
+class NullChecker {
+public:
+  explicit NullChecker(const CsvOptions& options) {
+    // Parse comma-separated null values into a vector
+    std::string_view null_values = options.null_values;
+    size_t start = 0;
+
+    while (start < null_values.size()) {
+      size_t end = null_values.find(',', start);
+      if (end == std::string_view::npos) {
+        end = null_values.size();
+      }
+
+      std::string_view null_val = null_values.substr(start, end - start);
+      if (!null_val.empty()) {
+        null_values_.emplace_back(null_val);
+        max_null_length_ = std::max(max_null_length_, null_val.size());
+      } else {
+        empty_is_null_ = true;
+      }
+
+      start = end + 1;
+    }
+  }
+
+  bool is_null(std::string_view value) const {
+    // Fast path: empty string check
+    if (value.empty()) {
+      return empty_is_null_;
+    }
+
+    // Fast path: length check (most null values are short: NA, null, NULL, etc.)
+    if (value.size() > max_null_length_) {
+      return false;
+    }
+
+    // Simple linear search - faster than hash for small N (typically 3-5 items)
+    for (const auto& nv : null_values_) {
+      if (nv == value) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+private:
+  std::vector<std::string> null_values_;
+  size_t max_null_length_ = 0;
+  bool empty_is_null_ = true; // Default: empty strings are null
+};
+
+} // namespace libvroom

--- a/include/libvroom/streaming.h
+++ b/include/libvroom/streaming.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "arrow_column_builder.h"
+#include "error.h"
+#include "options.h"
+#include "types.h"
+
+#include <deque>
+#include <istream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace libvroom {
+
+// Forward declarations
+class Table;
+
+// Options for streaming parsing
+struct StreamingOptions {
+  CsvOptions csv;
+  size_t batch_size = 8192; // Rows per batch (0 = all available rows per call)
+};
+
+// A batch of parsed rows as columnar builders
+struct StreamBatch {
+  std::vector<std::unique_ptr<ArrowColumnBuilder>> columns;
+  size_t num_rows = 0;
+  bool is_last = false; // True if this is the final batch from finish()
+};
+
+// Streaming CSV parser - accepts chunked input and produces columnar batches.
+//
+// Pull-model API:
+//   feed(data, size)  -- provide input chunks
+//   next_batch()      -- get next batch of parsed rows
+//   finish()          -- flush remaining partial row
+//
+// Output: StreamBatch containing vector<unique_ptr<ArrowColumnBuilder>> + row count,
+// directly compatible with Table::from_parsed_chunks() and Arrow export.
+//
+// Schema: Auto-inferred from header + first rows (default), or explicitly
+// set via set_schema().
+class StreamingParser {
+public:
+  explicit StreamingParser(const StreamingOptions& options = StreamingOptions{});
+  ~StreamingParser();
+
+  StreamingParser(const StreamingParser&) = delete;
+  StreamingParser& operator=(const StreamingParser&) = delete;
+  StreamingParser(StreamingParser&&) noexcept;
+  StreamingParser& operator=(StreamingParser&&) noexcept;
+
+  // Provide input data. May be called multiple times with partial chunks.
+  // Returns failure if a fatal parsing error occurs.
+  Result<void> feed(const char* data, size_t size);
+
+  // Get the next complete batch, or nullopt if no batch is ready.
+  std::optional<StreamBatch> next_batch();
+
+  // Signal end of input. Flushes any remaining buffered data as the final batch.
+  // Returns failure if a fatal parsing error occurs.
+  Result<void> finish();
+
+  // Explicitly set the schema (column names + types).
+  // Must be called before feed() if used. Disables auto-inference.
+  void set_schema(const std::vector<ColumnSchema>& schema);
+
+  // Check if schema has been determined (either auto-inferred or set explicitly).
+  bool schema_ready() const;
+
+  // Get the current schema (empty if not yet determined).
+  const std::vector<ColumnSchema>& schema() const;
+
+  // Check if any errors were collected.
+  bool has_errors() const;
+
+  // Get collected errors.
+  const std::vector<ParseError>& errors() const;
+
+  // Get the error collector (for advanced usage).
+  const ErrorCollector& error_collector() const;
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+// Convenience function: read from an istream and return a Table.
+// Reads in 64KB chunks, feeds to StreamingParser, assembles all batches into a Table.
+std::shared_ptr<Table> read_csv_stream(std::istream& input,
+                                       const StreamingOptions& options = StreamingOptions{});
+
+} // namespace libvroom

--- a/include/libvroom/types.h
+++ b/include/libvroom/types.h
@@ -146,6 +146,17 @@ template <typename T> struct Result {
   explicit operator bool() const { return ok; }
 };
 
+// Specialization for void result (operations that succeed or fail with no value)
+template <> struct Result<void> {
+  std::string error;
+  bool ok = true;
+
+  static Result success() { return {"", true}; }
+  static Result failure(std::string err) { return {std::move(err), false}; }
+
+  explicit operator bool() const { return ok; }
+};
+
 // Statistics for a column chunk
 struct ColumnStatistics {
   bool has_null = false;

--- a/src/reader/csv_reader.cpp
+++ b/src/reader/csv_reader.cpp
@@ -1,5 +1,6 @@
 #include "libvroom/arrow_column_builder.h"
 #include "libvroom/error.h"
+#include "libvroom/parse_utils.h"
 #include "libvroom/split_fields.h"
 #include "libvroom/table.h"
 #include "libvroom/vroom.h"
@@ -15,92 +16,6 @@
 #include <vector>
 
 namespace libvroom {
-
-// Helper function to unescape doubled quotes in a quoted field
-// Converts "" to " as per CSV specification (RFC 4180)
-// If has_invalid_escape is non-null, sets it to true when a lone quote is found
-static std::string unescape_quotes(std::string_view value, char quote,
-                                   bool* has_invalid_escape = nullptr) {
-  // Fast path: no escaped quotes
-  if (value.find(quote) == std::string_view::npos) {
-    return std::string(value);
-  }
-
-  std::string result;
-  result.reserve(value.size());
-
-  for (size_t i = 0; i < value.size(); ++i) {
-    if (value[i] == quote && i + 1 < value.size() && value[i + 1] == quote) {
-      // Escaped quote (doubled) - output single quote
-      result += quote;
-      ++i; // Skip next quote
-    } else if (value[i] == quote) {
-      // Lone quote - invalid escape
-      if (has_invalid_escape) {
-        *has_invalid_escape = true;
-      }
-      result += value[i];
-    } else {
-      result += value[i];
-    }
-  }
-
-  return result;
-}
-
-// Helper class for fast null value checking
-// Pre-parses the null values string once. Uses simple linear search since
-// the number of null values is typically very small (3-5 items).
-class NullChecker {
-public:
-  explicit NullChecker(const CsvOptions& options) {
-    // Parse comma-separated null values into a vector
-    std::string_view null_values = options.null_values;
-    size_t start = 0;
-
-    while (start < null_values.size()) {
-      size_t end = null_values.find(',', start);
-      if (end == std::string_view::npos) {
-        end = null_values.size();
-      }
-
-      std::string_view null_val = null_values.substr(start, end - start);
-      if (!null_val.empty()) {
-        null_values_.emplace_back(null_val);
-        max_null_length_ = std::max(max_null_length_, null_val.size());
-      } else {
-        empty_is_null_ = true;
-      }
-
-      start = end + 1;
-    }
-  }
-
-  bool is_null(std::string_view value) const {
-    // Fast path: empty string check
-    if (value.empty()) {
-      return empty_is_null_;
-    }
-
-    // Fast path: length check (most null values are short: NA, null, NULL, etc.)
-    if (value.size() > max_null_length_) {
-      return false;
-    }
-
-    // Simple linear search - faster than hash for small N (typically 3-5 items)
-    for (const auto& nv : null_values_) {
-      if (nv == value) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-private:
-  std::vector<std::string> null_values_;
-  size_t max_null_length_ = 0;
-  bool empty_is_null_ = true; // Default: empty strings are null
-};
 
 // Structure to hold dual-state analysis results (lightweight, no parsing)
 struct ChunkAnalysisResult {

--- a/src/reader/streaming_parser.cpp
+++ b/src/reader/streaming_parser.cpp
@@ -1,0 +1,609 @@
+#include "libvroom/arrow_column_builder.h"
+#include "libvroom/error.h"
+#include "libvroom/parse_utils.h"
+#include "libvroom/split_fields.h"
+#include "libvroom/streaming.h"
+#include "libvroom/table.h"
+#include "libvroom/vroom.h"
+
+#include <cstring>
+#include <deque>
+#include <vector>
+
+namespace libvroom {
+
+// =============================================================================
+// StreamingParser::Impl
+// =============================================================================
+
+struct StreamingParser::Impl {
+  StreamingOptions options;
+
+  // Internal buffer for accumulating partial input
+  std::vector<char> buffer;
+  size_t consumed = 0; // Bytes already parsed from the front of buffer
+
+  // Schema state
+  std::vector<ColumnSchema> schema;
+  bool schema_ready = false;
+  bool schema_explicit = false; // Set by set_schema()
+  bool header_parsed = false;
+  bool batch_initialized = false;
+
+  // Error handling
+  ErrorCollector error_collector;
+
+  // Current batch being built
+  std::vector<std::unique_ptr<ArrowColumnBuilder>> current_columns;
+  std::vector<FastArrowContext> fast_contexts;
+  size_t current_batch_rows = 0;
+
+  // Ready batches
+  std::deque<StreamBatch> ready_batches;
+
+  // Null checker (initialized once schema is ready)
+  std::unique_ptr<NullChecker> null_checker;
+
+  // Finished flag
+  bool finished = false;
+
+  explicit Impl(const StreamingOptions& opts)
+      : options(opts), error_collector(opts.csv.error_mode, opts.csv.max_errors) {}
+
+  // Compact the buffer by removing consumed bytes
+  void compact_buffer() {
+    if (consumed > 0) {
+      size_t remaining = buffer.size() - consumed;
+      if (remaining > 0) {
+        std::memmove(buffer.data(), buffer.data() + consumed, remaining);
+      }
+      buffer.resize(remaining);
+      consumed = 0;
+    }
+  }
+
+  // Initialize column builders for the current batch
+  void init_batch() {
+    current_columns.clear();
+    fast_contexts.clear();
+    current_batch_rows = 0;
+
+    for (const auto& col_schema : schema) {
+      auto builder = ArrowColumnBuilder::create(col_schema.type);
+      current_columns.push_back(std::move(builder));
+    }
+
+    fast_contexts.reserve(current_columns.size());
+    for (auto& col : current_columns) {
+      fast_contexts.push_back(col->create_context());
+    }
+
+    batch_initialized = true;
+  }
+
+  // Ensure null_checker and batch are initialized
+  void ensure_initialized() {
+    if (!null_checker) {
+      null_checker = std::make_unique<NullChecker>(options.csv);
+    }
+    if (!batch_initialized) {
+      init_batch();
+    }
+  }
+
+  // Flush the current batch to ready_batches
+  void flush_batch(bool is_last) {
+    if (current_batch_rows == 0 && !is_last) {
+      return;
+    }
+
+    if (current_batch_rows > 0 || is_last) {
+      StreamBatch batch;
+      batch.columns = std::move(current_columns);
+      batch.num_rows = current_batch_rows;
+      batch.is_last = is_last;
+      ready_batches.push_back(std::move(batch));
+    }
+
+    if (!is_last) {
+      init_batch();
+    }
+  }
+
+  // Try to parse the header from buffered data
+  // Returns true if header was successfully parsed
+  bool try_parse_header() {
+    if (header_parsed)
+      return true;
+
+    const char* data = buffer.data() + consumed;
+    size_t avail = buffer.size() - consumed;
+
+    if (avail == 0)
+      return false;
+
+    if (!options.csv.has_header) {
+      // No header mode - infer column count from the first row
+      // We need at least one complete row
+      size_t row_end = find_row_end_in_buffer(data, avail);
+      if (row_end == 0)
+        return false; // No complete row yet
+
+      // Count separators in first row (exclude the newline chars)
+      size_t content_end = row_end;
+      while (content_end > 0 && (data[content_end - 1] == '\n' || data[content_end - 1] == '\r')) {
+        content_end--;
+      }
+
+      bool in_q = false;
+      size_t col_count = 1;
+      for (size_t i = 0; i < content_end; ++i) {
+        char c = data[i];
+        if (c == options.csv.quote) {
+          if (in_q && i + 1 < content_end && data[i + 1] == options.csv.quote) {
+            ++i;
+          } else {
+            in_q = !in_q;
+          }
+        } else if (c == options.csv.separator && !in_q) {
+          ++col_count;
+        }
+      }
+
+      // Create generic column names
+      for (size_t i = 0; i < col_count; ++i) {
+        ColumnSchema col;
+        col.name = "V" + std::to_string(i + 1);
+        col.index = i;
+        col.type = DataType::STRING;
+        schema.push_back(std::move(col));
+      }
+
+      header_parsed = true;
+      // Don't consume any bytes - first row is data
+      return true;
+    }
+
+    // Find end of header line
+    size_t row_end = find_row_end_in_buffer(data, avail);
+    if (row_end == 0)
+      return false; // Header line not complete yet
+
+    // Parse header
+    LineParser parser(options.csv);
+    auto header_names = parser.parse_header(data, row_end);
+
+    for (size_t i = 0; i < header_names.size(); ++i) {
+      ColumnSchema col;
+      col.name = header_names[i];
+      col.index = i;
+      col.type = DataType::STRING; // Will be refined by type inference
+      schema.push_back(std::move(col));
+    }
+
+    consumed += row_end;
+    header_parsed = true;
+    return true;
+  }
+
+  // Try to infer types from available data
+  void try_infer_types() {
+    if (schema.empty())
+      return;
+
+    const char* data = buffer.data() + consumed;
+    size_t avail = buffer.size() - consumed;
+
+    if (avail == 0)
+      return;
+
+    TypeInference inference(options.csv);
+    auto inferred_types =
+        inference.infer_from_sample(data, avail, schema.size(), options.csv.sample_rows);
+
+    for (size_t i = 0; i < schema.size() && i < inferred_types.size(); ++i) {
+      schema[i].type = inferred_types[i];
+    }
+  }
+
+  // Find the end of the first complete row in the buffer.
+  // Returns offset past the row terminator, or 0 if no complete row.
+  size_t find_row_end_in_buffer(const char* data, size_t size) {
+    bool in_q = false;
+    for (size_t i = 0; i < size; ++i) {
+      char c = data[i];
+      if (c == options.csv.quote) {
+        if (in_q && i + 1 < size && data[i + 1] == options.csv.quote) {
+          ++i; // Skip escaped quote
+        } else {
+          in_q = !in_q;
+        }
+      } else if (!in_q && c == '\n') {
+        return i + 1;
+      } else if (!in_q && c == '\r') {
+        if (i + 1 < size && data[i + 1] == '\n') {
+          return i + 2;
+        }
+        return i + 1;
+      }
+    }
+    return 0; // No complete row
+  }
+
+  // Find the end of the last complete row in a data range.
+  // Returns offset past the last row terminator, or 0 if no complete row found.
+  size_t find_last_row_end(const char* data, size_t size) {
+    size_t last_end = 0;
+    size_t pos = 0;
+    while (pos < size) {
+      size_t row_end = find_row_end_in_buffer(data + pos, size - pos);
+      if (row_end == 0)
+        break;
+      pos += row_end;
+      last_end = pos;
+    }
+    return last_end;
+  }
+
+  // Parse a known-complete region of the buffer (all rows have terminators).
+  // data points to the start, parseable_size is the length of complete rows.
+  void parse_rows(const char* data, size_t parseable_size) {
+    if (schema.empty() || !batch_initialized || parseable_size == 0)
+      return;
+
+    const char quote = options.csv.quote;
+    const char sep = options.csv.separator;
+    const size_t num_cols = schema.size();
+    const bool check_errors = error_collector.is_enabled();
+    const size_t batch_size = options.batch_size;
+
+    size_t offset = 0;
+
+    while (offset < parseable_size) {
+      // Skip empty lines
+      while (offset < parseable_size) {
+        char c = data[offset];
+        if (c == '\n') {
+          offset++;
+          continue;
+        }
+        if (c == '\r') {
+          offset++;
+          if (offset < parseable_size && data[offset] == '\n') {
+            offset++;
+          }
+          continue;
+        }
+        break;
+      }
+
+      if (offset >= parseable_size)
+        break;
+
+      // Parse one row using SplitFields
+      size_t row_remaining = parseable_size - offset;
+      SplitFields iter(data + offset, row_remaining, sep, quote, '\n');
+
+      const char* field_data;
+      size_t field_len;
+      bool needs_escaping;
+      size_t col_idx = 0;
+
+      while (iter.next(field_data, field_len, needs_escaping)) {
+        // Strip trailing \r if present
+        if (field_len > 0 && field_data[field_len - 1] == '\r') {
+          field_len--;
+        }
+
+        std::string_view field_view(field_data, field_len);
+
+        // Error detection
+        if (check_errors) [[unlikely]] {
+          if (std::memchr(field_data, '\0', field_len)) {
+            for (size_t i = 0; i < field_len; ++i) {
+              if (field_data[i] == '\0') {
+                error_collector.add_error(ErrorCode::NULL_BYTE, ErrorSeverity::RECOVERABLE, 0,
+                                          col_idx + 1, 0, "Unexpected null byte in data");
+                if (error_collector.should_stop())
+                  return;
+              }
+            }
+          }
+
+          if (!needs_escaping && field_len > 0 && std::memchr(field_data, quote, field_len)) {
+            error_collector.add_error(ErrorCode::QUOTE_IN_UNQUOTED_FIELD,
+                                      ErrorSeverity::RECOVERABLE, 0, col_idx + 1, 0,
+                                      "Quote character in unquoted field");
+            if (error_collector.should_stop())
+              return;
+          }
+        }
+
+        if (col_idx >= num_cols) {
+          col_idx++;
+          continue;
+        }
+
+        if (null_checker->is_null(field_view)) {
+          fast_contexts[col_idx].append_null();
+        } else if (needs_escaping) {
+          // Strip outer quotes
+          if (field_len >= 2 && field_data[0] == quote && field_data[field_len - 1] == quote) {
+            field_view = std::string_view(field_data + 1, field_len - 2);
+          }
+          bool has_invalid_escape = false;
+          std::string unescaped =
+              unescape_quotes(field_view, quote, check_errors ? &has_invalid_escape : nullptr);
+
+          if (has_invalid_escape) [[unlikely]] {
+            error_collector.add_error(ErrorCode::INVALID_QUOTE_ESCAPE, ErrorSeverity::RECOVERABLE,
+                                      0, col_idx + 1, 0, "Invalid quote escape sequence");
+            if (error_collector.should_stop())
+              return;
+          }
+
+          fast_contexts[col_idx].append(unescaped);
+        } else {
+          fast_contexts[col_idx].append(field_view);
+        }
+        col_idx++;
+      }
+
+      // Error: inconsistent field count
+      if (check_errors && col_idx != num_cols) [[unlikely]] {
+        error_collector.add_error(
+            ErrorCode::INCONSISTENT_FIELD_COUNT, ErrorSeverity::RECOVERABLE, 0, 0, 0,
+            "Expected " + std::to_string(num_cols) + " fields, got " + std::to_string(col_idx));
+        if (error_collector.should_stop())
+          return;
+      }
+
+      // Fill remaining columns with nulls
+      for (; col_idx < num_cols; ++col_idx) {
+        fast_contexts[col_idx].append_null();
+      }
+
+      current_batch_rows++;
+      offset += row_remaining - iter.remaining();
+
+      // Check if we should flush the batch
+      if (batch_size > 0 && current_batch_rows >= batch_size) {
+        flush_batch(false);
+      }
+    }
+  }
+
+  // Parse available complete rows from the buffer
+  void parse_available_rows(bool is_final) {
+    if (schema.empty() || !batch_initialized)
+      return;
+
+    const char* data = buffer.data() + consumed;
+    size_t avail = buffer.size() - consumed;
+
+    if (avail == 0)
+      return;
+
+    if (is_final) {
+      // In final mode, parse everything (including partial final row)
+      parse_rows(data, avail);
+      consumed += avail;
+    } else {
+      // In non-final mode, only parse up to the last complete row
+      size_t parseable = find_last_row_end(data, avail);
+      if (parseable == 0)
+        return; // No complete rows yet
+
+      parse_rows(data, parseable);
+      consumed += parseable;
+    }
+  }
+};
+
+// =============================================================================
+// StreamingParser public interface
+// =============================================================================
+
+StreamingParser::StreamingParser(const StreamingOptions& options)
+    : impl_(std::make_unique<Impl>(options)) {}
+
+StreamingParser::~StreamingParser() = default;
+
+StreamingParser::StreamingParser(StreamingParser&&) noexcept = default;
+StreamingParser& StreamingParser::operator=(StreamingParser&&) noexcept = default;
+
+Result<void> StreamingParser::feed(const char* data, size_t size) {
+  if (impl_->finished) {
+    return Result<void>::failure("Cannot feed after finish()");
+  }
+
+  if (size == 0)
+    return Result<void>::success();
+
+  // Compact buffer if needed
+  if (impl_->consumed > impl_->buffer.size() / 2) {
+    impl_->compact_buffer();
+  }
+
+  // Append new data
+  impl_->buffer.insert(impl_->buffer.end(), data, data + size);
+
+  // Try to parse header if not done yet
+  if (!impl_->header_parsed) {
+    if (!impl_->schema_explicit) {
+      if (!impl_->try_parse_header()) {
+        return Result<void>::success(); // Need more data for header
+      }
+    } else {
+      // Schema was set explicitly, but we still need to skip the header line if present
+      if (impl_->options.csv.has_header) {
+        const char* buf_data = impl_->buffer.data() + impl_->consumed;
+        size_t avail = impl_->buffer.size() - impl_->consumed;
+        size_t row_end = impl_->find_row_end_in_buffer(buf_data, avail);
+        if (row_end == 0) {
+          return Result<void>::success(); // Need more data for header
+        }
+        impl_->consumed += row_end;
+      }
+      impl_->header_parsed = true;
+    }
+  }
+
+  // Infer types if schema is not yet finalized
+  if (!impl_->schema_ready) {
+    impl_->try_infer_types();
+    impl_->schema_ready = true;
+  }
+
+  // Ensure null_checker and batch are initialized
+  impl_->ensure_initialized();
+
+  // Parse available rows
+  impl_->parse_available_rows(false);
+
+  if (impl_->error_collector.should_stop()) {
+    return Result<void>::failure("Parsing stopped due to errors");
+  }
+
+  return Result<void>::success();
+}
+
+std::optional<StreamBatch> StreamingParser::next_batch() {
+  if (impl_->ready_batches.empty()) {
+    return std::nullopt;
+  }
+
+  StreamBatch batch = std::move(impl_->ready_batches.front());
+  impl_->ready_batches.pop_front();
+  return batch;
+}
+
+Result<void> StreamingParser::finish() {
+  if (impl_->finished) {
+    return Result<void>::success();
+  }
+  impl_->finished = true;
+
+  // If we never got any data, just return
+  if (impl_->buffer.empty() && impl_->consumed == 0) {
+    return Result<void>::success();
+  }
+
+  // If header wasn't parsed yet, try one more time
+  if (!impl_->header_parsed) {
+    if (!impl_->schema_explicit) {
+      impl_->try_parse_header();
+    } else {
+      if (impl_->options.csv.has_header) {
+        const char* buf_data = impl_->buffer.data() + impl_->consumed;
+        size_t avail = impl_->buffer.size() - impl_->consumed;
+        size_t row_end = impl_->find_row_end_in_buffer(buf_data, avail);
+        if (row_end > 0) {
+          impl_->consumed += row_end;
+        }
+      }
+      impl_->header_parsed = true;
+    }
+  }
+
+  // Initialize schema if not done
+  if (!impl_->schema_ready && !impl_->schema.empty()) {
+    impl_->try_infer_types();
+    impl_->schema_ready = true;
+  }
+
+  // Ensure null_checker and batch are initialized
+  if (impl_->schema_ready && !impl_->schema.empty()) {
+    impl_->ensure_initialized();
+  }
+
+  // Parse remaining data (including partial final row)
+  if (impl_->schema_ready && !impl_->schema.empty()) {
+    impl_->parse_available_rows(true);
+  }
+
+  // Flush remaining batch
+  if (impl_->current_batch_rows > 0 || impl_->ready_batches.empty()) {
+    impl_->flush_batch(true);
+  } else if (!impl_->ready_batches.empty()) {
+    // Mark the last batch as is_last
+    impl_->ready_batches.back().is_last = true;
+  }
+
+  if (impl_->error_collector.should_stop()) {
+    return Result<void>::failure("Parsing stopped due to errors");
+  }
+
+  return Result<void>::success();
+}
+
+void StreamingParser::set_schema(const std::vector<ColumnSchema>& schema) {
+  impl_->schema = schema;
+  impl_->schema_explicit = true;
+  impl_->schema_ready = true;
+  // Don't initialize batch yet - wait until feed() is called so we know we have data
+}
+
+bool StreamingParser::schema_ready() const {
+  return impl_->schema_ready;
+}
+
+const std::vector<ColumnSchema>& StreamingParser::schema() const {
+  return impl_->schema;
+}
+
+bool StreamingParser::has_errors() const {
+  return impl_->error_collector.has_errors();
+}
+
+const std::vector<ParseError>& StreamingParser::errors() const {
+  return impl_->error_collector.errors();
+}
+
+const ErrorCollector& StreamingParser::error_collector() const {
+  return impl_->error_collector;
+}
+
+// =============================================================================
+// read_csv_stream convenience function
+// =============================================================================
+
+std::shared_ptr<Table> read_csv_stream(std::istream& input, const StreamingOptions& options) {
+  StreamingParser parser(options);
+
+  constexpr size_t READ_SIZE = 64 * 1024; // 64KB chunks
+  std::vector<char> read_buffer(READ_SIZE);
+
+  while (input.good()) {
+    input.read(read_buffer.data(), static_cast<std::streamsize>(READ_SIZE));
+    auto bytes_read = static_cast<size_t>(input.gcount());
+    if (bytes_read == 0)
+      break;
+
+    auto result = parser.feed(read_buffer.data(), bytes_read);
+    if (!result.ok) {
+      return nullptr;
+    }
+  }
+
+  auto finish_result = parser.finish();
+  if (!finish_result.ok) {
+    return nullptr;
+  }
+
+  // Collect all batches into ParsedChunks
+  const auto& schema = parser.schema();
+  if (schema.empty()) {
+    return nullptr;
+  }
+
+  ParsedChunks parsed;
+  while (auto batch = parser.next_batch()) {
+    parsed.total_rows += batch->num_rows;
+    parsed.chunks.push_back(std::move(batch->columns));
+  }
+
+  return Table::from_parsed_chunks(schema, std::move(parsed));
+}
+
+} // namespace libvroom

--- a/test/streaming_test.cpp
+++ b/test/streaming_test.cpp
@@ -1,0 +1,593 @@
+/**
+ * @file streaming_test.cpp
+ * @brief Tests for the StreamingParser API (Issue #633).
+ *
+ * Verifies that StreamingParser correctly accepts chunked CSV input
+ * and produces columnar ArrowColumnBuilder batches incrementally.
+ */
+
+#include "libvroom.h"
+#include "libvroom/streaming.h"
+#include "libvroom/table.h"
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+
+using namespace libvroom;
+
+// =============================================================================
+// Basic Functionality Tests
+// =============================================================================
+
+TEST(StreamingParserTest, FeedCompleteCSV) {
+  StreamingOptions opts;
+  opts.batch_size = 8192;
+  StreamingParser parser(opts);
+
+  std::string csv = "a,b,c\n1,2,3\n4,5,6\n7,8,9\n";
+  auto result = parser.feed(csv.data(), csv.size());
+  ASSERT_TRUE(result.ok);
+
+  auto finish_result = parser.finish();
+  ASSERT_TRUE(finish_result.ok);
+
+  // Collect all batches
+  size_t total_rows = 0;
+  std::vector<StreamBatch> batches;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+    batches.push_back(std::move(*batch));
+  }
+
+  EXPECT_EQ(total_rows, 3);
+  ASSERT_FALSE(batches.empty());
+
+  // Verify column count
+  EXPECT_EQ(batches[0].columns.size(), 3);
+}
+
+TEST(StreamingParserTest, ColumnNamesFromHeader) {
+  StreamingParser parser;
+
+  std::string csv = "name,age,score\nAlice,30,95.5\n";
+  auto result = parser.feed(csv.data(), csv.size());
+  ASSERT_TRUE(result.ok);
+
+  ASSERT_TRUE(parser.schema_ready());
+  const auto& schema = parser.schema();
+  ASSERT_EQ(schema.size(), 3);
+  EXPECT_EQ(schema[0].name, "name");
+  EXPECT_EQ(schema[1].name, "age");
+  EXPECT_EQ(schema[2].name, "score");
+}
+
+TEST(StreamingParserTest, TypedColumns) {
+  StreamingParser parser;
+
+  std::string csv = "name,age,score\nAlice,30,95.5\nBob,25,87.3\n";
+  auto result = parser.feed(csv.data(), csv.size());
+  ASSERT_TRUE(result.ok);
+  parser.finish();
+
+  auto batch = parser.next_batch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->num_rows, 2);
+
+  // Verify types were inferred
+  const auto& schema = parser.schema();
+  EXPECT_EQ(schema[0].type, DataType::STRING);
+  EXPECT_EQ(schema[1].type, DataType::INT32);
+  EXPECT_EQ(schema[2].type, DataType::FLOAT64);
+}
+
+TEST(StreamingParserTest, RowCountAndStatistics) {
+  StreamingParser parser;
+
+  std::string csv = "x,y\n1,2\n3,4\n5,6\n7,8\n9,10\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  size_t total_rows = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+    // Each batch should have exactly 2 columns
+    EXPECT_EQ(batch->columns.size(), 2);
+    // Each column should have the same number of rows as the batch
+    for (const auto& col : batch->columns) {
+      EXPECT_EQ(col->size(), batch->num_rows);
+    }
+  }
+  EXPECT_EQ(total_rows, 5);
+}
+
+TEST(StreamingParserTest, NullHandling) {
+  StreamingParser parser;
+
+  std::string csv = "a,b\n1,NA\n,3\nNULL,null\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  auto batch = parser.next_batch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->num_rows, 3);
+
+  // Both columns should have some nulls
+  EXPECT_GT(batch->columns[0]->null_count(), 0);
+  EXPECT_GT(batch->columns[1]->null_count(), 0);
+}
+
+TEST(StreamingParserTest, QuotedFields) {
+  StreamingParser parser;
+
+  std::string csv = "a,b\n\"hello, world\",1\n\"with \"\"quotes\"\"\",2\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  auto batch = parser.next_batch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->num_rows, 2);
+}
+
+TEST(StreamingParserTest, EmptyInput) {
+  StreamingParser parser;
+
+  parser.finish();
+  auto batch = parser.next_batch();
+  // Should get no batch from empty input
+  EXPECT_FALSE(batch.has_value());
+}
+
+TEST(StreamingParserTest, HeaderOnly) {
+  StreamingParser parser;
+
+  std::string csv = "a,b,c\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  ASSERT_TRUE(parser.schema_ready());
+  EXPECT_EQ(parser.schema().size(), 3);
+
+  // Should get no data batch (or a batch with 0 rows)
+  bool got_data = false;
+  while (auto batch = parser.next_batch()) {
+    if (batch->num_rows > 0)
+      got_data = true;
+  }
+  EXPECT_FALSE(got_data);
+}
+
+// =============================================================================
+// Chunk Boundary Tests
+// =============================================================================
+
+TEST(StreamingParserTest, FeedByteByByte) {
+  StreamingParser parser;
+
+  std::string csv = "a,b\n1,2\n3,4\n";
+  for (size_t i = 0; i < csv.size(); ++i) {
+    auto result = parser.feed(csv.data() + i, 1);
+    ASSERT_TRUE(result.ok) << "Failed at byte " << i;
+  }
+  parser.finish();
+
+  size_t total_rows = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+  }
+  EXPECT_EQ(total_rows, 2);
+}
+
+TEST(StreamingParserTest, SplitAtEveryPosition) {
+  std::string csv = "a,b\n1,2\n3,4\n";
+
+  for (size_t split = 0; split <= csv.size(); ++split) {
+    StreamingParser parser;
+
+    if (split > 0) {
+      auto r1 = parser.feed(csv.data(), split);
+      ASSERT_TRUE(r1.ok) << "Failed at split " << split;
+    }
+    if (split < csv.size()) {
+      auto r2 = parser.feed(csv.data() + split, csv.size() - split);
+      ASSERT_TRUE(r2.ok) << "Failed at split " << split;
+    }
+    parser.finish();
+
+    size_t total_rows = 0;
+    while (auto batch = parser.next_batch()) {
+      total_rows += batch->num_rows;
+    }
+    EXPECT_EQ(total_rows, 2) << "Wrong row count at split position " << split;
+  }
+}
+
+TEST(StreamingParserTest, SplitCRLFAcrossChunks) {
+  StreamingParser parser;
+
+  // "a,b\r\n1,2\r\n" with split between \r and \n
+  std::string part1 = "a,b\r";
+  std::string part2 = "\n1,2\r";
+  std::string part3 = "\n";
+
+  parser.feed(part1.data(), part1.size());
+  parser.feed(part2.data(), part2.size());
+  parser.feed(part3.data(), part3.size());
+  parser.finish();
+
+  size_t total_rows = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+  }
+  EXPECT_EQ(total_rows, 1);
+}
+
+TEST(StreamingParserTest, SplitInsideQuotedField) {
+  std::string csv = "a,b\n\"hello, world\",1\n";
+
+  // Split right in the middle of the quoted field
+  for (size_t split = 4; split < csv.size(); ++split) {
+    StreamingParser parser;
+
+    parser.feed(csv.data(), split);
+    parser.feed(csv.data() + split, csv.size() - split);
+    parser.finish();
+
+    size_t total_rows = 0;
+    while (auto batch = parser.next_batch()) {
+      total_rows += batch->num_rows;
+    }
+    EXPECT_EQ(total_rows, 1) << "Wrong row count at split position " << split;
+  }
+}
+
+TEST(StreamingParserTest, SplitInsideDoubleQuoteEscape) {
+  std::string csv = "a\n\"ab\"\"cd\"\n";
+
+  for (size_t split = 0; split <= csv.size(); ++split) {
+    StreamingParser parser;
+
+    if (split > 0) {
+      parser.feed(csv.data(), split);
+    }
+    if (split < csv.size()) {
+      parser.feed(csv.data() + split, csv.size() - split);
+    }
+    parser.finish();
+
+    size_t total_rows = 0;
+    while (auto batch = parser.next_batch()) {
+      total_rows += batch->num_rows;
+    }
+    EXPECT_EQ(total_rows, 1) << "Wrong row count at split position " << split;
+  }
+}
+
+TEST(StreamingParserTest, SplitHeaderAcrossChunks) {
+  StreamingParser parser;
+
+  // Split header "name,a" + "ge\n..."
+  std::string part1 = "name,a";
+  std::string part2 = "ge\n30\n";
+
+  // After first feed, schema should not be ready yet (no newline)
+  // Actually it depends on implementation - header needs a complete line
+  parser.feed(part1.data(), part1.size());
+  parser.feed(part2.data(), part2.size());
+  parser.finish();
+
+  ASSERT_TRUE(parser.schema_ready());
+  const auto& schema = parser.schema();
+  ASSERT_EQ(schema.size(), 2);
+  EXPECT_EQ(schema[0].name, "name");
+  EXPECT_EQ(schema[1].name, "age");
+
+  size_t total_rows = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+  }
+  EXPECT_EQ(total_rows, 1);
+}
+
+TEST(StreamingParserTest, FeedWithNoCompleteRows) {
+  StreamingParser parser;
+
+  // Feed header but no data rows
+  std::string header = "a,b\n";
+  parser.feed(header.data(), header.size());
+
+  // Feed partial row (no newline)
+  std::string partial = "1,2";
+  parser.feed(partial.data(), partial.size());
+
+  // No batch should be ready yet (no complete data row terminated)
+  // Actually with batch_size=8192 default, it would only yield on finish or batch full
+  // But the partial row should be buffered
+
+  parser.finish();
+
+  size_t total_rows = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+  }
+  EXPECT_EQ(total_rows, 1);
+}
+
+// =============================================================================
+// Batch Size Control Tests
+// =============================================================================
+
+TEST(StreamingParserTest, BatchSizeOne) {
+  StreamingOptions opts;
+  opts.batch_size = 1;
+  StreamingParser parser(opts);
+
+  std::string csv = "a\n1\n2\n3\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  size_t batch_count = 0;
+  while (auto batch = parser.next_batch()) {
+    EXPECT_EQ(batch->num_rows, 1) << "Batch " << batch_count << " has wrong size";
+    batch_count++;
+  }
+  EXPECT_EQ(batch_count, 3);
+}
+
+TEST(StreamingParserTest, BatchSizeZero) {
+  StreamingOptions opts;
+  opts.batch_size = 0; // All available rows per call
+  StreamingParser parser(opts);
+
+  std::string csv = "a\n1\n2\n3\n4\n5\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  auto batch = parser.next_batch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->num_rows, 5);
+
+  // No more batches
+  EXPECT_FALSE(parser.next_batch().has_value());
+}
+
+TEST(StreamingParserTest, BatchSizeWithRemainder) {
+  StreamingOptions opts;
+  opts.batch_size = 100;
+  StreamingParser parser(opts);
+
+  // Generate 250 rows
+  std::string csv = "x\n";
+  for (int i = 0; i < 250; ++i) {
+    csv += std::to_string(i) + "\n";
+  }
+
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  std::vector<size_t> batch_sizes;
+  while (auto batch = parser.next_batch()) {
+    batch_sizes.push_back(batch->num_rows);
+  }
+
+  ASSERT_EQ(batch_sizes.size(), 3);
+  EXPECT_EQ(batch_sizes[0], 100);
+  EXPECT_EQ(batch_sizes[1], 100);
+  EXPECT_EQ(batch_sizes[2], 50);
+}
+
+// =============================================================================
+// Schema Handling Tests
+// =============================================================================
+
+TEST(StreamingParserTest, ExplicitSchema) {
+  StreamingParser parser;
+
+  // Set schema explicitly before feeding data
+  std::vector<ColumnSchema> schema;
+  schema.push_back({"name", DataType::STRING, true, 0});
+  schema.push_back({"value", DataType::INT32, true, 1});
+  parser.set_schema(schema);
+
+  ASSERT_TRUE(parser.schema_ready());
+
+  std::string csv = "name,value\nfoo,42\nbar,99\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  auto batch = parser.next_batch();
+  ASSERT_TRUE(batch.has_value());
+  EXPECT_EQ(batch->num_rows, 2);
+  EXPECT_EQ(batch->columns.size(), 2);
+
+  // Types should match the explicit schema
+  EXPECT_EQ(batch->columns[0]->type(), DataType::STRING);
+  EXPECT_EQ(batch->columns[1]->type(), DataType::INT32);
+}
+
+TEST(StreamingParserTest, NoHeader) {
+  StreamingOptions opts;
+  opts.csv.has_header = false;
+  StreamingParser parser(opts);
+
+  std::string csv = "1,2,3\n4,5,6\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  ASSERT_TRUE(parser.schema_ready());
+  const auto& schema = parser.schema();
+  ASSERT_EQ(schema.size(), 3);
+  // Without header, columns get auto-generated names
+  EXPECT_EQ(schema[0].name, "V1");
+  EXPECT_EQ(schema[1].name, "V2");
+  EXPECT_EQ(schema[2].name, "V3");
+
+  size_t total_rows = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+  }
+  EXPECT_EQ(total_rows, 2);
+}
+
+// =============================================================================
+// Error Handling Tests
+// =============================================================================
+
+TEST(StreamingParserTest, FailFastMode) {
+  StreamingOptions opts;
+  opts.csv.error_mode = ErrorMode::FAIL_FAST;
+  StreamingParser parser(opts);
+
+  // Inconsistent field count should trigger an error
+  std::string csv = "a,b\n1,2\n3\n4,5\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  EXPECT_TRUE(parser.has_errors());
+}
+
+TEST(StreamingParserTest, PermissiveMode) {
+  StreamingOptions opts;
+  opts.csv.error_mode = ErrorMode::PERMISSIVE;
+  StreamingParser parser(opts);
+
+  // Inconsistent field count in permissive mode
+  std::string csv = "a,b\n1,2\n3\n4,5\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  // Errors should be collected
+  EXPECT_TRUE(parser.has_errors());
+
+  // But we should still get data
+  size_t total_rows = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+  }
+  EXPECT_EQ(total_rows, 3); // All rows parsed despite error
+}
+
+TEST(StreamingParserTest, ErrorCollectorAccess) {
+  StreamingOptions opts;
+  opts.csv.error_mode = ErrorMode::PERMISSIVE;
+  StreamingParser parser(opts);
+
+  std::string csv = "a,b\n1,2\n3\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  const auto& collector = parser.error_collector();
+  EXPECT_TRUE(collector.has_errors());
+  EXPECT_GE(collector.error_count(), 1);
+}
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+TEST(StreamingParserTest, ReadCsvStream) {
+  std::istringstream input("a,b\n1,2\n3,4\n5,6\n");
+
+  auto table = read_csv_stream(input);
+  ASSERT_NE(table, nullptr);
+  EXPECT_EQ(table->num_rows(), 3);
+  EXPECT_EQ(table->num_columns(), 2);
+
+  auto names = table->column_names();
+  EXPECT_EQ(names[0], "a");
+  EXPECT_EQ(names[1], "b");
+}
+
+TEST(StreamingParserTest, ReadCsvStreamToArrow) {
+  std::istringstream input("x,y,z\n1,2,3\n4,5,6\n");
+
+  auto table = read_csv_stream(input);
+  ASSERT_NE(table, nullptr);
+
+  // Export to Arrow stream and verify
+  ArrowArrayStream stream;
+  table->export_to_stream(&stream);
+
+  ArrowSchema schema;
+  ASSERT_EQ(stream.get_schema(&stream, &schema), 0);
+  EXPECT_EQ(schema.n_children, 3);
+  schema.release(&schema);
+
+  size_t total_rows = 0;
+  while (true) {
+    ArrowArray batch;
+    ASSERT_EQ(stream.get_next(&stream, &batch), 0);
+    if (batch.release == nullptr)
+      break;
+    total_rows += static_cast<size_t>(batch.length);
+    batch.release(&batch);
+  }
+  EXPECT_EQ(total_rows, 2);
+
+  stream.release(&stream);
+}
+
+TEST(StreamingParserTest, ReadCsvStreamEmpty) {
+  std::istringstream input("");
+  auto table = read_csv_stream(input);
+  // Empty input should return nullptr or empty table
+  // Implementation can choose either, but should not crash
+  if (table) {
+    EXPECT_EQ(table->num_rows(), 0);
+  }
+}
+
+TEST(StreamingParserTest, ReadCsvStreamHeaderOnly) {
+  std::istringstream input("a,b,c\n");
+  auto table = read_csv_stream(input);
+  ASSERT_NE(table, nullptr);
+  EXPECT_EQ(table->num_rows(), 0);
+  EXPECT_EQ(table->num_columns(), 3);
+}
+
+TEST(StreamingParserTest, MultipleFeedsThenBatches) {
+  StreamingOptions opts;
+  opts.batch_size = 2;
+  StreamingParser parser(opts);
+
+  // Feed header + first row
+  std::string part1 = "a,b\n1,2\n";
+  parser.feed(part1.data(), part1.size());
+
+  // Should have 0 or 1 batch ready depending on batch threshold
+  // Feed more data
+  std::string part2 = "3,4\n5,6\n";
+  parser.feed(part2.data(), part2.size());
+
+  // Feed final data
+  std::string part3 = "7,8\n";
+  parser.feed(part3.data(), part3.size());
+  parser.finish();
+
+  size_t total_rows = 0;
+  size_t batch_count = 0;
+  while (auto batch = parser.next_batch()) {
+    total_rows += batch->num_rows;
+    batch_count++;
+  }
+  EXPECT_EQ(total_rows, 4);
+  // With batch_size=2 and 4 rows, we should get 2 batches
+  EXPECT_EQ(batch_count, 2);
+}
+
+TEST(StreamingParserTest, IsLastFlag) {
+  StreamingParser parser;
+
+  std::string csv = "a\n1\n2\n";
+  parser.feed(csv.data(), csv.size());
+  parser.finish();
+
+  std::vector<StreamBatch> batches;
+  while (auto batch = parser.next_batch()) {
+    batches.push_back(std::move(*batch));
+  }
+
+  ASSERT_FALSE(batches.empty());
+  // Last batch should have is_last set
+  EXPECT_TRUE(batches.back().is_last);
+}


### PR DESCRIPTION
## Summary

- Adds `StreamingParser` class with pull-model API (`feed()` / `next_batch()` / `finish()`) for incremental CSV parsing from chunked input (stdin, pipes, large files)
- Produces columnar `ArrowColumnBuilder` batches directly compatible with `Table::from_parsed_chunks()` and Arrow C Data Interface export
- Extracts shared `NullChecker` and `unescape_quotes()` into `parse_utils.h` for reuse between `CsvReader` and `StreamingParser`

## Design

- **Pull model only**: simpler than the old push/pull dual model, composes well with loops and iterators
- **Columnar output**: `StreamBatch` contains `vector<unique_ptr<ArrowColumnBuilder>>` + row count, integrating with existing Table/Arrow pipeline
- **Two-phase row parsing**: `find_last_row_end()` pre-scans for complete row boundaries before parsing, ensuring partial rows are preserved across `feed()` calls
- **SIMD-accelerated**: inner loop uses the same `SplitFields` + `FastArrowContext` code path as `CsvReader::read_all()`
- **Schema flexibility**: auto-infers types from header + first rows, or accepts explicit schema via `set_schema()`

## New files

| File | Purpose |
|------|---------|
| `include/libvroom/parse_utils.h` | Shared `NullChecker` + `unescape_quotes()` |
| `include/libvroom/streaming.h` | Public streaming API header |
| `src/reader/streaming_parser.cpp` | Implementation (609 lines) |
| `test/streaming_test.cpp` | 29 tests (593 lines) |

## Test plan

- [x] 29 new streaming parser tests covering:
  - Basic parsing, column names, typed columns, statistics
  - Null handling, quoted fields, empty input, header-only
  - Chunk boundary splitting: byte-by-byte, every position, CRLF across chunks, inside quoted fields, inside double-quote escapes, header across chunks
  - Batch size control: size=1, size=0 (all rows), remainder batches
  - Schema: explicit schema, no-header mode
  - Error modes: FAIL_FAST, PERMISSIVE, error collector access
  - Integration: `read_csv_stream()`, Arrow export, multiple feeds, `is_last` flag
- [x] All 849 tests pass (820 existing + 29 new)
- [x] Release build succeeds

Closes #633