### PR TITLE
feat: Re-enable performance regression workflow (#643)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -191,21 +191,20 @@ Automatically detects performance regressions on every push and PR.
 **How it Works:**
 1. Builds the benchmark executable in Release mode
 2. Runs a subset of benchmarks from `parser_overhead_benchmarks.cpp`:
-   - `BM_RawFirstPass` - Raw SIMD first pass scanning performance
-   - `BM_RawTwoPassComplete` - Complete two-pass index building
-   - `BM_ParserWithExplicitDialect` - Full parser overhead with known dialect
-   - `BM_ParserBranchless` - Branchless algorithm variant
-   - `BM_ParserSpeculative` - Speculative multi-threaded algorithm
-   - `BM_ParserMultiThread/1` - Single-threaded parser
-   - `BM_ParserMultiThread/4` - Multi-threaded parser (4 threads)
-3. Compares results against a cached baseline (from main branch)
-4. Fails if any benchmark regresses by more than 10%
+   - `BM_CountRows` - SIMD row counting throughput
+   - `BM_CsvReaderExplicit` - Full CsvReader pipeline with explicit dialect
+   - `BM_CsvReaderAutoDetect` - Full CsvReader pipeline with auto-detection
+   - `BM_CsvReaderMultiThread/1` - Single-threaded CsvReader
+   - `BM_CsvReaderMultiThread/4` - Multi-threaded CsvReader (4 threads)
+   - `BM_CsvReaderMultiThread/8` - Multi-threaded CsvReader (8 threads)
+3. Runs HEAD and BASE benchmarks in the same job for reliable comparison
+4. Fails if any benchmark regresses by more than 15%
 
 **Baseline Management:**
-- Baseline is cached per-OS with a version key (e.g., `benchmark-baseline-v3-Linux-main`)
-- On main branch pushes, the baseline is updated with current results
-- PRs compare against the cached main branch baseline
-- If benchmark names change, increment the cache version in `benchmark.yml`
+- Uses same-job relative benchmarking: HEAD and BASE are both built and run in the same CI job
+- For PRs, BASE is the PR base commit; for pushes to main, BASE is the parent commit
+- CPU affinity (`taskset -c 0`) and scheduling priority (`nice -n -5`) reduce variance
+- Each benchmark runs with 5 repetitions and minimum 0.5s per iteration
 
 **Cache Key Versioning:**
 If you rename benchmarks or change benchmark methodology, you need to reset the baseline:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,10 +14,6 @@ jobs:
   benchmark:
     name: Performance Regression Detection
     runs-on: ubuntu-latest
-    # Benchmarks need to be updated for libvroom2 API before this workflow can run
-    # Skip for now - see issue #XXX for tracking
-    if: false
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -69,7 +65,7 @@ jobs:
         ccache -s
 
     # Run HEAD benchmark first (current PR/commit)
-    # Multi-thread benchmarks (BM_ParserMultiThread/1, /4, /8) are critical for detecting
+    # Multi-thread benchmarks (BM_CsvReaderMultiThread/1, /4, /8) are critical for detecting
     # issue #591-type regressions where multi-threaded parsing gets slower with more threads.
     - name: Run benchmark (HEAD)
       timeout-minutes: 5
@@ -78,7 +74,7 @@ jobs:
         # Use taskset for CPU affinity (pin to CPU 0) and nice for scheduling priority
         # This reduces variance from CPU migration and context switching
         sudo nice -n -5 taskset -c 0 ./build/libvroom_benchmark \
-          --benchmark_filter="BM_RawFirstPass$|BM_RawTwoPassComplete|BM_ParserWithExplicitDialect|BM_ParserBranchless|BM_ParserSpeculative|BM_ParserMultiThread/1$|BM_ParserMultiThread/4$|BM_ParserMultiThread/8$" \
+          --benchmark_filter="BM_CountRows$|BM_CsvReaderExplicit$|BM_CsvReaderAutoDetect$|BM_CsvReaderMultiThread/1$|BM_CsvReaderMultiThread/4$|BM_CsvReaderMultiThread/8$" \
           --benchmark_repetitions=5 \
           --benchmark_min_time=0.5s \
           --benchmark_out=build/head_results.json \
@@ -92,20 +88,22 @@ jobs:
         git checkout ${{ steps.base.outputs.sha }}
 
     - name: Build benchmark (BASE)
+      id: base_build
       if: steps.base.outputs.sha != ''
+      continue-on-error: true
       run: |
         # Clean and rebuild for BASE commit
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON
         cmake --build build --target libvroom_benchmark --config Release -j$(nproc)
 
     - name: Run benchmark (BASE)
-      if: steps.base.outputs.sha != ''
+      if: steps.base.outputs.sha != '' && steps.base_build.outcome == 'success'
       timeout-minutes: 5
       run: |
         echo "=== Benchmarking BASE commit ==="
         # Use same CPU affinity and priority settings for fair comparison
         sudo nice -n -5 taskset -c 0 ./build/libvroom_benchmark \
-          --benchmark_filter="BM_RawFirstPass$|BM_RawTwoPassComplete|BM_ParserWithExplicitDialect|BM_ParserBranchless|BM_ParserSpeculative|BM_ParserMultiThread/1$|BM_ParserMultiThread/4$|BM_ParserMultiThread/8$" \
+          --benchmark_filter="BM_CountRows$|BM_CsvReaderExplicit$|BM_CsvReaderAutoDetect$|BM_CsvReaderMultiThread/1$|BM_CsvReaderMultiThread/4$|BM_CsvReaderMultiThread/8$" \
           --benchmark_repetitions=5 \
           --benchmark_min_time=0.5s \
           --benchmark_out=build/base_results.json \
@@ -118,7 +116,7 @@ jobs:
         git checkout ${{ github.sha }}
 
     - name: Compare benchmarks (same-job relative)
-      if: steps.base.outputs.sha != ''
+      if: steps.base.outputs.sha != '' && steps.base_build.outcome == 'success'
       id: compare
       run: |
         echo "=== Comparing HEAD vs BASE (same-job relative benchmarking) ==="
@@ -128,9 +126,12 @@ jobs:
           --threshold 0.15
 
     - name: Report results (no baseline)
-      if: steps.base.outputs.sha == ''
+      if: steps.base.outputs.sha == '' || steps.base_build.outcome != 'success'
       run: |
-        echo "=== No baseline commit available for comparison ==="
+        echo "=== No baseline available for comparison ==="
+        if [ "${{ steps.base_build.outcome }}" = "failure" ]; then
+          echo "BASE commit benchmarks failed to build (expected during API transitions)."
+        fi
         echo "HEAD benchmark completed successfully."
         jq -r '.benchmarks[] | select(.aggregate_name == null) | "  \(.name): \(.real_time | tostring | .[0:10]) ns"' build/head_results.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,14 +693,12 @@ set(BENCHMARK_SOURCES
     benchmark/performance_metrics.cpp
     benchmark/simd_benchmarks.cpp
     benchmark/energy_benchmarks.cpp
-    benchmark/number_parsing_benchmarks.cpp
     benchmark/error_collection_benchmark.cpp
     benchmark/parser_overhead_benchmarks.cpp
     benchmark/row_reconstruction_benchmarks.cpp
     benchmark/end_to_end_benchmarks.cpp
     benchmark/transpose_benchmarks.cpp
     benchmark/hypothesis_benchmarks.cpp
-    benchmark/escape_tracking_benchmarks.cpp
     benchmark/table_benchmarks.cpp
 )
 

--- a/benchmark/benchmark_main.cpp
+++ b/benchmark/benchmark_main.cpp
@@ -1,7 +1,5 @@
 #include "libvroom.h"
 
-#include "common_defs.h"
-
 #include <benchmark/benchmark.h>
 
 // Global variables for shared test data

--- a/benchmark/check_regression.py
+++ b/benchmark/check_regression.py
@@ -19,7 +19,7 @@ import os
 import shutil
 
 REGRESSION_THRESHOLD = 0.15  # 15% regression threshold (increased for CI variability)
-EXPECTED_BENCHMARK_COUNT = 7  # Number of benchmarks we expect to run
+EXPECTED_BENCHMARK_COUNT = 6  # Number of benchmarks we expect to run
 
 
 def load_benchmark(filepath, check_errors=False):

--- a/benchmark/dimensions_benchmarks.cpp
+++ b/benchmark/dimensions_benchmarks.cpp
@@ -1,8 +1,5 @@
 #include "libvroom.h"
 
-#include "common_defs.h"
-#include "mem_util.h"
-
 #include <benchmark/benchmark.h>
 #include <fstream>
 #include <iomanip>
@@ -98,23 +95,21 @@ static void BM_FileSizes(benchmark::State& state) {
   TempCSVFile temp_file(csv_data);
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
+    size_t file_size = csv_data.size();
 
-    int n_threads = 4;
-    libvroom::Parser parser(n_threads);
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
     // Performance metrics
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["ActualSize"] = static_cast<double>(buffer.size);
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
+    state.counters["ActualSize"] = static_cast<double>(file_size);
     state.counters["TargetSize"] = static_cast<double>(target_size);
     state.counters["Rows"] = static_cast<double>(estimated_rows);
     state.counters["Cols"] = static_cast<double>(cols);
@@ -138,23 +133,21 @@ static void BM_ColumnCounts(benchmark::State& state) {
   TempCSVFile temp_file(csv_data);
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
+    size_t file_size = csv_data.size();
 
-    int n_threads = 4;
-    libvroom::Parser parser(n_threads);
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
     // Performance metrics
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
+    state.counters["FileSize"] = static_cast<double>(file_size);
     state.counters["Columns"] = static_cast<double>(num_cols);
     state.counters["Rows"] = static_cast<double>(num_rows);
 
@@ -199,23 +192,21 @@ static void BM_DataTypes(benchmark::State& state) {
   TempCSVFile temp_file(csv_data);
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
+    size_t file_size = csv_data.size();
 
-    int n_threads = 4;
-    libvroom::Parser parser(n_threads);
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
     // Performance metrics
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
+    state.counters["FileSize"] = static_cast<double>(file_size);
     state.counters["DataType"] = static_cast<double>(data_type);
 
   } catch (const std::exception& e) {
@@ -237,22 +228,21 @@ static void BM_ThreadScaling(benchmark::State& state) {
   TempCSVFile temp_file(csv_data);
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
+    size_t file_size = csv_data.size();
 
-    libvroom::Parser parser(n_threads);
+    libvroom::CsvOptions opts;
+    opts.num_threads = static_cast<size_t>(n_threads);
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
     // Performance metrics
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
+    state.counters["FileSize"] = static_cast<double>(file_size);
     state.counters["Threads"] = static_cast<double>(n_threads);
 
     // Calculate efficiency metrics
@@ -279,25 +269,23 @@ static void BM_RowScaling(benchmark::State& state) {
   TempCSVFile temp_file(csv_data);
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
+    size_t file_size = csv_data.size();
 
-    int n_threads = 4;
-    libvroom::Parser parser(n_threads);
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
     // Performance metrics
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
+    state.counters["FileSize"] = static_cast<double>(file_size);
     state.counters["Rows"] = static_cast<double>(num_rows);
-    state.counters["BytesPerRecord"] = static_cast<double>(buffer.size) / num_rows;
+    state.counters["BytesPerRecord"] = static_cast<double>(file_size) / num_rows;
 
   } catch (const std::exception& e) {
     state.SkipWithError(e.what());
@@ -318,27 +306,25 @@ static void BM_RowColumnMatrix(benchmark::State& state) {
   TempCSVFile temp_file(csv_data);
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
+    size_t file_size = csv_data.size();
 
-    int n_threads = 4;
-    libvroom::Parser parser(n_threads);
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
     // Comprehensive performance metrics
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
+    state.counters["FileSize"] = static_cast<double>(file_size);
     state.counters["Rows"] = static_cast<double>(num_rows);
     state.counters["Cols"] = static_cast<double>(num_cols);
     state.counters["TotalFields"] = static_cast<double>(num_rows * num_cols);
-    state.counters["BytesPerField"] = static_cast<double>(buffer.size) / (num_rows * num_cols);
+    state.counters["BytesPerField"] = static_cast<double>(file_size) / (num_rows * num_cols);
 
   } catch (const std::exception& e) {
     state.SkipWithError(e.what());

--- a/benchmark/end_to_end_benchmarks.cpp
+++ b/benchmark/end_to_end_benchmarks.cpp
@@ -1,22 +1,18 @@
 /**
  * @file end_to_end_benchmarks.cpp
- * @brief Benchmarks for end-to-end parse time with and without transpose.
+ * @brief Benchmarks for end-to-end parse time.
  *
  * This file benchmarks the complete parsing pipeline to measure:
- * 1. BM_ParseOnly - Parse CSV to per-thread index (baseline)
- * 2. BM_ParseAndCompact - Parse CSV + compact to flat row-major index
- * 3. BM_ParseAndTranspose - Parse CSV + compact + transpose to column-major
+ * 1. BM_ParseOnly - Parse CSV via CsvReader (baseline)
  *
- * These benchmarks validate the hypothesis that transpose is <5% of total
- * parse time for typical workloads (Issue #599/#602).
+ * Migrated to libvroom v2 API (CsvReader).
  */
 
 #include "libvroom.h"
 
-#include "common_defs.h"
-#include "mem_util.h"
-
 #include <benchmark/benchmark.h>
+#include <cstring>
+#include <fstream>
 #include <memory>
 #include <random>
 #include <sstream>
@@ -68,37 +64,30 @@ std::string generate_csv(size_t target_size, size_t cols) {
   return oss.str();
 }
 
-/**
- * @brief Transpose row-major flat index to column-major.
- *
- * Converts from flat_indexes[row * ncols + col] format
- * to col_indexes[col * nrows + row] format.
- *
- * @param flat_indexes Source flat index array (row-major)
- * @param nrows Number of rows
- * @param ncols Number of columns
- * @return Column-major index array
- */
-std::unique_ptr<uint64_t[]> transpose_to_column_major(const uint64_t* flat_indexes, size_t nrows,
-                                                      size_t ncols) {
-  size_t total = nrows * ncols;
-  auto col_indexes = std::make_unique<uint64_t[]>(total);
+// Helper for temporary files
+class TempCSVFile {
+private:
+  std::string filename_;
 
-  for (size_t row = 0; row < nrows; ++row) {
-    for (size_t col = 0; col < ncols; ++col) {
-      col_indexes[col * nrows + row] = flat_indexes[row * ncols + col];
-    }
+public:
+  explicit TempCSVFile(const std::string& content)
+      : filename_("/tmp/libvroom_e2e_" + std::to_string(std::random_device{}()) + ".csv") {
+    std::ofstream file(filename_);
+    file << content;
+    file.close();
   }
 
-  return col_indexes;
-}
+  ~TempCSVFile() { std::remove(filename_.c_str()); }
 
-// Cache generated CSV data to avoid regeneration between iterations
+  const std::string& path() const { return filename_; }
+};
+
+// Cache generated CSV temp files to avoid regeneration between iterations
 struct CachedCSV {
-  libvroom::AlignedBuffer buffer;
+  std::shared_ptr<TempCSVFile> temp_file;
   size_t actual_size;
   size_t cols;
-  size_t rows; // Approximate rows (for transpose sizing)
+  size_t rows; // Approximate rows
 };
 
 std::map<std::pair<size_t, size_t>, CachedCSV> csv_cache;
@@ -113,15 +102,11 @@ CachedCSV& get_or_create_csv(size_t target_size, size_t cols) {
   // Generate CSV
   std::string csv = generate_csv(target_size, cols);
 
-  // Allocate aligned buffer with SIMD padding
-  AlignedPtr ptr = make_aligned_ptr(csv.size(), LIBVROOM_PADDING);
-  std::memcpy(ptr.get(), csv.data(), csv.size());
-
-  // Estimate rows (for transpose sizing)
+  // Estimate rows
   size_t approx_rows = csv.size() / (cols * 5);
 
   CachedCSV cached;
-  cached.buffer = libvroom::AlignedBuffer(std::move(ptr), csv.size());
+  cached.temp_file = std::make_shared<TempCSVFile>(csv);
   cached.actual_size = csv.size();
   cached.cols = cols;
   cached.rows = approx_rows;
@@ -133,7 +118,7 @@ CachedCSV& get_or_create_csv(size_t target_size, size_t cols) {
 } // anonymous namespace
 
 // ============================================================================
-// BM_ParseOnly - Parse CSV to per-thread index (baseline)
+// BM_ParseOnly - Parse CSV via CsvReader (baseline)
 // ============================================================================
 
 static void BM_ParseOnly(benchmark::State& state) {
@@ -142,137 +127,13 @@ static void BM_ParseOnly(benchmark::State& state) {
   int n_threads = static_cast<int>(state.range(2));
 
   auto& cached = get_or_create_csv(target_size, cols);
-  libvroom::Parser parser(n_threads);
+  libvroom::CsvOptions opts;
+  opts.num_threads = static_cast<size_t>(n_threads);
 
   for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    benchmark::DoNotOptimize(result);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Size_MB"] = static_cast<double>(cached.actual_size) / (1024.0 * 1024.0);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-}
-
-// ============================================================================
-// BM_ParseAndCompact - Parse CSV + compact to flat row-major index
-// ============================================================================
-
-static void BM_ParseAndCompact(benchmark::State& state) {
-  size_t target_size = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-
-  auto& cached = get_or_create_csv(target_size, cols);
-  libvroom::Parser parser(n_threads);
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact();
-    benchmark::DoNotOptimize(result);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Size_MB"] = static_cast<double>(cached.actual_size) / (1024.0 * 1024.0);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-}
-
-// ============================================================================
-// BM_ParseAndTranspose - Parse CSV + compact + transpose to column-major
-// ============================================================================
-
-static void BM_ParseAndTranspose(benchmark::State& state) {
-  size_t target_size = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-
-  auto& cached = get_or_create_csv(target_size, cols);
-  libvroom::Parser parser(n_threads);
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact();
-
-    // Transpose to column-major
-    // flat_indexes contains row * cols + col positions
-    // We need to know nrows: total_indexes / cols
-    size_t total = result.idx.flat_indexes_count;
-    size_t ncols = result.num_columns();
-    size_t nrows = (ncols > 0) ? total / ncols : 0;
-
-    if (nrows > 0 && ncols > 0) {
-      auto col_major = transpose_to_column_major(result.idx.flat_indexes, nrows, ncols);
-      benchmark::DoNotOptimize(col_major);
-    }
-
-    benchmark::DoNotOptimize(result);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Size_MB"] = static_cast<double>(cached.actual_size) / (1024.0 * 1024.0);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-}
-
-// ============================================================================
-// BM_TransposeOnly - Measure transpose overhead in isolation
-// ============================================================================
-
-static void BM_TransposeOnly(benchmark::State& state) {
-  size_t target_size = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-
-  auto& cached = get_or_create_csv(target_size, cols);
-  libvroom::Parser parser(n_threads);
-
-  // Parse and compact once outside the benchmark loop
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.compact();
-
-  size_t total = result.idx.flat_indexes_count;
-  size_t ncols = result.num_columns();
-  size_t nrows = (ncols > 0) ? total / ncols : 0;
-
-  for (auto _ : state) {
-    if (nrows > 0 && ncols > 0) {
-      auto col_major = transpose_to_column_major(result.idx.flat_indexes, nrows, ncols);
-      benchmark::DoNotOptimize(col_major);
-    }
-  }
-
-  // Report bytes transposed (8 bytes per uint64_t)
-  size_t bytes_transposed = total * sizeof(uint64_t);
-  state.SetBytesProcessed(static_cast<int64_t>(bytes_transposed * state.iterations()));
-  state.counters["Size_MB"] = static_cast<double>(cached.actual_size) / (1024.0 * 1024.0);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-  state.counters["Index_MB"] = static_cast<double>(bytes_transposed) / (1024.0 * 1024.0);
-}
-
-// ============================================================================
-// BM_CompactOnly - Measure compact overhead in isolation
-// ============================================================================
-
-static void BM_CompactOnly(benchmark::State& state) {
-  size_t target_size = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-
-  auto& cached = get_or_create_csv(target_size, cols);
-  libvroom::Parser parser(n_threads);
-
-  for (auto _ : state) {
-    // Parse fresh each time (since compact is in-place and idempotent)
-    // Pause timing during parse to measure only compact overhead
-    state.PauseTiming();
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    state.ResumeTiming();
-
-    result.compact();
-
+    libvroom::CsvReader reader(opts);
+    reader.open(cached.temp_file->path());
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
@@ -307,14 +168,3 @@ static void CustomArguments(benchmark::internal::Benchmark* b) {
 }
 
 BENCHMARK(BM_ParseOnly)->Apply(CustomArguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-BENCHMARK(BM_ParseAndCompact)->Apply(CustomArguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-BENCHMARK(BM_ParseAndTranspose)
-    ->Apply(CustomArguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_TransposeOnly)->Apply(CustomArguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-BENCHMARK(BM_CompactOnly)->Apply(CustomArguments)->Unit(benchmark::kMillisecond)->UseRealTime();

--- a/benchmark/hypothesis_benchmarks.cpp
+++ b/benchmark/hypothesis_benchmarks.cpp
@@ -4,26 +4,17 @@
  *
  * This file implements benchmarks to test the key hypotheses from Issue #611:
  *
- * H1: Column-major index provides no net benefit over row-major after transpose
- * H2: Arrow Builder API is the primary bottleneck (not index layout)
  * H3: Synchronization barriers dominate multi-threaded scaling
- * H4: Zero-copy string extraction is viable for most CSV data
- * H5: Parquet type widening is rare in real CSV data
- * H6: compact() is required for O(1) field access
- * H7: Row object creation is expensive for per-field access
  *
- * Each benchmark is designed to discriminate between hypotheses and guide
- * implementation decisions.
+ * Benchmarks that required internal Parser/TwoPass/ParseIndex/ValueExtractor
+ * APIs (H1, H2 field-access, H4, H5, H6, H7) have been removed since the
+ * v2 CsvReader API does not expose those internals.
  *
- * IMPORTANT: H6 benchmarks use TwoPass API directly to avoid Parser's
- * auto-compaction behavior.
+ * Retained benchmarks use the CsvReader public API to measure thread scaling
+ * and end-to-end parse throughput.
  */
 
 #include "libvroom.h"
-
-#include "common_defs.h"
-#include "mem_util.h"
-#include "two_pass.h"
 
 #include <benchmark/benchmark.h>
 #include <chrono>
@@ -121,50 +112,27 @@ std::string generate_csv(size_t target_rows, size_t cols, const std::string& typ
   return oss.str();
 }
 
-/**
- * @brief Generate CSV with escape sequences for H4 testing.
- *
- * @param target_rows Number of rows
- * @param cols Number of columns
- * @param escape_ratio Ratio of fields with escape sequences (0.0-1.0)
- */
-std::string generate_csv_with_escapes(size_t target_rows, size_t cols, double escape_ratio) {
-  std::mt19937 rng(42);
-  std::uniform_real_distribution<double> prob_dist(0.0, 1.0);
+// Helper for temporary files
+class TempCSVFile {
+private:
+  std::string filename_;
 
-  std::ostringstream oss;
-
-  // Header
-  for (size_t c = 0; c < cols; ++c) {
-    if (c > 0)
-      oss << ',';
-    oss << "col" << c;
-  }
-  oss << '\n';
-
-  // Data rows
-  for (size_t r = 0; r < target_rows; ++r) {
-    for (size_t c = 0; c < cols; ++c) {
-      if (c > 0)
-        oss << ',';
-
-      if (prob_dist(rng) < escape_ratio) {
-        // Field with escape sequence
-        oss << "\"value" << r << "\"\"inside\"\"field\"";
-      } else {
-        // Normal field
-        oss << "value" << r << "_" << c;
-      }
-    }
-    oss << '\n';
+public:
+  explicit TempCSVFile(const std::string& content)
+      : filename_("/tmp/libvroom_hyp_" + std::to_string(std::random_device{}()) + ".csv") {
+    std::ofstream file(filename_);
+    file << content;
+    file.close();
   }
 
-  return oss.str();
-}
+  ~TempCSVFile() { std::remove(filename_.c_str()); }
+
+  const std::string& path() const { return filename_; }
+};
 
 // CSV cache for repeated benchmarks
 struct CachedCSV {
-  libvroom::AlignedBuffer buffer;
+  std::shared_ptr<TempCSVFile> temp_file;
   size_t actual_size;
   size_t rows;
   size_t cols;
@@ -182,12 +150,8 @@ CachedCSV& get_or_create_csv(size_t rows, size_t cols, const std::string& type_p
   // Generate CSV
   std::string csv = generate_csv(rows, cols, type_pattern);
 
-  // Allocate aligned buffer
-  AlignedPtr ptr = make_aligned_ptr(csv.size(), LIBVROOM_PADDING);
-  std::memcpy(ptr.get(), csv.data(), csv.size());
-
   CachedCSV cached;
-  cached.buffer = libvroom::AlignedBuffer(std::move(ptr), csv.size());
+  cached.temp_file = std::make_shared<TempCSVFile>(csv);
   cached.actual_size = csv.size();
   cached.rows = rows;
   cached.cols = cols;
@@ -197,547 +161,6 @@ CachedCSV& get_or_create_csv(size_t rows, size_t cols, const std::string& type_p
 }
 
 } // anonymous namespace
-
-// ============================================================================
-// H6: compact() is Required for O(1) Field Access
-// ============================================================================
-//
-// IMPORTANT: These benchmarks use TwoPass API directly instead of Parser
-// because Parser::parse() auto-compacts the index. TwoPass::parse() does NOT
-// auto-compact, allowing us to measure the true difference.
-
-/**
- * @brief Benchmark field access WITHOUT compact() using TwoPass API.
- *
- * Without compact(), field access is O(n_threads) as it must search
- * through per-thread regions.
- */
-static void BM_H6_FieldAccess_NoCompact(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-
-  auto& cached = get_or_create_csv(rows, cols);
-
-  // Use TwoPass directly to avoid Parser's auto-compaction
-  libvroom::TwoPass tp;
-  libvroom::ParseIndex idx = tp.init(cached.actual_size, static_cast<size_t>(n_threads));
-  tp.parse(cached.buffer.data(), idx, cached.actual_size);
-  // Index is NOT compacted - flat_indexes should be empty
-  // Set columns to enable num_rows() calculation
-  idx.columns = cols;
-
-  size_t actual_rows = idx.num_rows();
-
-  // Access pattern: iterate all fields in column 0
-  for (auto _ : state) {
-    for (size_t row = 0; row < actual_rows; ++row) {
-      auto span = idx.get_field_span(row, 0);
-      benchmark::DoNotOptimize(span);
-    }
-    benchmark::ClobberMemory();
-  }
-
-  state.counters["Rows"] = static_cast<double>(actual_rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-  state.counters["IsFlat"] = static_cast<double>(idx.is_flat() ? 1 : 0);
-  state.counters["RowsPerSec"] = benchmark::Counter(static_cast<double>(actual_rows),
-                                                    benchmark::Counter::kIsIterationInvariantRate);
-}
-
-/**
- * @brief Benchmark field access WITH compact().
- *
- * After compact(), field access is O(1) via flat index.
- */
-static void BM_H6_FieldAccess_WithCompact(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-
-  auto& cached = get_or_create_csv(rows, cols);
-
-  // Use TwoPass directly and explicitly compact
-  libvroom::TwoPass tp;
-  libvroom::ParseIndex idx = tp.init(cached.actual_size, static_cast<size_t>(n_threads));
-  tp.parse(cached.buffer.data(), idx, cached.actual_size);
-  // Set columns to enable num_rows() calculation
-  idx.columns = cols;
-  idx.compact(); // Explicitly compact to flat index
-
-  size_t actual_rows = idx.num_rows();
-
-  // Access pattern: iterate all fields in column 0
-  for (auto _ : state) {
-    for (size_t row = 0; row < actual_rows; ++row) {
-      auto span = idx.get_field_span(row, 0);
-      benchmark::DoNotOptimize(span);
-    }
-    benchmark::ClobberMemory();
-  }
-
-  state.counters["Rows"] = static_cast<double>(actual_rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-  state.counters["IsFlat"] = static_cast<double>(idx.is_flat() ? 1 : 0);
-  state.counters["RowsPerSec"] = benchmark::Counter(static_cast<double>(actual_rows),
-                                                    benchmark::Counter::kIsIterationInvariantRate);
-}
-
-/**
- * @brief Benchmark random field access without compact.
- */
-static void BM_H6_RandomAccess_NoCompact(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-  size_t num_accesses = 10000;
-
-  auto& cached = get_or_create_csv(rows, cols);
-
-  // Use TwoPass directly to avoid Parser's auto-compaction
-  libvroom::TwoPass tp;
-  libvroom::ParseIndex idx = tp.init(cached.actual_size, static_cast<size_t>(n_threads));
-  tp.parse(cached.buffer.data(), idx, cached.actual_size);
-  // Index is NOT compacted
-  // Set columns to enable num_rows() calculation
-  idx.columns = cols;
-
-  size_t actual_rows = idx.num_rows();
-
-  // Pre-generate random access pattern
-  std::mt19937_64 rng(42);
-  std::uniform_int_distribution<size_t> row_dist(0, actual_rows - 1);
-  std::uniform_int_distribution<size_t> col_dist(0, cols - 1);
-
-  std::vector<std::pair<size_t, size_t>> access_pattern(num_accesses);
-  for (size_t i = 0; i < num_accesses; ++i) {
-    access_pattern[i] = {row_dist(rng), col_dist(rng)};
-  }
-
-  for (auto _ : state) {
-    for (const auto& [row, col] : access_pattern) {
-      auto span = idx.get_field_span(row, col);
-      benchmark::DoNotOptimize(span);
-    }
-    benchmark::ClobberMemory();
-  }
-
-  state.counters["Accesses"] = static_cast<double>(num_accesses);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-  state.counters["IsFlat"] = static_cast<double>(idx.is_flat() ? 1 : 0);
-  state.counters["AccessesPerSec"] = benchmark::Counter(
-      static_cast<double>(num_accesses), benchmark::Counter::kIsIterationInvariantRate);
-}
-
-/**
- * @brief Benchmark random field access with compact.
- */
-static void BM_H6_RandomAccess_WithCompact(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-  int n_threads = static_cast<int>(state.range(2));
-  size_t num_accesses = 10000;
-
-  auto& cached = get_or_create_csv(rows, cols);
-
-  // Use TwoPass directly and explicitly compact
-  libvroom::TwoPass tp;
-  libvroom::ParseIndex idx = tp.init(cached.actual_size, static_cast<size_t>(n_threads));
-  tp.parse(cached.buffer.data(), idx, cached.actual_size);
-  // Set columns to enable num_rows() calculation
-  idx.columns = cols;
-  idx.compact(); // Explicitly compact
-
-  size_t actual_rows = idx.num_rows();
-
-  std::mt19937_64 rng(42);
-  std::uniform_int_distribution<size_t> row_dist(0, actual_rows - 1);
-  std::uniform_int_distribution<size_t> col_dist(0, cols - 1);
-
-  std::vector<std::pair<size_t, size_t>> access_pattern(num_accesses);
-  for (size_t i = 0; i < num_accesses; ++i) {
-    access_pattern[i] = {row_dist(rng), col_dist(rng)};
-  }
-
-  for (auto _ : state) {
-    for (const auto& [row, col] : access_pattern) {
-      auto span = idx.get_field_span(row, col);
-      benchmark::DoNotOptimize(span);
-    }
-    benchmark::ClobberMemory();
-  }
-
-  state.counters["Accesses"] = static_cast<double>(num_accesses);
-  state.counters["Threads"] = static_cast<double>(n_threads);
-  state.counters["IsFlat"] = static_cast<double>(idx.is_flat() ? 1 : 0);
-  state.counters["AccessesPerSec"] = benchmark::Counter(
-      static_cast<double>(num_accesses), benchmark::Counter::kIsIterationInvariantRate);
-}
-
-// H6 registration
-static void H6_Arguments(benchmark::internal::Benchmark* b) {
-  // {rows, cols, threads}
-  std::vector<std::tuple<int64_t, int64_t, int64_t>> configs = {
-      {100000, 10, 1}, {100000, 10, 4}, {1000000, 10, 1}, {1000000, 10, 4}, {1000000, 10, 8},
-  };
-  for (const auto& [rows, cols, threads] : configs) {
-    b->Args({rows, cols, threads});
-  }
-}
-
-BENCHMARK(BM_H6_FieldAccess_NoCompact)
-    ->Apply(H6_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H6_FieldAccess_WithCompact)
-    ->Apply(H6_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H6_RandomAccess_NoCompact)
-    ->Apply(H6_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H6_RandomAccess_WithCompact)
-    ->Apply(H6_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-// ============================================================================
-// H7: Row Object Creation Cost
-// ============================================================================
-
-/**
- * @brief Benchmark access via Row object pattern.
- *
- * This is the pattern: result_.row(row).get_string_view(col)
- * which creates a temporary Row object for each access.
- */
-static void BM_H7_ViaRowObject(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.compact();
-
-  // Access all fields in column 0 using Row objects (via iterator)
-  for (auto _ : state) {
-    size_t row_idx = 0;
-    for (auto row : result.rows()) {
-      auto sv = row.get_string_view(0);
-      benchmark::DoNotOptimize(sv);
-      ++row_idx;
-    }
-    benchmark::ClobberMemory();
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["RowsPerSec"] =
-      benchmark::Counter(static_cast<double>(rows), benchmark::Counter::kIsIterationInvariantRate);
-}
-
-/**
- * @brief Benchmark direct field span access (bypassing Row object).
- *
- * Uses result.idx.get_field_span() directly, avoiding Row object creation.
- */
-static void BM_H7_DirectSpanAccess(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.compact();
-
-  const uint8_t* buf = cached.buffer.data();
-
-  // Access all fields in column 0 directly via span
-  for (auto _ : state) {
-    for (size_t row = 0; row < rows; ++row) {
-      auto span = result.idx.get_field_span(row, 0);
-      if (span.is_valid()) {
-        std::string_view sv(reinterpret_cast<const char*>(buf + span.start), span.length());
-        benchmark::DoNotOptimize(sv);
-      }
-    }
-    benchmark::ClobberMemory();
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["RowsPerSec"] =
-      benchmark::Counter(static_cast<double>(rows), benchmark::Counter::kIsIterationInvariantRate);
-}
-
-/**
- * @brief Benchmark ValueExtractor get_string_view (middle ground).
- */
-static void BM_H7_ViaExtractor(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.compact();
-
-  // Create extractor directly
-  libvroom::ValueExtractor extractor(cached.buffer.data(), cached.actual_size, result.idx);
-
-  for (auto _ : state) {
-    for (size_t row = 0; row < rows; ++row) {
-      auto sv = extractor.get_string_view(row, 0);
-      benchmark::DoNotOptimize(sv);
-    }
-    benchmark::ClobberMemory();
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["RowsPerSec"] =
-      benchmark::Counter(static_cast<double>(rows), benchmark::Counter::kIsIterationInvariantRate);
-}
-
-// H7 registration
-static void H7_Arguments(benchmark::internal::Benchmark* b) {
-  // {rows, cols}
-  b->Args({100000, 10});
-  b->Args({1000000, 10});
-}
-
-BENCHMARK(BM_H7_ViaRowObject)->Apply(H7_Arguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-BENCHMARK(BM_H7_DirectSpanAccess)
-    ->Apply(H7_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H7_ViaExtractor)->Apply(H7_Arguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-// ============================================================================
-// H1: Column-Major Index Overhead
-// ============================================================================
-
-/**
- * @brief Benchmark row-major column iteration (no transpose).
- */
-static void BM_H1_RowMajor_ColumnIteration(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.compact(); // Row-major flat index
-
-  const uint8_t* buf = cached.buffer.data();
-
-  // Iterate column 0 with row-major index
-  for (auto _ : state) {
-    uint64_t sum = 0;
-    for (size_t row = 0; row < rows; ++row) {
-      auto span = result.idx.get_field_span(row, 0);
-      sum += span.start;
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["RowsPerSec"] =
-      benchmark::Counter(static_cast<double>(rows), benchmark::Counter::kIsIterationInvariantRate);
-}
-
-/**
- * @brief Benchmark column-major iteration (with transpose overhead).
- */
-static void BM_H1_ColMajor_ColumnIteration(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.idx.compact_column_major(4); // Column-major transpose
-
-  // Iterate column 0 with column-major index (contiguous access)
-  for (auto _ : state) {
-    uint64_t sum = 0;
-    if (result.idx.col_indexes) {
-      const uint64_t* col_data = result.idx.col_indexes;
-      for (size_t row = 0; row < rows; ++row) {
-        sum += col_data[row]; // col 0 is at indices 0..rows-1
-      }
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["RowsPerSec"] =
-      benchmark::Counter(static_cast<double>(rows), benchmark::Counter::kIsIterationInvariantRate);
-}
-
-/**
- * @brief Measure transpose time in isolation.
- */
-static void BM_H1_TransposeOnly(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  for (auto _ : state) {
-    state.PauseTiming();
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact(); // First compact to row-major
-    state.ResumeTiming();
-
-    // Now time the transpose
-    result.idx.compact_column_major(4);
-    benchmark::DoNotOptimize(result.idx.col_indexes);
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Fields"] = static_cast<double>(rows * cols);
-}
-
-// H1 registration - test matrix from issue
-static void H1_Arguments(benchmark::internal::Benchmark* b) {
-  // (rows, cols) from issue: [(10K,10), (100K,10), (1M,10), (100K,100),
-  // (100K,1000)]
-  b->Args({10000, 10});
-  b->Args({100000, 10});
-  b->Args({1000000, 10});
-  b->Args({100000, 100});
-  // b->Args({100000, 1000});  // Too large for in-memory benchmark
-}
-
-BENCHMARK(BM_H1_RowMajor_ColumnIteration)
-    ->Apply(H1_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H1_ColMajor_ColumnIteration)
-    ->Apply(H1_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H1_TransposeOnly)->Apply(H1_Arguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-/**
- * @brief Full pipeline: parse + compact + iterate N columns (row-major).
- *
- * This benchmark measures the total cost of iterating multiple columns
- * with row-major layout to establish break-even point with column-major.
- */
-static void BM_H1_FullPipeline_RowMajor_MultiCol(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t total_cols = static_cast<size_t>(state.range(1));
-  size_t cols_to_iterate = static_cast<size_t>(state.range(2));
-
-  auto& cached = get_or_create_csv(rows, total_cols);
-  libvroom::Parser parser(4);
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact(); // Row-major
-
-    // Iterate cols_to_iterate columns
-    uint64_t sum = 0;
-    for (size_t col = 0; col < cols_to_iterate; ++col) {
-      for (size_t row = 0; row < rows; ++row) {
-        auto span = result.idx.get_field_span(row, col);
-        sum += span.start;
-      }
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["TotalCols"] = static_cast<double>(total_cols);
-  state.counters["ColsIterated"] = static_cast<double>(cols_to_iterate);
-  state.counters["FieldsAccessed"] = static_cast<double>(rows * cols_to_iterate);
-}
-
-/**
- * @brief Full pipeline: parse + transpose + iterate N columns (column-major).
- *
- * This benchmark measures the total cost including transpose overhead
- * to find when column-major layout pays off.
- */
-static void BM_H1_FullPipeline_ColMajor_MultiCol(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t total_cols = static_cast<size_t>(state.range(1));
-  size_t cols_to_iterate = static_cast<size_t>(state.range(2));
-
-  auto& cached = get_or_create_csv(rows, total_cols);
-  libvroom::Parser parser(4);
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.idx.compact_column_major(4); // Column-major transpose
-
-    // Iterate cols_to_iterate columns (contiguous access per column)
-    uint64_t sum = 0;
-    if (result.idx.col_indexes) {
-      for (size_t col = 0; col < cols_to_iterate; ++col) {
-        const uint64_t* col_data = result.idx.column(col);
-        if (col_data) {
-          for (size_t row = 0; row < rows; ++row) {
-            sum += col_data[row];
-          }
-        }
-      }
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["TotalCols"] = static_cast<double>(total_cols);
-  state.counters["ColsIterated"] = static_cast<double>(cols_to_iterate);
-  state.counters["FieldsAccessed"] = static_cast<double>(rows * cols_to_iterate);
-}
-
-// H1 Break-even registration - vary columns iterated to find break-even
-static void H1_BreakEven_Arguments(benchmark::internal::Benchmark* b) {
-  // (rows, total_cols, cols_to_iterate)
-  // Test 1M rows x 10 cols, iterating 1, 2, 5, 10 columns
-  b->Args({1000000, 10, 1});
-  b->Args({1000000, 10, 2});
-  b->Args({1000000, 10, 5});
-  b->Args({1000000, 10, 10});
-  // Test 100K rows x 100 cols, iterating various amounts
-  b->Args({100000, 100, 1});
-  b->Args({100000, 100, 5});
-  b->Args({100000, 100, 10});
-  b->Args({100000, 100, 50});
-  b->Args({100000, 100, 100});
-}
-
-BENCHMARK(BM_H1_FullPipeline_RowMajor_MultiCol)
-    ->Apply(H1_BreakEven_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H1_FullPipeline_ColMajor_MultiCol)
-    ->Apply(H1_BreakEven_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
 
 // ============================================================================
 // H3: Synchronization Barrier Overhead
@@ -757,10 +180,13 @@ static void BM_H3_ThreadScaling(benchmark::State& state) {
   size_t approx_rows = target_size / (cols * 10); // ~10 bytes per field
   auto& cached = get_or_create_csv(approx_rows, cols);
 
-  libvroom::Parser parser(n_threads);
+  libvroom::CsvOptions opts;
+  opts.num_threads = static_cast<size_t>(n_threads);
 
   for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
+    libvroom::CsvReader reader(opts);
+    reader.open(cached.temp_file->path());
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
@@ -771,7 +197,7 @@ static void BM_H3_ThreadScaling(benchmark::State& state) {
 
 // H3 registration - thread counts: 1, 2, 4, 8, 16
 static void H3_Arguments(benchmark::internal::Benchmark* b) {
-  // Thread counts × target file sizes
+  // Thread counts x target file sizes
   std::vector<int64_t> threads = {1, 2, 4, 8, 16};
   std::vector<int64_t> sizes = {10 * 1024 * 1024, 100 * 1024 * 1024}; // 10MB, 100MB
 
@@ -785,375 +211,33 @@ static void H3_Arguments(benchmark::internal::Benchmark* b) {
 BENCHMARK(BM_H3_ThreadScaling)->Apply(H3_Arguments)->Unit(benchmark::kMillisecond)->UseRealTime();
 
 // ============================================================================
-// H4: Escape Sequence Frequency Analysis
+// H2: Parse Throughput at Different Sizes (simplified)
 // ============================================================================
 
 /**
- * @brief Count escape sequences in CSV data.
+ * @brief Baseline: Parse only via CsvReader, no internal access.
  *
- * This benchmark scans CSV data to count fields with escape sequences,
- * validating the hypothesis that most CSV data doesn't need escape processing.
- */
-static void BM_H4_EscapeAnalysis(benchmark::State& state) {
-  double escape_ratio = state.range(0) / 100.0; // 0-100% as integer
-  size_t rows = 100000;
-  size_t cols = 10;
-
-  // Generate CSV with specified escape ratio
-  std::string csv = generate_csv_with_escapes(rows, cols, escape_ratio);
-  AlignedPtr ptr = make_aligned_ptr(csv.size(), LIBVROOM_PADDING);
-  std::memcpy(ptr.get(), csv.data(), csv.size());
-
-  libvroom::Parser parser(4);
-  auto result = parser.parse(ptr.get(), csv.size(), {.dialect = libvroom::Dialect::csv()});
-  result.compact();
-
-  const uint8_t* buf = ptr.get();
-  size_t escape_count = 0;
-
-  for (auto _ : state) {
-    escape_count = 0;
-    // Count fields containing "" escape sequence
-    for (size_t row = 0; row < rows; ++row) {
-      for (size_t col = 0; col < cols; ++col) {
-        auto span = result.idx.get_field_span(row, col);
-        if (span.is_valid()) {
-          std::string_view field(reinterpret_cast<const char*>(buf + span.start), span.length());
-          // Check for doubled quote (escape sequence)
-          if (field.find("\"\"") != std::string_view::npos) {
-            ++escape_count;
-          }
-        }
-      }
-    }
-    benchmark::DoNotOptimize(escape_count);
-  }
-
-  state.counters["EscapeRatio_Input"] = escape_ratio;
-  state.counters["EscapeCount"] = static_cast<double>(escape_count);
-  state.counters["TotalFields"] = static_cast<double>(rows * cols);
-  state.counters["ActualEscapeRatio"] =
-      static_cast<double>(escape_count) / static_cast<double>(rows * cols);
-}
-
-// H4 registration - escape ratios: 0%, 5%, 20%, 50%, 80%
-BENCHMARK(BM_H4_EscapeAnalysis)
-    ->Arg(0)  // 0% escapes
-    ->Arg(5)  // 5% escapes
-    ->Arg(20) // 20% escapes
-    ->Arg(50) // 50% escapes
-    ->Arg(80) // 80% escapes
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-// ============================================================================
-// H5: Type Widening Detection
-// ============================================================================
-
-/**
- * @brief Simulate type inference on CSV data.
- *
- * This benchmark simulates streaming type inference to detect how often
- * type widening would be needed (e.g., int64 -> double).
- */
-static void BM_H5_TypeInference(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t sample_rows = static_cast<size_t>(state.range(1));
-
-  // Generate CSV with mixed types that might need widening
-  // Pattern: some columns start as int but have doubles later
-  auto& cached = get_or_create_csv(rows, 10, "iiiiddddsss");
-
-  libvroom::Parser parser(4);
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.compact();
-
-  const uint8_t* buf = cached.buffer.data();
-
-  // Simulate type inference: scan first sample_rows to infer types
-  // Then scan remaining rows to detect type changes
-  size_t type_changes = 0;
-
-  for (auto _ : state) {
-    type_changes = 0;
-    size_t cols = result.num_columns();
-
-    // This is a simplified simulation - in practice we'd track inferred types
-    // For benchmark purposes, we just measure the cost of scanning for type
-    // changes
-    for (size_t col = 0; col < cols; ++col) {
-      bool saw_decimal = false;
-
-      for (size_t row = 0; row < rows; ++row) {
-        auto span = result.idx.get_field_span(row, col);
-        if (span.is_valid()) {
-          std::string_view field(reinterpret_cast<const char*>(buf + span.start), span.length());
-
-          // Check if field contains decimal point (would force int -> double)
-          bool has_decimal = field.find('.') != std::string_view::npos;
-
-          if (has_decimal && !saw_decimal && row >= sample_rows) {
-            // Type change detected after sample window
-            ++type_changes;
-          }
-          saw_decimal = saw_decimal || has_decimal;
-        }
-      }
-    }
-    benchmark::DoNotOptimize(type_changes);
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["SampleRows"] = static_cast<double>(sample_rows);
-  state.counters["TypeChanges"] = static_cast<double>(type_changes);
-}
-
-// H5 registration
-static void H5_Arguments(benchmark::internal::Benchmark* b) {
-  // {total_rows, sample_rows}
-  b->Args({100000, 1000});
-  b->Args({1000000, 1000});
-}
-
-BENCHMARK(BM_H5_TypeInference)->Apply(H5_Arguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-// ============================================================================
-// Full Pipeline Benchmarks (for comparison)
-// ============================================================================
-
-/**
- * @brief Full pipeline: parse + compact + column iteration.
- */
-static void BM_FullPipeline_RowMajor(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact();
-
-    // Iterate all values in column 0
-    uint64_t sum = 0;
-    for (size_t row = 0; row < rows; ++row) {
-      auto span = result.idx.get_field_span(row, 0);
-      sum += span.start;
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-}
-
-/**
- * @brief Full pipeline: parse + transpose + column iteration.
- */
-static void BM_FullPipeline_ColMajor(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.idx.compact_column_major(4);
-
-    // Iterate all values in column 0 (contiguous)
-    uint64_t sum = 0;
-    if (result.idx.col_indexes) {
-      const uint64_t* col_data = result.idx.col_indexes;
-      for (size_t row = 0; row < rows; ++row) {
-        sum += col_data[row];
-      }
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-}
-
-BENCHMARK(BM_FullPipeline_RowMajor)
-    ->Apply(H1_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_FullPipeline_ColMajor)
-    ->Apply(H1_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-// ============================================================================
-// H2: Arrow Builder API Bottleneck Analysis
-// ============================================================================
-//
-// This hypothesis tests whether Arrow Builder API is the primary bottleneck
-// compared to index layout. We compare:
-// 1. Parse-only time (baseline)
-// 2. Parse + field extraction (without Arrow)
-// 3. Parse + Arrow conversion (full Builders path)
-// 4. Direct buffer writes (simulating zero-copy approach)
-//
-// If H2 is true: Arrow conversion time >> parse time
-// If H2 is false: Arrow conversion time is comparable to parse time
-
-/**
- * @brief Baseline: Parse only, no conversion.
- *
- * Measures the raw parsing throughput without any value extraction.
+ * Measures the raw end-to-end parsing throughput at various data sizes.
  */
 static void BM_H2_ParseOnly(benchmark::State& state) {
   size_t rows = static_cast<size_t>(state.range(0));
   size_t cols = static_cast<size_t>(state.range(1));
 
   auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
+
+  libvroom::CsvOptions opts;
+  opts.num_threads = 4;
 
   for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact();
+    libvroom::CsvReader reader(opts);
+    reader.open(cached.temp_file->path());
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
   state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
   state.counters["Rows"] = static_cast<double>(rows);
   state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Stage"] = 0; // Parse only
-}
-
-/**
- * @brief Parse + field extraction without conversion.
- *
- * Measures time to extract all field values as string_views.
- * This is the minimum work needed to access all data.
- */
-static void BM_H2_ParseAndExtract(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact();
-
-    // Extract all fields as string_views (simulating minimum extraction cost)
-    const uint8_t* buf = cached.buffer.data();
-    uint64_t sum = 0;
-    for (size_t row = 0; row < rows; ++row) {
-      for (size_t col = 0; col < cols; ++col) {
-        auto span = result.idx.get_field_span(row, col);
-        if (span.is_valid()) {
-          // Access the field data (forces memory access)
-          sum += buf[span.start];
-        }
-      }
-    }
-    benchmark::DoNotOptimize(sum);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Stage"] = 1; // Parse + extract
-}
-
-/**
- * @brief Simulate direct buffer construction (zero-copy ideal).
- *
- * This benchmark simulates what a direct buffer approach would cost:
- * pre-allocated arrays with direct writes instead of Builder appends.
- * Uses pre-allocated std::vector instead of Arrow Builders.
- */
-static void BM_H2_DirectBufferSimulation(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  // Pre-allocate output buffers (simulating direct Arrow buffer construction)
-  std::vector<std::vector<int64_t>> int_columns(cols);
-  for (auto& col : int_columns) {
-    col.resize(rows);
-  }
-
-  for (auto _ : state) {
-    auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-    result.compact();
-
-    const uint8_t* buf = cached.buffer.data();
-
-    // Direct buffer writes (no Builder overhead)
-    for (size_t row = 0; row < rows; ++row) {
-      for (size_t col = 0; col < cols; ++col) {
-        auto span = result.idx.get_field_span(row, col);
-        if (span.is_valid()) {
-          // Simulate type conversion and direct write
-          // This is the minimum cost for populating typed arrays
-          int_columns[col][row] = static_cast<int64_t>(span.start);
-        }
-      }
-    }
-    benchmark::DoNotOptimize(int_columns);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Stage"] = 2; // Direct buffer
-}
-
-/**
- * @brief Simulate per-element Builder overhead.
- *
- * This benchmark isolates the cost of the Builder append pattern:
- * calling a function per element vs direct array assignment.
- */
-static void BM_H2_BuilderPatternOverhead(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-  libvroom::Parser parser(4);
-
-  // Simulate Builder with a vector that grows (like Arrow Builders)
-  auto result = parser.parse(cached.buffer.data(), cached.actual_size);
-  result.compact();
-
-  for (auto _ : state) {
-    // Simulate Builder pattern: clear and re-append
-    std::vector<std::vector<int64_t>> builder_columns(cols);
-    for (auto& col : builder_columns) {
-      col.reserve(rows); // Reserve like Arrow Builders do
-    }
-
-    const uint8_t* buf = cached.buffer.data();
-
-    // Builder-style appends (function call per element)
-    for (size_t row = 0; row < rows; ++row) {
-      for (size_t col = 0; col < cols; ++col) {
-        auto span = result.idx.get_field_span(row, col);
-        if (span.is_valid()) {
-          // Append pattern (like Builder.Append())
-          builder_columns[col].push_back(static_cast<int64_t>(span.start));
-        }
-      }
-    }
-    benchmark::DoNotOptimize(builder_columns);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Stage"] = 3; // Builder pattern
 }
 
 // H2 registration
@@ -1166,126 +250,3 @@ static void H2_Arguments(benchmark::internal::Benchmark* b) {
 }
 
 BENCHMARK(BM_H2_ParseOnly)->Apply(H2_Arguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-BENCHMARK(BM_H2_ParseAndExtract)->Apply(H2_Arguments)->Unit(benchmark::kMillisecond)->UseRealTime();
-
-BENCHMARK(BM_H2_DirectBufferSimulation)
-    ->Apply(H2_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H2_BuilderPatternOverhead)
-    ->Apply(H2_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-#ifdef LIBVROOM_ENABLE_ARROW
-#include "arrow_output.h"
-
-/**
- * @brief Full Arrow conversion via ArrowConverter (Builders path).
- *
- * This measures the actual Arrow conversion including type inference
- * and Builder-based column construction.
- */
-static void BM_H2_ArrowBuilders_Full(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-
-  libvroom::ArrowConvertOptions opts;
-  opts.infer_types = true;
-
-  for (auto _ : state) {
-    libvroom::TwoPass tp;
-    libvroom::ParseIndex idx = tp.init(cached.actual_size, 4);
-    tp.parse(cached.buffer.data(), idx, cached.actual_size);
-
-    libvroom::ArrowConverter converter(opts);
-    auto result = converter.convert(cached.buffer.data(), cached.actual_size, idx);
-    benchmark::DoNotOptimize(result);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Stage"] = 4; // Full Arrow
-}
-
-/**
- * @brief Arrow conversion without type inference.
- *
- * Measures Arrow Builders cost when types are pre-specified (no inference).
- */
-static void BM_H2_ArrowBuilders_NoInference(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-
-  libvroom::ArrowConvertOptions opts;
-  opts.infer_types = false; // Skip type inference, treat all as strings
-
-  for (auto _ : state) {
-    libvroom::TwoPass tp;
-    libvroom::ParseIndex idx = tp.init(cached.actual_size, 4);
-    tp.parse(cached.buffer.data(), idx, cached.actual_size);
-
-    libvroom::ArrowConverter converter(opts);
-    auto result = converter.convert(cached.buffer.data(), cached.actual_size, idx);
-    benchmark::DoNotOptimize(result);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(cached.actual_size * state.iterations()));
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Stage"] = 5; // Arrow no inference
-}
-
-/**
- * @brief Type inference only (no column building).
- *
- * Isolates the cost of type inference from the Builder cost.
- */
-static void BM_H2_TypeInferenceOnly(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  size_t cols = static_cast<size_t>(state.range(1));
-
-  auto& cached = get_or_create_csv(rows, cols);
-
-  // Parse once
-  libvroom::TwoPass tp;
-  libvroom::ParseIndex idx = tp.init(cached.actual_size, 4);
-  tp.parse(cached.buffer.data(), idx, cached.actual_size);
-
-  libvroom::ArrowConvertOptions opts;
-  opts.infer_types = true;
-  libvroom::ArrowConverter converter(opts);
-
-  for (auto _ : state) {
-    auto types = converter.infer_types(cached.buffer.data(), cached.actual_size, idx);
-    benchmark::DoNotOptimize(types);
-  }
-
-  state.counters["Rows"] = static_cast<double>(rows);
-  state.counters["Cols"] = static_cast<double>(cols);
-  state.counters["Stage"] = 6; // Type inference only
-}
-
-BENCHMARK(BM_H2_ArrowBuilders_Full)
-    ->Apply(H2_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H2_ArrowBuilders_NoInference)
-    ->Apply(H2_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-BENCHMARK(BM_H2_TypeInferenceOnly)
-    ->Apply(H2_Arguments)
-    ->Unit(benchmark::kMillisecond)
-    ->UseRealTime();
-
-#endif // LIBVROOM_ENABLE_ARROW

--- a/benchmark/real_world_benchmarks.cpp
+++ b/benchmark/real_world_benchmarks.cpp
@@ -1,8 +1,5 @@
 #include "libvroom.h"
 
-#include "common_defs.h"
-#include "mem_util.h"
-
 #include <algorithm>
 #include <benchmark/benchmark.h>
 #include <fstream>
@@ -222,26 +219,22 @@ static void BM_financial_data(benchmark::State& state) {
   size_t num_rows = static_cast<size_t>(state.range(0));
   auto data_str = CSVDataGenerator::generate_financial_data(num_rows);
   TempFile temp_file(data_str);
+  size_t file_size = data_str.size();
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(4);
-    // Use explicit CSV dialect to avoid auto-detection overhead in benchmarks
-    libvroom::ParseOptions opts{.dialect = libvroom::Dialect::csv()};
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, opts);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
     state.counters["Rows"] = static_cast<double>(num_rows);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.counters["FileSize"] = static_cast<double>(file_size);
 
   } catch (const std::exception& e) {
     state.SkipWithError(e.what());
@@ -257,26 +250,22 @@ static void BM_nyc_taxi_data(benchmark::State& state) {
   size_t num_rows = static_cast<size_t>(state.range(0));
   auto data_str = CSVDataGenerator::generate_nyc_taxi_data(num_rows);
   TempFile temp_file(data_str);
+  size_t file_size = data_str.size();
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(4);
-    // Use explicit CSV dialect to avoid auto-detection overhead in benchmarks
-    libvroom::ParseOptions opts{.dialect = libvroom::Dialect::csv()};
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, opts);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
     state.counters["Rows"] = static_cast<double>(num_rows);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.counters["FileSize"] = static_cast<double>(file_size);
     state.counters["Columns"] = 19.0; // NYC taxi has 19 columns
 
   } catch (const std::exception& e) {
@@ -292,26 +281,22 @@ static void BM_genomics_data(benchmark::State& state) {
   size_t num_rows = static_cast<size_t>(state.range(0));
   auto data_str = CSVDataGenerator::generate_genomics_data(num_rows);
   TempFile temp_file(data_str);
+  size_t file_size = data_str.size();
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(4);
-    // Use explicit CSV dialect to avoid auto-detection overhead in benchmarks
-    libvroom::ParseOptions opts{.dialect = libvroom::Dialect::csv()};
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, opts);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
     state.counters["Rows"] = static_cast<double>(num_rows);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.counters["FileSize"] = static_cast<double>(file_size);
 
   } catch (const std::exception& e) {
     state.SkipWithError(e.what());
@@ -326,26 +311,22 @@ static void BM_log_data(benchmark::State& state) {
   size_t num_rows = static_cast<size_t>(state.range(0));
   auto data_str = CSVDataGenerator::generate_log_data(num_rows);
   TempFile temp_file(data_str);
+  size_t file_size = data_str.size();
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(4);
-    // Use explicit CSV dialect to avoid auto-detection overhead in benchmarks
-    libvroom::ParseOptions opts{.dialect = libvroom::Dialect::csv()};
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, opts);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
     state.counters["Rows"] = static_cast<double>(num_rows);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.counters["FileSize"] = static_cast<double>(file_size);
 
   } catch (const std::exception& e) {
     state.SkipWithError(e.what());
@@ -358,27 +339,23 @@ static void BM_wide_table(benchmark::State& state) {
   size_t num_cols = static_cast<size_t>(state.range(1));
   auto data_str = CSVDataGenerator::generate_wide_table(num_rows, num_cols);
   TempFile temp_file(data_str);
+  size_t file_size = data_str.size();
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(4);
-    // Use explicit CSV dialect to avoid auto-detection overhead in benchmarks
-    libvroom::ParseOptions opts{.dialect = libvroom::Dialect::csv()};
+    libvroom::CsvOptions opts;
+    opts.num_threads = 4;
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, opts);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
+    state.SetBytesProcessed(static_cast<int64_t>(file_size * state.iterations()));
     state.counters["Rows"] = static_cast<double>(num_rows);
     state.counters["Cols"] = static_cast<double>(num_cols);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.counters["FileSize"] = static_cast<double>(file_size);
 
   } catch (const std::exception& e) {
     state.SkipWithError(e.what());
@@ -390,8 +367,7 @@ BENCHMARK(BM_wide_table)
 
 // SIMD instruction level benchmarks
 static void BM_simd_levels(benchmark::State& state) {
-  // This would require modifying the parser to expose SIMD level selection
-  // For now, we'll benchmark the default parser
+  // Benchmark the default parser on a test file
   std::string filename = "test/data/basic/many_rows.csv";
 
   if (test_data.find(filename) == test_data.end()) {
@@ -409,16 +385,17 @@ static void BM_simd_levels(benchmark::State& state) {
   }
 
   const auto& buffer = test_data.at(filename);
-  libvroom::Parser parser(1);
-  // Use explicit CSV dialect to avoid auto-detection overhead in benchmarks
-  libvroom::ParseOptions opts{.dialect = libvroom::Dialect::csv()};
+  libvroom::CsvOptions opts;
+  opts.num_threads = 1;
 
   for (auto _ : state) {
-    auto result = parser.parse(buffer.data(), buffer.size, opts);
+    libvroom::CsvReader reader(opts);
+    reader.open(filename);
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
+  state.SetBytesProcessed(static_cast<int64_t>(buffer.size() * state.iterations()));
   state.counters["SIMD"] = 1.0; // Default SIMD level
 }
 BENCHMARK(BM_simd_levels)->Unit(benchmark::kMillisecond);

--- a/benchmark/simd_benchmarks.cpp
+++ b/benchmark/simd_benchmarks.cpp
@@ -1,16 +1,12 @@
 #include "libvroom.h"
 
-#include "common_defs.h"
-#include "mem_util.h"
-
 #include <benchmark/benchmark.h>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <random>
 #include <sstream>
-
-extern std::map<std::string, libvroom::AlignedBuffer> test_data;
 
 // SIMD instruction level benchmarks and comparisons
 
@@ -98,36 +94,29 @@ std::string generate_simd_test_data(size_t rows, size_t cols,
   return ss.str();
 }
 
-// Benchmark SIMD vs scalar for different CSV patterns
+// Benchmark CsvReader with different thread counts for various CSV patterns
 static void BM_SIMD_vs_Scalar(benchmark::State& state) {
   int pattern_type = static_cast<int>(state.range(0));
-  int use_simd = static_cast<int>(state.range(1)); // 0 = scalar simulation, 1 = SIMD
+  int n_threads = static_cast<int>(state.range(1)); // 1 = single-threaded, 4 = multi-threaded
 
-  std::string pattern_name;
   std::string pattern;
   switch (pattern_type) {
   case 0:
-    pattern_name = "mixed";
     pattern = "mixed";
     break;
   case 1:
-    pattern_name = "quote_heavy";
     pattern = "quote_heavy";
     break;
   case 2:
-    pattern_name = "long_fields";
     pattern = "long_fields";
     break;
   case 3:
-    pattern_name = "many_commas";
     pattern = "many_commas";
     break;
   case 4:
-    pattern_name = "newlines_in_quotes";
     pattern = "newlines_in_quotes";
     break;
   default:
-    pattern_name = "mixed";
     pattern = "mixed";
     break;
   }
@@ -138,26 +127,19 @@ static void BM_SIMD_vs_Scalar(benchmark::State& state) {
   TempCSVFile temp_file(csv_data);
 
   try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    // For this benchmark, we're testing the current SIMD implementation
-    // vs a conceptual scalar implementation (using single thread to simulate)
-    int n_threads = use_simd ? 4 : 1; // More threads generally means more SIMD usage
-    libvroom::Parser parser(n_threads);
+    libvroom::CsvOptions opts;
+    opts.num_threads = static_cast<size_t>(n_threads);
 
     for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size);
+      libvroom::CsvReader reader(opts);
+      reader.open(temp_file.path());
+      auto result = reader.read_all();
       benchmark::DoNotOptimize(result);
     }
 
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
+    state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
     state.counters["PatternType"] = static_cast<double>(pattern_type);
-    state.counters["UseSIMD"] = static_cast<double>(use_simd);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
+    state.counters["FileSize"] = static_cast<double>(csv_data.size());
     state.counters["Threads"] = static_cast<double>(n_threads);
 
   } catch (const std::exception& e) {
@@ -166,7 +148,7 @@ static void BM_SIMD_vs_Scalar(benchmark::State& state) {
 }
 
 BENCHMARK(BM_SIMD_vs_Scalar)
-    ->Ranges({{0, 4}, {0, 1}}) // pattern_type: 0-4, use_simd: 0-1
+    ->ArgsProduct({{0, 1, 2, 3, 4}, {1, 4}}) // pattern_type: 0-4, n_threads: 1 or 4
     ->Unit(benchmark::kMillisecond);
 
 // Vector width effectiveness benchmark
@@ -175,36 +157,52 @@ static void BM_VectorWidth_Effectiveness(benchmark::State& state) {
 
   // Generate data with specific characteristics for vector processing
   size_t data_size = 64 * 1024; // 64KB
-  auto data = static_cast<uint8_t*>(aligned_malloc(64, data_size + LIBVROOM_PADDING));
+
+  // Build CSV content with a header and structured rows
+  std::ostringstream ss;
+  ss << "col_0";
+  ss << "\n";
 
   // Pattern optimized for different vector widths
+  std::string row;
+  row.reserve(chunk_size + 1);
   for (size_t i = 0; i < data_size; ++i) {
-    // Create pattern that benefits from wide vectors
-    if (i % chunk_size == 0)
-      data[i] = '\n';
-    else if ((i % chunk_size) % 8 == 0)
-      data[i] = ',';
-    else if ((i % chunk_size) % 16 == 0)
-      data[i] = '"';
-    else
-      data[i] = 'a' + (i % 26);
+    if (i % chunk_size == 0) {
+      if (!row.empty()) {
+        ss << row << "\n";
+        row.clear();
+      }
+    } else if ((i % chunk_size) % 8 == 0) {
+      // Insert comma as field separator within row
+      row += ',';
+    } else {
+      row += static_cast<char>('a' + (i % 26));
+    }
+  }
+  if (!row.empty()) {
+    ss << row << "\n";
   }
 
-  // Add padding
-  for (size_t i = data_size; i < data_size + LIBVROOM_PADDING; ++i) {
-    data[i] = '\0';
+  std::string csv_data = ss.str();
+  std::string temp_path = "/tmp/libvroom_bench_vecwidth_" + std::to_string(chunk_size) + ".csv";
+  {
+    std::ofstream out(temp_path);
+    out.write(csv_data.data(), static_cast<std::streamsize>(csv_data.size()));
   }
 
-  libvroom::Parser parser(1);
+  libvroom::CsvOptions opts;
+  opts.num_threads = 1;
 
   for (auto _ : state) {
-    auto result = parser.parse(data, data_size);
+    libvroom::CsvReader reader(opts);
+    reader.open(temp_path);
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>(data_size * state.iterations()));
+  state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
   state.counters["ChunkSize"] = static_cast<double>(chunk_size);
-  state.counters["DataSize"] = static_cast<double>(data_size);
+  state.counters["DataSize"] = static_cast<double>(csv_data.size());
 
   // Estimate vector width efficiency
   if (chunk_size <= 16) {
@@ -215,7 +213,7 @@ static void BM_VectorWidth_Effectiveness(benchmark::State& state) {
     state.counters["VectorWidth"] = 512.0; // AVX-512
   }
 
-  aligned_free(data);
+  std::remove(temp_path.c_str());
 }
 
 BENCHMARK(BM_VectorWidth_Effectiveness)
@@ -229,57 +227,65 @@ static void BM_QuoteDetection_SIMD(benchmark::State& state) {
   double quote_density = static_cast<double>(state.range(0)) / 100.0; // Percentage as decimal
 
   size_t data_size = 1024 * 1024; // 1MB
-  auto data = static_cast<uint8_t*>(aligned_malloc(64, data_size + LIBVROOM_PADDING));
 
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_real_distribution<> dist(0.0, 1.0);
 
-  // Generate data with specific quote density
+  // Build CSV content with specific quote density
+  std::ostringstream ss;
+  ss << "col_0\n"; // header
+
+  std::string row;
   bool in_quote = false;
   for (size_t i = 0; i < data_size; ++i) {
     if (dist(gen) < quote_density) {
-      data[i] = '"';
+      row += '"';
       in_quote = !in_quote;
     } else if (!in_quote && dist(gen) < 0.1) {
-      data[i] = ',';
+      row += ',';
     } else if (!in_quote && dist(gen) < 0.02) {
-      data[i] = '\n';
+      // End of row
+      if (in_quote) {
+        row += '"';
+        in_quote = false;
+      }
+      ss << row << "\n";
+      row.clear();
     } else {
-      data[i] = 'a' + (i % 26);
+      row += static_cast<char>('a' + (i % 26));
     }
   }
-
   // Ensure we end not in quote state
   if (in_quote) {
-    for (int i = data_size - 1; i >= 0; --i) {
-      if (data[i] == '"') {
-        break;
-      }
-      if (i == data_size - 100) { // Add quote if needed
-        data[i] = '"';
-        break;
-      }
-    }
+    row += '"';
+  }
+  if (!row.empty()) {
+    ss << row << "\n";
   }
 
-  // Add padding
-  for (size_t i = data_size; i < data_size + LIBVROOM_PADDING; ++i) {
-    data[i] = '\0';
+  std::string csv_data = ss.str();
+  std::string temp_path = "/tmp/libvroom_bench_quotes_" + std::to_string(state.range(0)) + ".csv";
+  {
+    std::ofstream out(temp_path);
+    out.write(csv_data.data(), static_cast<std::streamsize>(csv_data.size()));
   }
 
-  libvroom::Parser parser(1);
+  libvroom::CsvOptions opts;
+  opts.num_threads = 1;
 
   for (auto _ : state) {
-    auto result = parser.parse(data, data_size);
+    libvroom::CsvReader reader(opts);
+    reader.open(temp_path);
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>(data_size * state.iterations()));
+  state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
   state.counters["QuoteDensity%"] = quote_density * 100.0;
-  state.counters["DataSize"] = static_cast<double>(data_size);
+  state.counters["DataSize"] = static_cast<double>(csv_data.size());
 
-  aligned_free(data);
+  std::remove(temp_path.c_str());
 }
 
 BENCHMARK(BM_QuoteDetection_SIMD)
@@ -295,36 +301,51 @@ static void BM_SeparatorDetection_SIMD(benchmark::State& state) {
   char separator = static_cast<char>(state.range(0));
 
   size_t data_size = 1024 * 1024; // 1MB
-  auto data = static_cast<uint8_t*>(aligned_malloc(64, data_size + LIBVROOM_PADDING));
 
-  // Generate data with specific separator
+  // Generate CSV data with specific separator
+  std::ostringstream ss;
+  ss << "col_0" << separator << "col_1\n"; // header with the target separator
+
+  std::string row;
   for (size_t i = 0; i < data_size; ++i) {
     if (i % 50 == 0) {
-      data[i] = '\n';
+      // End of row
+      ss << row << "\n";
+      row.clear();
     } else if (i % 8 == 0) {
-      data[i] = separator;
+      row += separator;
     } else {
-      data[i] = 'a' + (i % 26);
+      row += static_cast<char>('a' + (i % 26));
     }
   }
-
-  // Add padding
-  for (size_t i = data_size; i < data_size + LIBVROOM_PADDING; ++i) {
-    data[i] = '\0';
+  if (!row.empty()) {
+    ss << row << "\n";
   }
 
-  libvroom::Parser parser(1);
+  std::string csv_data = ss.str();
+  std::string temp_path =
+      "/tmp/libvroom_bench_sep_" + std::to_string(static_cast<int>(separator)) + ".csv";
+  {
+    std::ofstream out(temp_path);
+    out.write(csv_data.data(), static_cast<std::streamsize>(csv_data.size()));
+  }
+
+  libvroom::CsvOptions opts;
+  opts.separator = separator;
+  opts.num_threads = 1;
 
   for (auto _ : state) {
-    auto result = parser.parse(data, data_size);
+    libvroom::CsvReader reader(opts);
+    reader.open(temp_path);
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>(data_size * state.iterations()));
+  state.SetBytesProcessed(static_cast<int64_t>(csv_data.size() * state.iterations()));
   state.counters["SeparatorASCII"] = static_cast<double>(separator);
-  state.counters["DataSize"] = static_cast<double>(data_size);
+  state.counters["DataSize"] = static_cast<double>(csv_data.size());
 
-  aligned_free(data);
+  std::remove(temp_path.c_str());
 }
 
 BENCHMARK(BM_SeparatorDetection_SIMD)
@@ -339,307 +360,72 @@ static void BM_MemoryAccess_SIMD(benchmark::State& state) {
   int access_pattern = static_cast<int>(state.range(0));
 
   size_t data_size = 2 * 1024 * 1024; // 2MB
-  auto data = static_cast<uint8_t*>(aligned_malloc(64, data_size + LIBVROOM_PADDING));
 
-  // Different memory access patterns
+  // Build CSV data with different memory access patterns
+  std::vector<uint8_t> raw(data_size);
+
   switch (access_pattern) {
   case 0: // Sequential (SIMD-friendly)
     for (size_t i = 0; i < data_size; ++i) {
-      data[i] = static_cast<uint8_t>(i % 256);
+      raw[i] = static_cast<uint8_t>(i % 256);
     }
     break;
   case 1: // Strided (less SIMD-friendly)
     for (size_t i = 0; i < data_size; i += 2) {
-      data[i] = static_cast<uint8_t>(i % 256);
+      raw[i] = static_cast<uint8_t>(i % 256);
       if (i + 1 < data_size)
-        data[i + 1] = 0;
+        raw[i + 1] = 0;
     }
     break;
   case 2: // Random (SIMD-unfriendly)
   {
     std::mt19937 gen(12345);
     for (size_t i = 0; i < data_size; ++i) {
-      data[i] = static_cast<uint8_t>(gen() % 256);
+      raw[i] = static_cast<uint8_t>(gen() % 256);
     }
   } break;
   }
 
-  // Add CSV structure
+  // Add CSV structure: newlines and commas at regular intervals
   for (size_t i = 0; i < data_size; i += 100) {
-    data[i] = '\n';
+    raw[i] = '\n';
   }
   for (size_t i = 10; i < data_size; i += 20) {
-    data[i] = ',';
+    raw[i] = ',';
   }
 
-  // Add padding
-  for (size_t i = data_size; i < data_size + LIBVROOM_PADDING; ++i) {
-    data[i] = '\0';
+  // Write to temp file with a header
+  std::string temp_path =
+      "/tmp/libvroom_bench_memaccess_" + std::to_string(access_pattern) + ".csv";
+  {
+    std::ofstream out(temp_path, std::ios::binary);
+    // Write a simple header first
+    std::string header = "col_0,col_1\n";
+    out.write(header.data(), static_cast<std::streamsize>(header.size()));
+    out.write(reinterpret_cast<const char*>(raw.data()), static_cast<std::streamsize>(data_size));
   }
 
-  libvroom::Parser parser(1);
+  size_t total_size = data_size + 12; // header + data
+
+  libvroom::CsvOptions opts;
+  opts.num_threads = 1;
 
   for (auto _ : state) {
-    auto result = parser.parse(data, data_size);
+    libvroom::CsvReader reader(opts);
+    reader.open(temp_path);
+    auto result = reader.read_all();
     benchmark::DoNotOptimize(result);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>(data_size * state.iterations()));
+  state.SetBytesProcessed(static_cast<int64_t>(total_size * state.iterations()));
   state.counters["AccessPattern"] = static_cast<double>(access_pattern);
-  state.counters["DataSize"] = static_cast<double>(data_size);
+  state.counters["DataSize"] = static_cast<double>(total_size);
 
-  aligned_free(data);
+  std::remove(temp_path.c_str());
 }
 
 BENCHMARK(BM_MemoryAccess_SIMD)
     ->Arg(0) // Sequential
     ->Arg(1) // Strided
     ->Arg(2) // Random
-    ->Unit(benchmark::kMillisecond);
-
-// ============================================================================
-// BRANCHLESS STATE MACHINE BENCHMARKS
-// ============================================================================
-
-// Compare branchless vs standard state machine for different data patterns
-static void BM_Branchless_vs_Standard(benchmark::State& state) {
-  int use_branchless = static_cast<int>(state.range(0));
-  int pattern_type = static_cast<int>(state.range(1));
-
-  std::string pattern;
-  switch (pattern_type) {
-  case 0:
-    pattern = "mixed";
-    break;
-  case 1:
-    pattern = "quote_heavy";
-    break;
-  case 2:
-    pattern = "many_commas";
-    break;
-  default:
-    pattern = "mixed";
-    break;
-  }
-
-  size_t rows = 10000;
-  size_t cols = 10;
-  auto csv_data = generate_simd_test_data(rows, cols, pattern);
-  TempCSVFile temp_file(csv_data);
-
-  try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(1);
-    libvroom::ParseOptions options;
-    if (use_branchless) {
-      options.algorithm = libvroom::ParseAlgorithm::BRANCHLESS;
-    }
-
-    for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, options);
-      benchmark::DoNotOptimize(result);
-    }
-
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["Branchless"] = static_cast<double>(use_branchless);
-    state.counters["PatternType"] = static_cast<double>(pattern_type);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
-
-  } catch (const std::exception& e) {
-    state.SkipWithError(e.what());
-  }
-}
-
-BENCHMARK(BM_Branchless_vs_Standard)
-    ->ArgsProduct({{0, 1}, {0, 1, 2}}) // use_branchless: 0-1, pattern_type: 0-2
-    ->Unit(benchmark::kMillisecond);
-
-// Branchless state machine with varying file sizes
-static void BM_Branchless_Scalability(benchmark::State& state) {
-  size_t rows = static_cast<size_t>(state.range(0));
-  int use_branchless = static_cast<int>(state.range(1));
-
-  auto csv_data = generate_simd_test_data(rows, 10, "mixed");
-  TempCSVFile temp_file(csv_data);
-
-  try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(1);
-    libvroom::ParseOptions options;
-    if (use_branchless) {
-      options.algorithm = libvroom::ParseAlgorithm::BRANCHLESS;
-    }
-
-    for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, options);
-      benchmark::DoNotOptimize(result);
-    }
-
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["Rows"] = static_cast<double>(rows);
-    state.counters["Branchless"] = static_cast<double>(use_branchless);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
-
-    // Calculate throughput in MB/s
-    double bytes = static_cast<double>(buffer.size);
-    state.counters["MB"] = bytes / (1024.0 * 1024.0);
-
-  } catch (const std::exception& e) {
-    state.SkipWithError(e.what());
-  }
-}
-
-BENCHMARK(BM_Branchless_Scalability)
-    ->ArgsProduct({{1000, 5000, 10000, 50000}, {0, 1}}) // rows, use_branchless
-    ->Unit(benchmark::kMillisecond);
-
-// Branchless multithreaded performance comparison
-static void BM_Branchless_Multithreaded(benchmark::State& state) {
-  int n_threads = static_cast<int>(state.range(0));
-  int use_branchless = static_cast<int>(state.range(1));
-
-  size_t rows = 50000;
-  size_t cols = 10;
-  auto csv_data = generate_simd_test_data(rows, cols, "mixed");
-  TempCSVFile temp_file(csv_data);
-
-  try {
-    auto buffer = libvroom::load_file_to_ptr(temp_file.path(), LIBVROOM_PADDING);
-    if (!buffer) {
-      state.SkipWithError("Failed to load temp file");
-      return;
-    }
-
-    libvroom::Parser parser(n_threads);
-    libvroom::ParseOptions options;
-    if (use_branchless) {
-      options.algorithm = libvroom::ParseAlgorithm::BRANCHLESS;
-    }
-
-    for (auto _ : state) {
-      auto result = parser.parse(buffer.data(), buffer.size, options);
-      benchmark::DoNotOptimize(result);
-    }
-
-    state.SetBytesProcessed(static_cast<int64_t>(buffer.size * state.iterations()));
-    state.counters["Threads"] = static_cast<double>(n_threads);
-    state.counters["Branchless"] = static_cast<double>(use_branchless);
-    state.counters["FileSize"] = static_cast<double>(buffer.size);
-
-  } catch (const std::exception& e) {
-    state.SkipWithError(e.what());
-  }
-}
-
-BENCHMARK(BM_Branchless_Multithreaded)
-    ->ArgsProduct({{1, 2, 4, 8}, {0, 1}}) // n_threads, use_branchless
-    ->Unit(benchmark::kMillisecond);
-
-// Branch misprediction sensitive patterns
-static void BM_Branchless_BranchSensitive(benchmark::State& state) {
-  int use_branchless = static_cast<int>(state.range(0));
-  int pattern_type = static_cast<int>(state.range(1));
-
-  size_t data_size = 1024 * 1024; // 1MB
-  auto data = static_cast<uint8_t*>(aligned_malloc(64, data_size + LIBVROOM_PADDING));
-
-  std::random_device rd;
-  std::mt19937 gen(rd());
-
-  // Generate patterns that are particularly sensitive to branch prediction
-  switch (pattern_type) {
-  case 0: // Highly predictable: regular pattern
-    for (size_t i = 0; i < data_size; ++i) {
-      if (i % 10 == 0)
-        data[i] = ',';
-      else if (i % 100 == 0)
-        data[i] = '\n';
-      else
-        data[i] = 'a' + (i % 26);
-    }
-    break;
-  case 1: // Unpredictable: random quotes
-  {
-    std::uniform_int_distribution<> dist(0, 99);
-    bool in_quote = false;
-    for (size_t i = 0; i < data_size; ++i) {
-      if (!in_quote && dist(gen) < 5) {
-        data[i] = '"';
-        in_quote = true;
-      } else if (in_quote && dist(gen) < 10) {
-        data[i] = '"';
-        in_quote = false;
-      } else if (!in_quote && i % 10 == 0) {
-        data[i] = ',';
-      } else if (!in_quote && i % 100 == 0) {
-        data[i] = '\n';
-      } else {
-        data[i] = 'a' + (i % 26);
-      }
-    }
-    // Close any open quote
-    if (in_quote)
-      data[data_size - 1] = '"';
-  } break;
-  case 2: // Alternating: quote every other field
-  {
-    bool use_quote = false;
-    for (size_t i = 0; i < data_size; ++i) {
-      if (i % 10 == 0) {
-        data[i] = ',';
-        use_quote = !use_quote;
-      } else if (i % 100 == 0) {
-        data[i] = '\n';
-        use_quote = false;
-      } else if (i % 10 == 1 && use_quote) {
-        data[i] = '"';
-      } else if (i % 10 == 9 && use_quote) {
-        data[i] = '"';
-      } else {
-        data[i] = 'a' + (i % 26);
-      }
-    }
-  } break;
-  }
-
-  // Add padding
-  for (size_t i = data_size; i < data_size + LIBVROOM_PADDING; ++i) {
-    data[i] = '\0';
-  }
-
-  libvroom::Parser parser(1);
-  libvroom::ParseOptions options;
-  if (use_branchless) {
-    options.algorithm = libvroom::ParseAlgorithm::BRANCHLESS;
-  }
-
-  for (auto _ : state) {
-    auto result = parser.parse(data, data_size, options);
-    benchmark::DoNotOptimize(result);
-  }
-
-  state.SetBytesProcessed(static_cast<int64_t>(data_size * state.iterations()));
-  state.counters["Branchless"] = static_cast<double>(use_branchless);
-  state.counters["PatternType"] = static_cast<double>(pattern_type);
-  state.counters["DataSize"] = static_cast<double>(data_size);
-
-  // Pattern descriptions for reporting
-  const char* pattern_names[] = {"predictable", "random_quotes", "alternating"};
-  state.SetLabel(pattern_names[pattern_type]);
-
-  aligned_free(data);
-}
-
-BENCHMARK(BM_Branchless_BranchSensitive)
-    ->ArgsProduct({{0, 1}, {0, 1, 2}}) // use_branchless, pattern_type
     ->Unit(benchmark::kMillisecond);


### PR DESCRIPTION
## Summary

- Update 14 benchmark files to use the v2 `CsvReader` API instead of removed v1 `Parser`/`TwoPass`/`ParseOptions`/`ValueExtractor` APIs
- Remove `number_parsing_benchmarks.cpp` and `escape_tracking_benchmarks.cpp` from build (depend on removed v1 internals `simd_number_parsing.h`, `value_extraction.h`)
- Remove the `if: false` guard from the performance regression workflow and update the benchmark filter to match new benchmark names
- Update `EXPECTED_BENCHMARK_COUNT` in `check_regression.py` to match the 6 benchmarks in the new filter
- Update `.github/workflows/README.md` with new benchmark names and workflow description

## Details

The performance regression workflow was disabled during the v1->v2 migration because benchmark files referenced removed APIs. This PR rewrites all benchmark files to use the v2 public API:

| Old (v1) | New (v2) |
|---|---|
| `Parser(n).parse(data, size)` | `CsvReader(opts).open(path) + read_all()` |
| `aligned_malloc`/`aligned_free` | `posix_memalign`/`std::free` |
| `TwoPass`/`ParseIndex` | `count_rows_simd`/`split_fields_simd` |
| `ParseAlgorithm::BRANCHLESS` | Removed (algorithm doesn't exist in v2) |
| `ValueExtractor` | Removed (no v2 equivalent) |

The regression workflow now runs these benchmarks on every PR:
- `BM_CountRows` - SIMD row counting throughput
- `BM_CsvReaderExplicit` - Full pipeline with explicit dialect
- `BM_CsvReaderAutoDetect` - Full pipeline with auto-detection
- `BM_CsvReaderMultiThread/1,4,8` - Multi-threaded scaling

## Test plan

- [x] All 476 benchmarks compile and link
- [x] Regression workflow benchmarks run and produce results locally
- [x] All 937 existing tests pass
- [x] `check_regression.py` EXPECTED_BENCHMARK_COUNT matches filter (6)
- [ ] CI performance regression workflow runs successfully on this PR

Closes #643