### PR TITLE
feat: Add character encoding detection and transcoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,7 @@ endif()
 
 # Library target (SHARED or STATIC based on BUILD_SHARED_LIBS)
 set(VROOM_SOURCES
+    src/encoding.cpp
     src/error.cpp
     src/io_util.cpp
     src/dialect.cpp
@@ -668,6 +669,13 @@ if(BUILD_TESTING)
     target_link_libraries(streaming_test PRIVATE vroom GTest::gtest_main pthread)
     target_include_directories(streaming_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
     gtest_discover_tests(streaming_test)
+
+    # Character encoding detection and transcoding tests (Issue #636)
+    add_executable(encoding_test test/encoding_test.cpp)
+    target_link_libraries(encoding_test PRIVATE vroom GTest::gtest_main pthread)
+    target_include_directories(encoding_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    add_dependencies(encoding_test copy_test_data)
+    gtest_discover_tests(encoding_test)
 
 endif() # BUILD_TESTING
 

--- a/include/libvroom.h
+++ b/include/libvroom.h
@@ -20,6 +20,7 @@
 #include "libvroom/common_defs.h"
 #include "libvroom/dialect.h"
 #include "libvroom/elias_fano.h"
+#include "libvroom/encoding.h"
 #include "libvroom/error.h"
 #include "libvroom/io_util.h"
 #include "libvroom/options.h"

--- a/include/libvroom/encoding.h
+++ b/include/libvroom/encoding.h
@@ -1,0 +1,77 @@
+/**
+ * @file encoding.h
+ * @brief Character encoding detection and transcoding to UTF-8.
+ *
+ * Detects file encoding (via BOM or heuristic analysis) and transcodes
+ * non-UTF-8 content to UTF-8 before CSV parsing. Uses simdutf for
+ * SIMD-accelerated conversion.
+ *
+ * The common case (UTF-8/ASCII) has essentially zero overhead: just a
+ * 4-byte BOM check with no allocation or copy.
+ */
+
+#pragma once
+
+#include "io_util.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace libvroom {
+
+/// Character encoding types for CSV file input.
+/// Named CharEncoding to avoid collision with Parquet Encoding enum in types.h.
+enum class CharEncoding : uint8_t {
+  UTF8 = 0,
+  UTF8_BOM = 1,
+  UTF16_LE = 2,
+  UTF16_BE = 3,
+  UTF32_LE = 4,
+  UTF32_BE = 5,
+  LATIN1 = 6,
+  WINDOWS_1252 = 7,
+  UNKNOWN = 255
+};
+
+/// Result of encoding detection.
+struct EncodingResult {
+  CharEncoding encoding = CharEncoding::UTF8;
+  size_t bom_length = 0;
+  double confidence = 1.0;
+  bool needs_transcoding = false;
+
+  /// True if detection succeeded (encoding is not UNKNOWN).
+  bool success() const { return encoding != CharEncoding::UNKNOWN; }
+};
+
+/// Get the string name of an encoding (e.g., "UTF-8", "UTF-16LE").
+const char* encoding_to_string(CharEncoding enc);
+
+/// Parse an encoding name string to CharEncoding.
+/// Accepts various forms: "utf-8", "UTF8", "utf-16le", "UTF-16LE",
+/// "latin1", "iso-8859-1", "windows-1252", "cp1252", etc.
+/// Returns CharEncoding::UNKNOWN for unrecognized names.
+CharEncoding parse_encoding_name(std::string_view name);
+
+/// Detect encoding of a data buffer.
+/// Checks BOM first, then uses heuristic analysis if no BOM is found.
+/// For UTF-8/ASCII data (the common case), returns immediately with no
+/// allocation or heavy computation.
+EncodingResult detect_encoding(const uint8_t* data, size_t size);
+
+/// Transcode a buffer from the given encoding to UTF-8.
+/// Returns a new AlignedBuffer with the transcoded content.
+/// The BOM (if any) is stripped from the output.
+///
+/// @param data   Pointer to the raw input data.
+/// @param size   Size of the input data in bytes.
+/// @param enc    Source encoding.
+/// @param bom_length  Number of BOM bytes to skip.
+/// @return AlignedBuffer containing UTF-8 data with SIMD padding.
+/// @throws std::runtime_error on transcoding failure.
+AlignedBuffer transcode_to_utf8(const uint8_t* data, size_t size, CharEncoding enc,
+                                size_t bom_length);
+
+} // namespace libvroom

--- a/include/libvroom/options.h
+++ b/include/libvroom/options.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cache.h"
+#include "encoding.h"
 #include "error.h"
 #include "types.h"
 
@@ -34,6 +35,9 @@ struct CsvOptions {
   // Error handling (DISABLED = no collection for max performance)
   ErrorMode error_mode = ErrorMode::DISABLED;
   size_t max_errors = ErrorCollector::DEFAULT_MAX_ERRORS;
+
+  // Character encoding (nullopt = auto-detect)
+  std::optional<CharEncoding> encoding;
 
   // Index caching (nullopt = disabled)
   std::optional<CacheConfig> cache;

--- a/include/libvroom/vroom.h
+++ b/include/libvroom/vroom.h
@@ -136,6 +136,9 @@ public:
   // Get total number of rows (only valid after read_all() is called)
   size_t row_count() const;
 
+  // Get detected encoding (valid after open/open_from_buffer)
+  const EncodingResult& encoding() const;
+
   // Get collected errors (only populated when error_mode != DISABLED)
   const std::vector<ParseError>& errors() const;
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -199,6 +199,7 @@ endif()
 # =============================================================================
 set(LIBVROOM_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
 set(VROOM_SOURCES
+    ${LIBVROOM_ROOT}/src/encoding.cpp
     ${LIBVROOM_ROOT}/src/error.cpp
     ${LIBVROOM_ROOT}/src/io_util.cpp
     ${LIBVROOM_ROOT}/src/dialect.cpp

--- a/src/encoding.cpp
+++ b/src/encoding.cpp
@@ -1,0 +1,481 @@
+/**
+ * @file encoding.cpp
+ * @brief Character encoding detection and transcoding implementation.
+ *
+ * Uses simdutf for SIMD-accelerated encoding conversion. Custom handling
+ * for Windows-1252 (0x80-0x9F range) which simdutf doesn't support.
+ */
+
+#include "libvroom/encoding.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <simdutf.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace libvroom {
+
+const char* encoding_to_string(CharEncoding enc) {
+  switch (enc) {
+  case CharEncoding::UTF8:
+    return "UTF-8";
+  case CharEncoding::UTF8_BOM:
+    return "UTF-8 (BOM)";
+  case CharEncoding::UTF16_LE:
+    return "UTF-16LE";
+  case CharEncoding::UTF16_BE:
+    return "UTF-16BE";
+  case CharEncoding::UTF32_LE:
+    return "UTF-32LE";
+  case CharEncoding::UTF32_BE:
+    return "UTF-32BE";
+  case CharEncoding::LATIN1:
+    return "Latin-1";
+  case CharEncoding::WINDOWS_1252:
+    return "Windows-1252";
+  case CharEncoding::UNKNOWN:
+    return "Unknown";
+  }
+  return "Unknown";
+}
+
+CharEncoding parse_encoding_name(std::string_view name) {
+  // Normalize: lowercase, remove hyphens and underscores
+  std::string normalized;
+  normalized.reserve(name.size());
+  for (char c : name) {
+    if (c != '-' && c != '_') {
+      normalized += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+  }
+
+  if (normalized == "utf8")
+    return CharEncoding::UTF8;
+  if (normalized == "utf16le")
+    return CharEncoding::UTF16_LE;
+  if (normalized == "utf16be")
+    return CharEncoding::UTF16_BE;
+  if (normalized == "utf32le")
+    return CharEncoding::UTF32_LE;
+  if (normalized == "utf32be")
+    return CharEncoding::UTF32_BE;
+  if (normalized == "latin1" || normalized == "iso88591")
+    return CharEncoding::LATIN1;
+  if (normalized == "windows1252" || normalized == "cp1252" || normalized == "win1252")
+    return CharEncoding::WINDOWS_1252;
+
+  return CharEncoding::UNKNOWN;
+}
+
+// Windows-1252 lookup table for bytes 0x80-0x9F.
+// These map to Unicode code points that differ from Latin-1.
+// Entries of 0 indicate undefined bytes (mapped to U+FFFD replacement char).
+static const uint32_t windows1252_to_unicode[32] = {
+    0x20AC, // 0x80 -> Euro sign
+    0,      // 0x81 -> undefined
+    0x201A, // 0x82 -> Single low-9 quotation mark
+    0x0192, // 0x83 -> Latin small letter f with hook
+    0x201E, // 0x84 -> Double low-9 quotation mark
+    0x2026, // 0x85 -> Horizontal ellipsis
+    0x2020, // 0x86 -> Dagger
+    0x2021, // 0x87 -> Double dagger
+    0x02C6, // 0x88 -> Modifier letter circumflex accent
+    0x2030, // 0x89 -> Per mille sign
+    0x0160, // 0x8A -> Latin capital letter S with caron
+    0x2039, // 0x8B -> Single left-pointing angle quotation mark
+    0x0152, // 0x8C -> Latin capital ligature OE
+    0,      // 0x8D -> undefined
+    0x017D, // 0x8E -> Latin capital letter Z with caron
+    0,      // 0x8F -> undefined
+    0,      // 0x90 -> undefined
+    0x2018, // 0x91 -> Left single quotation mark
+    0x2019, // 0x92 -> Right single quotation mark
+    0x201C, // 0x93 -> Left double quotation mark
+    0x201D, // 0x94 -> Right double quotation mark
+    0x2022, // 0x95 -> Bullet
+    0x2013, // 0x96 -> En dash
+    0x2014, // 0x97 -> Em dash
+    0x02DC, // 0x98 -> Small tilde
+    0x2122, // 0x99 -> Trade mark sign
+    0x0161, // 0x9A -> Latin small letter s with caron
+    0x203A, // 0x9B -> Single right-pointing angle quotation mark
+    0x0153, // 0x9C -> Latin small ligature oe
+    0,      // 0x9D -> undefined
+    0x017E, // 0x9E -> Latin small letter z with caron
+    0x0178, // 0x9F -> Latin capital letter Y with diaeresis
+};
+
+// Encode a Unicode code point as UTF-8 bytes. Returns number of bytes written.
+static size_t encode_utf8(uint32_t cp, uint8_t* out) {
+  if (cp < 0x80) {
+    out[0] = static_cast<uint8_t>(cp);
+    return 1;
+  } else if (cp < 0x800) {
+    out[0] = static_cast<uint8_t>(0xC0 | (cp >> 6));
+    out[1] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+    return 2;
+  } else if (cp < 0x10000) {
+    out[0] = static_cast<uint8_t>(0xE0 | (cp >> 12));
+    out[1] = static_cast<uint8_t>(0x80 | ((cp >> 6) & 0x3F));
+    out[2] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+    return 3;
+  } else {
+    out[0] = static_cast<uint8_t>(0xF0 | (cp >> 18));
+    out[1] = static_cast<uint8_t>(0x80 | ((cp >> 12) & 0x3F));
+    out[2] = static_cast<uint8_t>(0x80 | ((cp >> 6) & 0x3F));
+    out[3] = static_cast<uint8_t>(0x80 | (cp & 0x3F));
+    return 4;
+  }
+}
+
+// Check if the data contains any bytes in the Windows-1252 0x80-0x9F range.
+static bool has_windows1252_bytes(const uint8_t* data, size_t size) {
+  for (size_t i = 0; i < size; ++i) {
+    if (data[i] >= 0x80 && data[i] <= 0x9F) {
+      return true;
+    }
+  }
+  return false;
+}
+
+EncodingResult detect_encoding(const uint8_t* data, size_t size) {
+  EncodingResult result;
+
+  if (size == 0) {
+    result.encoding = CharEncoding::UTF8;
+    result.confidence = 1.0;
+    return result;
+  }
+
+  // Check BOM (byte order mark)
+  // Check UTF-32 BOMs first (4 bytes) before UTF-16 (2 bytes)
+  if (size >= 4) {
+    if (data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00) {
+      result.encoding = CharEncoding::UTF32_LE;
+      result.bom_length = 4;
+      result.confidence = 1.0;
+      result.needs_transcoding = true;
+      return result;
+    }
+    if (data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF) {
+      result.encoding = CharEncoding::UTF32_BE;
+      result.bom_length = 4;
+      result.confidence = 1.0;
+      result.needs_transcoding = true;
+      return result;
+    }
+  }
+
+  if (size >= 3) {
+    if (data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) {
+      result.encoding = CharEncoding::UTF8_BOM;
+      result.bom_length = 3;
+      result.confidence = 1.0;
+      result.needs_transcoding = false; // Just skip BOM bytes
+      return result;
+    }
+  }
+
+  if (size >= 2) {
+    if (data[0] == 0xFF && data[1] == 0xFE) {
+      result.encoding = CharEncoding::UTF16_LE;
+      result.bom_length = 2;
+      result.confidence = 1.0;
+      result.needs_transcoding = true;
+      return result;
+    }
+    if (data[0] == 0xFE && data[1] == 0xFF) {
+      result.encoding = CharEncoding::UTF16_BE;
+      result.bom_length = 2;
+      result.confidence = 1.0;
+      result.needs_transcoding = true;
+      return result;
+    }
+  }
+
+  // No BOM found — heuristic detection.
+  // Check for null byte patterns first, since null bytes are valid UTF-8
+  // but strongly indicate UTF-16/32 encoding in text data.
+  if (size >= 4) {
+    // UTF-32: every 4th byte pattern
+    bool could_be_utf32_le = true;
+    bool could_be_utf32_be = true;
+    size_t check_bytes = std::min(size, size_t(256));
+    // Ensure we check a multiple of 4 bytes
+    check_bytes = (check_bytes / 4) * 4;
+
+    if (check_bytes >= 4) {
+      for (size_t i = 0; i < check_bytes; i += 4) {
+        // UTF-32 LE: significant byte first, then nulls
+        if (data[i + 2] != 0 || data[i + 3] != 0) {
+          could_be_utf32_le = false;
+        }
+        // UTF-32 BE: nulls first, then significant byte
+        if (data[i] != 0 || data[i + 1] != 0) {
+          could_be_utf32_be = false;
+        }
+        if (!could_be_utf32_le && !could_be_utf32_be)
+          break;
+      }
+
+      if (could_be_utf32_le) {
+        result.encoding = CharEncoding::UTF32_LE;
+        result.confidence = 0.8;
+        result.needs_transcoding = true;
+        return result;
+      }
+      if (could_be_utf32_be) {
+        result.encoding = CharEncoding::UTF32_BE;
+        result.confidence = 0.8;
+        result.needs_transcoding = true;
+        return result;
+      }
+    }
+  }
+
+  // Check for UTF-16 null byte patterns
+  if (size >= 2) {
+    size_t null_even = 0; // Nulls at even positions (UTF-16BE pattern)
+    size_t null_odd = 0;  // Nulls at odd positions (UTF-16LE pattern)
+    size_t check_bytes = std::min(size, size_t(256));
+    // Ensure we check a multiple of 2 bytes
+    check_bytes = (check_bytes / 2) * 2;
+
+    for (size_t i = 0; i < check_bytes; i += 2) {
+      if (data[i] == 0)
+        null_even++;
+      if (data[i + 1] == 0)
+        null_odd++;
+    }
+
+    size_t pairs = check_bytes / 2;
+    // If most odd bytes are null -> UTF-16LE (ASCII range)
+    if (null_odd > pairs / 2 && null_even < pairs / 4) {
+      result.encoding = CharEncoding::UTF16_LE;
+      result.confidence = 0.7;
+      result.needs_transcoding = true;
+      return result;
+    }
+    // If most even bytes are null -> UTF-16BE
+    if (null_even > pairs / 2 && null_odd < pairs / 4) {
+      result.encoding = CharEncoding::UTF16_BE;
+      result.confidence = 0.7;
+      result.needs_transcoding = true;
+      return result;
+    }
+  }
+
+  // No null byte patterns found. Check if it's valid UTF-8.
+  if (simdutf::validate_utf8(reinterpret_cast<const char*>(data), size)) {
+    result.encoding = CharEncoding::UTF8;
+    result.confidence = 1.0;
+    result.needs_transcoding = false;
+    return result;
+  }
+
+  // Not valid UTF-8 and not UTF-16/32 — likely a single-byte encoding.
+  // Check for Windows-1252 bytes (0x80-0x9F range differs from Latin-1).
+  if (has_windows1252_bytes(data, std::min(size, size_t(4096)))) {
+    result.encoding = CharEncoding::WINDOWS_1252;
+    result.confidence = 0.6;
+    result.needs_transcoding = true;
+    return result;
+  }
+
+  // Default to Latin-1 for any non-UTF-8 single-byte data
+  result.encoding = CharEncoding::LATIN1;
+  result.confidence = 0.5;
+  result.needs_transcoding = true;
+  return result;
+}
+
+// Transcode Windows-1252 to UTF-8.
+// Handles the 0x80-0x9F range via lookup table, delegates 0xA0-0xFF to Latin-1 path.
+static AlignedBuffer transcode_windows1252_to_utf8(const uint8_t* data, size_t size) {
+  // Worst case: each byte could become 3 UTF-8 bytes (for BMP code points)
+  AlignedBuffer buf = AlignedBuffer::allocate(size * 3);
+  uint8_t* out = buf.data();
+  size_t out_len = 0;
+
+  for (size_t i = 0; i < size; ++i) {
+    uint8_t byte = data[i];
+    if (byte < 0x80) {
+      // ASCII: pass through
+      out[out_len++] = byte;
+    } else if (byte >= 0x80 && byte <= 0x9F) {
+      // Windows-1252 specific range
+      uint32_t cp = windows1252_to_unicode[byte - 0x80];
+      if (cp == 0) {
+        // Undefined: use U+FFFD replacement character
+        cp = 0xFFFD;
+      }
+      out_len += encode_utf8(cp, out + out_len);
+    } else {
+      // 0xA0-0xFF: same as Latin-1 (Unicode code point == byte value)
+      out_len += encode_utf8(static_cast<uint32_t>(byte), out + out_len);
+    }
+  }
+
+  // AlignedBuffer has no resize(), so we allocate a right-sized copy.
+  // Acceptable since Windows-1252 files are typically small.
+  AlignedBuffer result = AlignedBuffer::allocate(out_len);
+  std::memcpy(result.data(), buf.data(), out_len);
+  return result;
+}
+
+AlignedBuffer transcode_to_utf8(const uint8_t* data, size_t size, CharEncoding enc,
+                                size_t bom_length) {
+  // Skip BOM
+  const uint8_t* src = data + bom_length;
+  size_t src_size = size - bom_length;
+
+  switch (enc) {
+  case CharEncoding::UTF8:
+  case CharEncoding::UTF8_BOM: {
+    // Just copy without BOM
+    AlignedBuffer buf = AlignedBuffer::allocate(src_size);
+    std::memcpy(buf.data(), src, src_size);
+    return buf;
+  }
+
+  case CharEncoding::UTF16_LE: {
+    // Copy into aligned char16_t buffer to avoid UB from misaligned reinterpret_cast.
+    // Current callers (mmap, AlignedBuffer) are 64-byte aligned with even BOM sizes,
+    // but this is a public API so we don't assume alignment.
+    size_t src16_len = src_size / 2;
+    std::vector<char16_t> aligned16(src16_len);
+    std::memcpy(aligned16.data(), src, src16_len * sizeof(char16_t));
+
+    size_t utf8_len = simdutf::utf8_length_from_utf16le(aligned16.data(), src16_len);
+    AlignedBuffer buf = AlignedBuffer::allocate(utf8_len);
+
+    size_t written = simdutf::convert_utf16le_to_utf8(aligned16.data(), src16_len,
+                                                      reinterpret_cast<char*>(buf.data()));
+    if (written == 0 && src16_len > 0) {
+      throw std::runtime_error("Failed to transcode UTF-16LE to UTF-8");
+    }
+
+    if (written != utf8_len) {
+      AlignedBuffer result = AlignedBuffer::allocate(written);
+      std::memcpy(result.data(), buf.data(), written);
+      return result;
+    }
+    return buf;
+  }
+
+  case CharEncoding::UTF16_BE: {
+    size_t src16_len = src_size / 2;
+    std::vector<char16_t> aligned16(src16_len);
+    std::memcpy(aligned16.data(), src, src16_len * sizeof(char16_t));
+
+    size_t utf8_len = simdutf::utf8_length_from_utf16be(aligned16.data(), src16_len);
+    AlignedBuffer buf = AlignedBuffer::allocate(utf8_len);
+
+    size_t written = simdutf::convert_utf16be_to_utf8(aligned16.data(), src16_len,
+                                                      reinterpret_cast<char*>(buf.data()));
+    if (written == 0 && src16_len > 0) {
+      throw std::runtime_error("Failed to transcode UTF-16BE to UTF-8");
+    }
+
+    if (written != utf8_len) {
+      AlignedBuffer result = AlignedBuffer::allocate(written);
+      std::memcpy(result.data(), buf.data(), written);
+      return result;
+    }
+    return buf;
+  }
+
+  case CharEncoding::UTF32_LE: {
+    size_t src32_len = src_size / 4;
+    std::vector<char32_t> aligned32(src32_len);
+    std::memcpy(aligned32.data(), src, src32_len * sizeof(char32_t));
+
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    // Byte-swap for big-endian machines
+    for (size_t i = 0; i < src32_len; ++i) {
+      uint32_t val = static_cast<uint32_t>(aligned32[i]);
+      aligned32[i] = static_cast<char32_t>(__builtin_bswap32(val));
+    }
+#endif
+
+    size_t utf8_len = simdutf::utf8_length_from_utf32(aligned32.data(), src32_len);
+    AlignedBuffer buf = AlignedBuffer::allocate(utf8_len);
+
+    size_t written = simdutf::convert_utf32_to_utf8(aligned32.data(), src32_len,
+                                                    reinterpret_cast<char*>(buf.data()));
+    if (written == 0 && src32_len > 0) {
+      throw std::runtime_error("Failed to transcode UTF-32LE to UTF-8");
+    }
+
+    if (written != utf8_len) {
+      AlignedBuffer result = AlignedBuffer::allocate(written);
+      std::memcpy(result.data(), buf.data(), written);
+      return result;
+    }
+    return buf;
+  }
+
+  case CharEncoding::UTF32_BE: {
+    size_t src32_len = src_size / 4;
+    std::vector<char32_t> aligned32(src32_len);
+    std::memcpy(aligned32.data(), src, src32_len * sizeof(char32_t));
+
+#if __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__
+    // Byte-swap for little-endian machines (common case)
+    for (size_t i = 0; i < src32_len; ++i) {
+      uint32_t val = static_cast<uint32_t>(aligned32[i]);
+      aligned32[i] = static_cast<char32_t>(__builtin_bswap32(val));
+    }
+#endif
+
+    size_t utf8_len = simdutf::utf8_length_from_utf32(aligned32.data(), src32_len);
+    AlignedBuffer buf = AlignedBuffer::allocate(utf8_len);
+
+    size_t written = simdutf::convert_utf32_to_utf8(aligned32.data(), src32_len,
+                                                    reinterpret_cast<char*>(buf.data()));
+    if (written == 0 && src32_len > 0) {
+      throw std::runtime_error("Failed to transcode UTF-32BE to UTF-8");
+    }
+
+    if (written != utf8_len) {
+      AlignedBuffer result = AlignedBuffer::allocate(written);
+      std::memcpy(result.data(), buf.data(), written);
+      return result;
+    }
+    return buf;
+  }
+
+  case CharEncoding::LATIN1: {
+    size_t utf8_len =
+        simdutf::utf8_length_from_latin1(reinterpret_cast<const char*>(src), src_size);
+    AlignedBuffer buf = AlignedBuffer::allocate(utf8_len);
+
+    size_t written = simdutf::convert_latin1_to_utf8(reinterpret_cast<const char*>(src), src_size,
+                                                     reinterpret_cast<char*>(buf.data()));
+    if (written == 0 && src_size > 0) {
+      throw std::runtime_error("Failed to transcode Latin-1 to UTF-8");
+    }
+
+    if (written != utf8_len) {
+      AlignedBuffer result = AlignedBuffer::allocate(written);
+      std::memcpy(result.data(), buf.data(), written);
+      return result;
+    }
+    return buf;
+  }
+
+  case CharEncoding::WINDOWS_1252: {
+    return transcode_windows1252_to_utf8(src, src_size);
+  }
+
+  case CharEncoding::UNKNOWN:
+    throw std::runtime_error("Cannot transcode from unknown encoding");
+  }
+
+  throw std::runtime_error("Unsupported encoding for transcoding");
+}
+
+} // namespace libvroom

--- a/test/encoding_test.cpp
+++ b/test/encoding_test.cpp
@@ -1,0 +1,529 @@
+/**
+ * @file encoding_test.cpp
+ * @brief Tests for character encoding detection and transcoding (Issue #636).
+ */
+
+#include "libvroom/encoding.h"
+#include "libvroom/io_util.h"
+#include "libvroom/vroom.h"
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using namespace libvroom;
+
+// Helper: path to test data files (copied to build dir by CMake)
+static std::string testDataPath(const std::string& subpath) {
+  return "test/data/encoding/" + subpath;
+}
+
+// =============================================================================
+// BOM Detection Tests
+// =============================================================================
+
+TEST(EncodingDetection, UTF8BOM) {
+  const uint8_t data[] = {0xEF, 0xBB, 0xBF, 'h', 'i'};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF8_BOM);
+  EXPECT_EQ(result.bom_length, 3u);
+  EXPECT_FALSE(result.needs_transcoding);
+  EXPECT_TRUE(result.success());
+}
+
+TEST(EncodingDetection, UTF16LEBOM) {
+  const uint8_t data[] = {0xFF, 0xFE, 'h', 0, 'i', 0};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF16_LE);
+  EXPECT_EQ(result.bom_length, 2u);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, UTF16BEBOM) {
+  const uint8_t data[] = {0xFE, 0xFF, 0, 'h', 0, 'i'};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF16_BE);
+  EXPECT_EQ(result.bom_length, 2u);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, UTF32LEBOM) {
+  const uint8_t data[] = {0xFF, 0xFE, 0x00, 0x00, 'h', 0, 0, 0};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF32_LE);
+  EXPECT_EQ(result.bom_length, 4u);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, UTF32BEBOM) {
+  const uint8_t data[] = {0x00, 0x00, 0xFE, 0xFF, 0, 0, 0, 'h'};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF32_BE);
+  EXPECT_EQ(result.bom_length, 4u);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, UTF32LEBOMNotConfusedWithUTF16LE) {
+  // The UTF-32 LE BOM starts with FF FE (same as UTF-16 LE BOM)
+  // but is followed by 00 00. Must detect as UTF-32 LE, not UTF-16 LE.
+  const uint8_t data[] = {0xFF, 0xFE, 0x00, 0x00, 'A', 0, 0, 0};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF32_LE);
+  EXPECT_EQ(result.bom_length, 4u);
+}
+
+TEST(EncodingDetection, EmptyBuffer) {
+  auto result = detect_encoding(nullptr, 0);
+  EXPECT_EQ(result.encoding, CharEncoding::UTF8);
+  EXPECT_EQ(result.bom_length, 0u);
+  EXPECT_FALSE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, TinyBuffer) {
+  const uint8_t data[] = {'A'};
+  auto result = detect_encoding(data, 1);
+  EXPECT_EQ(result.encoding, CharEncoding::UTF8);
+  EXPECT_FALSE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, PartialBOM) {
+  // Just the first two bytes of a UTF-8 BOM — not a valid BOM
+  const uint8_t data[] = {0xEF, 0xBB, 'h', 'i'};
+  auto result = detect_encoding(data, sizeof(data));
+  // Should not detect as UTF-8 BOM
+  EXPECT_NE(result.encoding, CharEncoding::UTF8_BOM);
+}
+
+// =============================================================================
+// Heuristic Detection Tests
+// =============================================================================
+
+TEST(EncodingDetection, PureASCII) {
+  const char* text = "name,value\nAlice,100\nBob,200\n";
+  auto result = detect_encoding(reinterpret_cast<const uint8_t*>(text), std::strlen(text));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF8);
+  EXPECT_FALSE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, ValidUTF8WithHighBytes) {
+  // UTF-8 encoded "José" = 4A 6F 73 C3 A9
+  const uint8_t data[] = {0x4A, 0x6F, 0x73, 0xC3, 0xA9, 0x0A};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF8);
+  EXPECT_FALSE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, UTF16LEWithoutBOM) {
+  // ASCII text in UTF-16LE: null bytes at odd positions
+  const uint8_t data[] = {'n', 0, 'a', 0, 'm', 0, 'e',  0, ',', 0, 'v', 0, 'a',  0,
+                          'l', 0, 'u', 0, 'e', 0, '\n', 0, 'A', 0, 'l', 0, 'i',  0,
+                          'c', 0, 'e', 0, ',', 0, '1',  0, '0', 0, '0', 0, '\n', 0};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF16_LE);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, UTF16BEWithoutBOM) {
+  // ASCII text in UTF-16BE: null bytes at even positions
+  const uint8_t data[] = {0, 'n', 0, 'a', 0, 'm', 0, 'e',  0, ',', 0, 'v', 0, 'a',
+                          0, 'l', 0, 'u', 0, 'e', 0, '\n', 0, 'A', 0, 'l', 0, 'i',
+                          0, 'c', 0, 'e', 0, ',', 0, '1',  0, '0', 0, '0', 0, '\n'};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::UTF16_BE);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, Latin1SingleByteHighBytes) {
+  // Latin-1: bytes in 0xA0-0xFF range, no 0x80-0x9F bytes
+  // "café" in Latin-1: 63 61 66 E9
+  const uint8_t data[] = {'c', 'a', 'f', 0xE9, '\n'};
+  auto result = detect_encoding(data, sizeof(data));
+  // Should detect as either Latin-1 or Windows-1252 (both valid)
+  EXPECT_TRUE(result.encoding == CharEncoding::LATIN1 ||
+              result.encoding == CharEncoding::WINDOWS_1252);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+TEST(EncodingDetection, Windows1252SmartQuotes) {
+  // Windows-1252 "smart quotes": 0x93 = left double quote, 0x94 = right double quote
+  const uint8_t data[] = {'H', 'e', ' ', 's', 'a', 'i', 'd', ' ', 0x93, 'h', 'i', 0x94, '\n'};
+  auto result = detect_encoding(data, sizeof(data));
+  EXPECT_EQ(result.encoding, CharEncoding::WINDOWS_1252);
+  EXPECT_TRUE(result.needs_transcoding);
+}
+
+// =============================================================================
+// Encoding Name Parsing Tests
+// =============================================================================
+
+TEST(EncodingNameParsing, UTF8Variants) {
+  EXPECT_EQ(parse_encoding_name("utf-8"), CharEncoding::UTF8);
+  EXPECT_EQ(parse_encoding_name("UTF-8"), CharEncoding::UTF8);
+  EXPECT_EQ(parse_encoding_name("utf8"), CharEncoding::UTF8);
+  EXPECT_EQ(parse_encoding_name("UTF8"), CharEncoding::UTF8);
+}
+
+TEST(EncodingNameParsing, UTF16Variants) {
+  EXPECT_EQ(parse_encoding_name("utf-16le"), CharEncoding::UTF16_LE);
+  EXPECT_EQ(parse_encoding_name("UTF-16LE"), CharEncoding::UTF16_LE);
+  EXPECT_EQ(parse_encoding_name("utf-16be"), CharEncoding::UTF16_BE);
+  EXPECT_EQ(parse_encoding_name("UTF-16BE"), CharEncoding::UTF16_BE);
+  EXPECT_EQ(parse_encoding_name("utf16le"), CharEncoding::UTF16_LE);
+  EXPECT_EQ(parse_encoding_name("utf16be"), CharEncoding::UTF16_BE);
+}
+
+TEST(EncodingNameParsing, UTF32Variants) {
+  EXPECT_EQ(parse_encoding_name("utf-32le"), CharEncoding::UTF32_LE);
+  EXPECT_EQ(parse_encoding_name("utf-32be"), CharEncoding::UTF32_BE);
+  EXPECT_EQ(parse_encoding_name("UTF-32LE"), CharEncoding::UTF32_LE);
+  EXPECT_EQ(parse_encoding_name("UTF-32BE"), CharEncoding::UTF32_BE);
+}
+
+TEST(EncodingNameParsing, Latin1Variants) {
+  EXPECT_EQ(parse_encoding_name("latin1"), CharEncoding::LATIN1);
+  EXPECT_EQ(parse_encoding_name("Latin1"), CharEncoding::LATIN1);
+  EXPECT_EQ(parse_encoding_name("iso-8859-1"), CharEncoding::LATIN1);
+  EXPECT_EQ(parse_encoding_name("ISO-8859-1"), CharEncoding::LATIN1);
+}
+
+TEST(EncodingNameParsing, Windows1252Variants) {
+  EXPECT_EQ(parse_encoding_name("windows-1252"), CharEncoding::WINDOWS_1252);
+  EXPECT_EQ(parse_encoding_name("Windows-1252"), CharEncoding::WINDOWS_1252);
+  EXPECT_EQ(parse_encoding_name("cp1252"), CharEncoding::WINDOWS_1252);
+  EXPECT_EQ(parse_encoding_name("CP1252"), CharEncoding::WINDOWS_1252);
+  EXPECT_EQ(parse_encoding_name("win-1252"), CharEncoding::WINDOWS_1252);
+}
+
+TEST(EncodingNameParsing, Unknown) {
+  EXPECT_EQ(parse_encoding_name("ebcdic"), CharEncoding::UNKNOWN);
+  EXPECT_EQ(parse_encoding_name(""), CharEncoding::UNKNOWN);
+  EXPECT_EQ(parse_encoding_name("invalid"), CharEncoding::UNKNOWN);
+}
+
+// =============================================================================
+// encoding_to_string Tests
+// =============================================================================
+
+TEST(EncodingToString, AllValues) {
+  EXPECT_STREQ(encoding_to_string(CharEncoding::UTF8), "UTF-8");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::UTF8_BOM), "UTF-8 (BOM)");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::UTF16_LE), "UTF-16LE");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::UTF16_BE), "UTF-16BE");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::UTF32_LE), "UTF-32LE");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::UTF32_BE), "UTF-32BE");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::LATIN1), "Latin-1");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::WINDOWS_1252), "Windows-1252");
+  EXPECT_STREQ(encoding_to_string(CharEncoding::UNKNOWN), "Unknown");
+}
+
+// =============================================================================
+// Transcoding Tests
+// =============================================================================
+
+TEST(Transcoding, UTF8BOMStripped) {
+  const uint8_t data[] = {0xEF, 0xBB, 0xBF, 'h', 'i'};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::UTF8_BOM, 3);
+  ASSERT_TRUE(buf.valid());
+  EXPECT_EQ(buf.size(), 2u);
+  EXPECT_EQ(buf.data()[0], 'h');
+  EXPECT_EQ(buf.data()[1], 'i');
+}
+
+TEST(Transcoding, UTF16LEBasic) {
+  // "hi\n" in UTF-16LE
+  const uint8_t data[] = {'h', 0, 'i', 0, '\n', 0};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::UTF16_LE, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  EXPECT_EQ(result, "hi\n");
+}
+
+TEST(Transcoding, UTF16LEWithBOM) {
+  // BOM + "hi\n" in UTF-16LE
+  const uint8_t data[] = {0xFF, 0xFE, 'h', 0, 'i', 0, '\n', 0};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::UTF16_LE, 2);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  EXPECT_EQ(result, "hi\n");
+}
+
+TEST(Transcoding, UTF16BEBasic) {
+  // "hi\n" in UTF-16BE
+  const uint8_t data[] = {0, 'h', 0, 'i', 0, '\n'};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::UTF16_BE, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  EXPECT_EQ(result, "hi\n");
+}
+
+TEST(Transcoding, UTF16LEAccentedChars) {
+  // "José\n" in UTF-16LE: J=4A00, o=6F00, s=7300, é=E900, \n=0A00
+  const uint8_t data[] = {0x4A, 0x00, 0x6F, 0x00, 0x73, 0x00, 0xE9, 0x00, 0x0A, 0x00};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::UTF16_LE, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  EXPECT_EQ(result, "Jos\xC3\xA9\n"); // UTF-8 é = C3 A9
+}
+
+TEST(Transcoding, UTF32LEBasic) {
+  // "hi\n" in UTF-32LE
+  const uint8_t data[] = {'h', 0, 0, 0, 'i', 0, 0, 0, '\n', 0, 0, 0};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::UTF32_LE, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  EXPECT_EQ(result, "hi\n");
+}
+
+TEST(Transcoding, UTF32BEBasic) {
+  // "hi\n" in UTF-32BE
+  const uint8_t data[] = {0, 0, 0, 'h', 0, 0, 0, 'i', 0, 0, 0, '\n'};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::UTF32_BE, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  EXPECT_EQ(result, "hi\n");
+}
+
+TEST(Transcoding, Latin1Basic) {
+  // "café\n" in Latin-1: 63 61 66 E9 0A
+  const uint8_t data[] = {0x63, 0x61, 0x66, 0xE9, 0x0A};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::LATIN1, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  EXPECT_EQ(result, "caf\xC3\xA9\n"); // UTF-8 é = C3 A9
+}
+
+TEST(Transcoding, Windows1252SmartQuotes) {
+  // 0x93 = left double quote (U+201C), 0x94 = right double quote (U+201D)
+  const uint8_t data[] = {0x93, 'h', 'i', 0x94};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::WINDOWS_1252, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  // U+201C = E2 80 9C, U+201D = E2 80 9D
+  EXPECT_EQ(result, "\xE2\x80\x9C"
+                    "hi"
+                    "\xE2\x80\x9D");
+}
+
+TEST(Transcoding, Windows1252EuroSign) {
+  // 0x80 = Euro sign (U+20AC)
+  const uint8_t data[] = {0x80};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::WINDOWS_1252, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  // U+20AC = E2 82 AC
+  EXPECT_EQ(result, "\xE2\x82\xAC");
+}
+
+TEST(Transcoding, Windows1252UndefinedByte) {
+  // 0x81 is undefined in Windows-1252, should map to U+FFFD
+  const uint8_t data[] = {0x81};
+  auto buf = transcode_to_utf8(data, sizeof(data), CharEncoding::WINDOWS_1252, 0);
+  ASSERT_TRUE(buf.valid());
+  std::string result(reinterpret_cast<const char*>(buf.data()), buf.size());
+  // U+FFFD = EF BF BD
+  EXPECT_EQ(result, "\xEF\xBF\xBD");
+}
+
+TEST(Transcoding, UnknownEncodingThrows) {
+  const uint8_t data[] = {'h', 'i'};
+  EXPECT_THROW(transcode_to_utf8(data, sizeof(data), CharEncoding::UNKNOWN, 0), std::runtime_error);
+}
+
+// =============================================================================
+// File Loading Tests
+// =============================================================================
+
+TEST(EncodingFileLoading, UTF8BOMFile) {
+  auto buf = load_file_to_ptr(testDataPath("utf8_bom.csv"));
+  auto result = detect_encoding(buf.data(), buf.size());
+  EXPECT_EQ(result.encoding, CharEncoding::UTF8_BOM);
+  EXPECT_EQ(result.bom_length, 3u);
+  EXPECT_FALSE(result.needs_transcoding);
+}
+
+TEST(EncodingFileLoading, UTF16LEBOMFile) {
+  auto buf = load_file_to_ptr(testDataPath("utf16_le_bom.csv"));
+  auto result = detect_encoding(buf.data(), buf.size());
+  EXPECT_EQ(result.encoding, CharEncoding::UTF16_LE);
+  EXPECT_EQ(result.bom_length, 2u);
+  EXPECT_TRUE(result.needs_transcoding);
+
+  // Transcode and verify content
+  auto utf8 = transcode_to_utf8(buf.data(), buf.size(), result.encoding, result.bom_length);
+  std::string content(reinterpret_cast<const char*>(utf8.data()), utf8.size());
+  EXPECT_NE(content.find("name,city,country"), std::string::npos);
+  EXPECT_NE(content.find("Jos"), std::string::npos);
+}
+
+TEST(EncodingFileLoading, UTF16BEBOMFile) {
+  auto buf = load_file_to_ptr(testDataPath("utf16_be_bom.csv"));
+  auto result = detect_encoding(buf.data(), buf.size());
+  EXPECT_EQ(result.encoding, CharEncoding::UTF16_BE);
+  EXPECT_EQ(result.bom_length, 2u);
+  EXPECT_TRUE(result.needs_transcoding);
+
+  auto utf8 = transcode_to_utf8(buf.data(), buf.size(), result.encoding, result.bom_length);
+  std::string content(reinterpret_cast<const char*>(utf8.data()), utf8.size());
+  EXPECT_NE(content.find("name,city,country"), std::string::npos);
+}
+
+TEST(EncodingFileLoading, UTF32LEBOMFile) {
+  auto buf = load_file_to_ptr(testDataPath("utf32_le_bom.csv"));
+  auto result = detect_encoding(buf.data(), buf.size());
+  EXPECT_EQ(result.encoding, CharEncoding::UTF32_LE);
+  EXPECT_EQ(result.bom_length, 4u);
+  EXPECT_TRUE(result.needs_transcoding);
+
+  auto utf8 = transcode_to_utf8(buf.data(), buf.size(), result.encoding, result.bom_length);
+  std::string content(reinterpret_cast<const char*>(utf8.data()), utf8.size());
+  EXPECT_NE(content.find("name,city,country"), std::string::npos);
+}
+
+TEST(EncodingFileLoading, UTF32BEBOMFile) {
+  auto buf = load_file_to_ptr(testDataPath("utf32_be_bom.csv"));
+  auto result = detect_encoding(buf.data(), buf.size());
+  EXPECT_EQ(result.encoding, CharEncoding::UTF32_BE);
+  EXPECT_EQ(result.bom_length, 4u);
+  EXPECT_TRUE(result.needs_transcoding);
+
+  auto utf8 = transcode_to_utf8(buf.data(), buf.size(), result.encoding, result.bom_length);
+  std::string content(reinterpret_cast<const char*>(utf8.data()), utf8.size());
+  EXPECT_NE(content.find("name,city,country"), std::string::npos);
+}
+
+TEST(EncodingFileLoading, Latin1File) {
+  auto buf = load_file_to_ptr(testDataPath("latin1.csv"));
+  auto result = detect_encoding(buf.data(), buf.size());
+  // Latin-1 with accented chars (0xE9, 0xE1, 0xE7) in 0xA0-0xFF range
+  // These are not valid UTF-8, so should be detected as LATIN1 or WINDOWS_1252
+  EXPECT_TRUE(result.encoding == CharEncoding::LATIN1 ||
+              result.encoding == CharEncoding::WINDOWS_1252);
+  EXPECT_TRUE(result.needs_transcoding);
+
+  // Transcode with Latin-1
+  auto utf8 = transcode_to_utf8(buf.data(), buf.size(), CharEncoding::LATIN1, 0);
+  std::string content(reinterpret_cast<const char*>(utf8.data()), utf8.size());
+  EXPECT_NE(content.find("name,city"), std::string::npos);
+  // "José" should now be valid UTF-8
+  EXPECT_NE(content.find("Jos\xC3\xA9"), std::string::npos);
+}
+
+// =============================================================================
+// CsvReader Integration Tests
+// =============================================================================
+
+TEST(CsvReaderEncoding, UTF8BOMFile) {
+  CsvOptions opts;
+  CsvReader reader(opts);
+  auto result = reader.open(testDataPath("utf8_bom.csv"));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::UTF8_BOM);
+  EXPECT_EQ(reader.encoding().bom_length, 3u);
+
+  // Verify header is parsed correctly (BOM was stripped)
+  ASSERT_EQ(reader.schema().size(), 2u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+  EXPECT_EQ(reader.schema()[1].name, "value");
+
+  auto read_result = reader.read_all();
+  ASSERT_TRUE(read_result.ok) << read_result.error;
+  EXPECT_EQ(read_result.value.total_rows, 2u);
+}
+
+TEST(CsvReaderEncoding, UTF16LEBOMFile) {
+  CsvOptions opts;
+  CsvReader reader(opts);
+  auto result = reader.open(testDataPath("utf16_le_bom.csv"));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::UTF16_LE);
+  EXPECT_TRUE(reader.encoding().needs_transcoding);
+
+  // Verify header is parsed correctly after transcoding
+  ASSERT_EQ(reader.schema().size(), 3u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+  EXPECT_EQ(reader.schema()[1].name, "city");
+  EXPECT_EQ(reader.schema()[2].name, "country");
+
+  auto read_result = reader.read_all();
+  ASSERT_TRUE(read_result.ok) << read_result.error;
+  EXPECT_GT(read_result.value.total_rows, 0u);
+}
+
+TEST(CsvReaderEncoding, UTF16BEBOMFile) {
+  CsvOptions opts;
+  CsvReader reader(opts);
+  auto result = reader.open(testDataPath("utf16_be_bom.csv"));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::UTF16_BE);
+  ASSERT_EQ(reader.schema().size(), 3u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+}
+
+TEST(CsvReaderEncoding, UTF32LEBOMFile) {
+  CsvOptions opts;
+  CsvReader reader(opts);
+  auto result = reader.open(testDataPath("utf32_le_bom.csv"));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::UTF32_LE);
+  ASSERT_EQ(reader.schema().size(), 3u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+}
+
+TEST(CsvReaderEncoding, UTF32BEBOMFile) {
+  CsvOptions opts;
+  CsvReader reader(opts);
+  auto result = reader.open(testDataPath("utf32_be_bom.csv"));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::UTF32_BE);
+  ASSERT_EQ(reader.schema().size(), 3u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+}
+
+TEST(CsvReaderEncoding, Latin1FileWithForcedEncoding) {
+  CsvOptions opts;
+  opts.encoding = CharEncoding::LATIN1;
+  CsvReader reader(opts);
+  auto result = reader.open(testDataPath("latin1.csv"));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::LATIN1);
+  ASSERT_EQ(reader.schema().size(), 2u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+  EXPECT_EQ(reader.schema()[1].name, "city");
+
+  auto read_result = reader.read_all();
+  ASSERT_TRUE(read_result.ok) << read_result.error;
+  EXPECT_EQ(read_result.value.total_rows, 2u);
+}
+
+TEST(CsvReaderEncoding, ForcedEncodingOverridesAutoDetect) {
+  // Force UTF-16LE on a UTF-16 LE BOM file — should still work
+  CsvOptions opts;
+  opts.encoding = CharEncoding::UTF16_LE;
+  CsvReader reader(opts);
+  auto result = reader.open(testDataPath("utf16_le_bom.csv"));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::UTF16_LE);
+  ASSERT_EQ(reader.schema().size(), 3u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+}
+
+TEST(CsvReaderEncoding, OpenFromBufferUTF16LE) {
+  // Load a UTF-16LE file into a buffer and open_from_buffer
+  auto file_buf = load_file_to_ptr(testDataPath("utf16_le_bom.csv"));
+  CsvOptions opts;
+  CsvReader reader(opts);
+  auto result = reader.open_from_buffer(std::move(file_buf));
+  ASSERT_TRUE(result.ok) << result.error;
+
+  EXPECT_EQ(reader.encoding().encoding, CharEncoding::UTF16_LE);
+  ASSERT_EQ(reader.schema().size(), 3u);
+  EXPECT_EQ(reader.schema()[0].name, "name");
+}


### PR DESCRIPTION
## Summary

Closes #636. Adds character encoding detection and transcoding to UTF-8 before CSV parsing, using simdutf for SIMD-accelerated conversion.

- **Auto-detection**: BOM check → null byte pattern analysis → UTF-8 validation → single-byte encoding fallback
- **Supported encodings**: UTF-8, UTF-8 BOM, UTF-16LE/BE, UTF-32LE/BE, Latin-1, Windows-1252
- **Zero overhead for UTF-8/ASCII**: Just a 4-byte BOM comparison, no allocation or copy
- **UTF-8 BOM**: Handled via pointer adjustment (no copy)
- **Non-UTF-8**: Eager transcoding into AlignedBuffer before parsing begins
- **Windows-1252**: Custom 32-entry lookup table for 0x80-0x9F range (simdutf doesn't support it)
- **New `CharEncoding` enum**: Avoids collision with existing Parquet `Encoding` enum in types.h

### API surfaces updated
- `CsvOptions.encoding` — optional encoding override (nullopt = auto-detect)
- `CsvReader::encoding()` — accessor for detected encoding result
- CLI: `-e`/`--encoding` flag, encoding shown in `vroom info` output
- Python: `encoding` parameter on `read_csv()`

### Files
| File | Change |
|------|--------|
| `include/libvroom/encoding.h` | **New** — CharEncoding enum, EncodingResult, public API |
| `src/encoding.cpp` | **New** — Detection and transcoding via simdutf |
| `test/encoding_test.cpp` | **New** — 48 tests across 6 suites |
| `include/libvroom/options.h` | Add `encoding` to CsvOptions |
| `include/libvroom/vroom.h` | Add `encoding()` to CsvReader |
| `src/reader/csv_reader.cpp` | Detect+transcode in open/open_from_buffer |
| `src/cli.cpp` | `-e` flag, encoding in `info` output |
| `python/src/bindings.cpp` | `encoding` param on `read_csv()` |
| `CMakeLists.txt` | Add source + test target |
| `python/CMakeLists.txt` | Add source |

## Test plan

- [x] 48 new encoding tests pass (BOM detection, heuristic detection, transcoding, file loading, CsvReader integration)
- [x] All 937 existing tests pass — no regressions
- [x] CLI verified manually: `vroom count/head/info` with UTF-16LE/BE, UTF-32LE, Latin-1 files
- [x] `-e latin1` forced encoding override works correctly