### PR TITLE
Fix Windows build: MinGW compatibility for aligned alloc and mmap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -618,6 +618,13 @@ if(BUILD_TESTING)
     add_dependencies(io_util_test copy_test_data)
     gtest_discover_tests(io_util_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
+    # MmapSource tests (memory-mapped file I/O)
+    add_executable(mmap_source_test test/mmap_source_test.cpp)
+    target_link_libraries(mmap_source_test PRIVATE vroom GTest::gtest_main pthread)
+    target_include_directories(mmap_source_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    add_dependencies(mmap_source_test copy_test_data)
+    gtest_discover_tests(mmap_source_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
     # CLI integration tests (tests the vroom command-line tool)
     add_executable(cli_test test/cli_test.cpp)
     target_link_libraries(cli_test PRIVATE GTest::gtest_main)

--- a/benchmark/comparison_benchmarks.cpp
+++ b/benchmark/comparison_benchmarks.cpp
@@ -190,13 +190,11 @@ BENCHMARK(BM_parsing_approaches_quoted)
 // Memory bandwidth benchmark
 static void BM_memory_bandwidth(benchmark::State& state) {
   size_t size = static_cast<size_t>(state.range(0));
-  void* raw = nullptr;
-  int rc = posix_memalign(&raw, 64, size);
-  if (rc != 0 || !raw) {
+  auto* data = static_cast<char*>(libvroom::aligned_alloc_portable(size));
+  if (!data) {
     state.SkipWithError("Failed to allocate aligned memory");
     return;
   }
-  auto data = static_cast<char*>(raw);
 
   // Initialize data
   for (size_t i = 0; i < size; ++i) {
@@ -215,7 +213,7 @@ static void BM_memory_bandwidth(benchmark::State& state) {
 
   // Google Benchmark calculates throughput automatically
 
-  std::free(data);
+  libvroom::aligned_free_portable(data);
 }
 BENCHMARK(BM_memory_bandwidth)
     ->Range(1024, 1024 * 1024 * 100) // 1KB to 100MB

--- a/benchmark/transpose_benchmarks.cpp
+++ b/benchmark/transpose_benchmarks.cpp
@@ -361,15 +361,11 @@ static void transpose_nontemporal_store(const uint64_t* row_major, uint64_t* col
 #endif // __x86_64__
 
 // =============================================================================
-// Helper: posix_memalign-based allocation
+// Helper: portable aligned allocation for uint64_t arrays
 // =============================================================================
 
 static uint64_t* alloc_aligned_u64(size_t count) {
-  void* raw = nullptr;
-  int rc = posix_memalign(&raw, 64, count * sizeof(uint64_t));
-  if (rc != 0)
-    return nullptr;
-  return static_cast<uint64_t*>(raw);
+  return static_cast<uint64_t*>(libvroom::aligned_alloc_portable(count * sizeof(uint64_t)));
 }
 
 // =============================================================================
@@ -392,8 +388,8 @@ static void BM_TransposeSingleThreaded(benchmark::State& state) {
 
   if (!row_major || !col_major) {
     state.SkipWithError("Failed to allocate memory");
-    std::free(row_major);
-    std::free(col_major);
+    libvroom::aligned_free_portable(row_major);
+    libvroom::aligned_free_portable(col_major);
     return;
   }
 
@@ -419,8 +415,8 @@ static void BM_TransposeSingleThreaded(benchmark::State& state) {
   state.counters["MemoryMB"] =
       static_cast<double>(total_elements * sizeof(uint64_t) * 2) / (1024.0 * 1024.0);
 
-  std::free(row_major);
-  std::free(col_major);
+  libvroom::aligned_free_portable(row_major);
+  libvroom::aligned_free_portable(col_major);
 }
 
 /**
@@ -439,8 +435,8 @@ static void BM_TransposeMultiThreaded(benchmark::State& state) {
 
   if (!row_major || !col_major) {
     state.SkipWithError("Failed to allocate memory");
-    std::free(row_major);
-    std::free(col_major);
+    libvroom::aligned_free_portable(row_major);
+    libvroom::aligned_free_portable(col_major);
     return;
   }
 
@@ -463,8 +459,8 @@ static void BM_TransposeMultiThreaded(benchmark::State& state) {
   state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
                                                     benchmark::Counter::kIsIterationInvariantRate);
 
-  std::free(row_major);
-  std::free(col_major);
+  libvroom::aligned_free_portable(row_major);
+  libvroom::aligned_free_portable(col_major);
 }
 
 /**
@@ -482,8 +478,8 @@ static void BM_TransposeBlocked(benchmark::State& state) {
 
   if (!row_major || !col_major) {
     state.SkipWithError("Failed to allocate memory");
-    std::free(row_major);
-    std::free(col_major);
+    libvroom::aligned_free_portable(row_major);
+    libvroom::aligned_free_portable(col_major);
     return;
   }
 
@@ -505,8 +501,8 @@ static void BM_TransposeBlocked(benchmark::State& state) {
   state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
                                                     benchmark::Counter::kIsIterationInvariantRate);
 
-  std::free(row_major);
-  std::free(col_major);
+  libvroom::aligned_free_portable(row_major);
+  libvroom::aligned_free_portable(col_major);
 }
 
 /**
@@ -525,8 +521,8 @@ static void BM_TransposeBlockedMultiThreaded(benchmark::State& state) {
 
   if (!row_major || !col_major) {
     state.SkipWithError("Failed to allocate memory");
-    std::free(row_major);
-    std::free(col_major);
+    libvroom::aligned_free_portable(row_major);
+    libvroom::aligned_free_portable(col_major);
     return;
   }
 
@@ -549,8 +545,8 @@ static void BM_TransposeBlockedMultiThreaded(benchmark::State& state) {
   state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
                                                     benchmark::Counter::kIsIterationInvariantRate);
 
-  std::free(row_major);
-  std::free(col_major);
+  libvroom::aligned_free_portable(row_major);
+  libvroom::aligned_free_portable(col_major);
 }
 
 /**
@@ -572,8 +568,8 @@ static void BM_TransposeScaling(benchmark::State& state) {
 
   if (!row_major || !col_major) {
     state.SkipWithError("Failed to allocate memory");
-    std::free(row_major);
-    std::free(col_major);
+    libvroom::aligned_free_portable(row_major);
+    libvroom::aligned_free_portable(col_major);
     return;
   }
 
@@ -617,8 +613,8 @@ static void BM_TransposeScaling(benchmark::State& state) {
   state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
                                                     benchmark::Counter::kIsIterationInvariantRate);
 
-  std::free(row_major);
-  std::free(col_major);
+  libvroom::aligned_free_portable(row_major);
+  libvroom::aligned_free_portable(col_major);
 }
 
 // =============================================================================
@@ -899,8 +895,8 @@ static void BM_TransposeSIMD(benchmark::State& state) {
 
   if (!row_major || !col_major) {
     state.SkipWithError("Failed to allocate memory");
-    std::free(row_major);
-    std::free(col_major);
+    libvroom::aligned_free_portable(row_major);
+    libvroom::aligned_free_portable(col_major);
     return;
   }
 
@@ -959,8 +955,8 @@ static void BM_TransposeSIMD(benchmark::State& state) {
   state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
                                                     benchmark::Counter::kIsIterationInvariantRate);
 
-  std::free(row_major);
-  std::free(col_major);
+  libvroom::aligned_free_portable(row_major);
+  libvroom::aligned_free_portable(col_major);
 }
 
 // SIMD method comparison at key sizes
@@ -1018,8 +1014,8 @@ static void BM_TransposeSIMD_MT(benchmark::State& state) {
 
   if (!row_major || !col_major) {
     state.SkipWithError("Failed to allocate memory");
-    std::free(row_major);
-    std::free(col_major);
+    libvroom::aligned_free_portable(row_major);
+    libvroom::aligned_free_portable(col_major);
     return;
   }
 
@@ -1065,8 +1061,8 @@ static void BM_TransposeSIMD_MT(benchmark::State& state) {
   state.counters["Elements/s"] = benchmark::Counter(static_cast<double>(total_elements),
                                                     benchmark::Counter::kIsIterationInvariantRate);
 
-  std::free(row_major);
-  std::free(col_major);
+  libvroom::aligned_free_portable(row_major);
+  libvroom::aligned_free_portable(col_major);
 }
 
 // Multi-threaded comparison

--- a/test/mmap_source_test.cpp
+++ b/test/mmap_source_test.cpp
@@ -1,0 +1,139 @@
+/**
+ * @file mmap_source_test.cpp
+ * @brief Tests for MmapSource memory-mapped file I/O.
+ *
+ * Tests open, close, content integrity, empty files, error handling,
+ * and reopen behavior for the platform-specific MmapSource implementation.
+ *
+ * @see GitHub issue #649
+ */
+
+#include "libvroom/vroom.h"
+
+#include <cstring>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+
+using libvroom::MmapSource;
+
+class MmapSourceTest : public ::testing::Test {
+protected:
+  std::string testDataPath(const std::string& subpath) { return "test/data/" + subpath; }
+};
+
+// =============================================================================
+// Open and basic state tests
+// =============================================================================
+
+TEST_F(MmapSourceTest, DefaultStateNotOpen) {
+  MmapSource source;
+  EXPECT_FALSE(source.is_open());
+  EXPECT_EQ(source.size(), 0);
+  EXPECT_EQ(source.data(), nullptr);
+}
+
+TEST_F(MmapSourceTest, OpenValidFile) {
+  std::string path = testDataPath("basic/simple.csv");
+  std::ifstream check(path);
+  if (!check.good()) {
+    GTEST_SKIP() << "Test data not found: " << path;
+  }
+
+  MmapSource source;
+  auto result = source.open(path);
+  ASSERT_TRUE(result.ok);
+  EXPECT_TRUE(source.is_open());
+  EXPECT_GT(source.size(), 0);
+  EXPECT_NE(source.data(), nullptr);
+}
+
+TEST_F(MmapSourceTest, OpenNonExistentFile) {
+  MmapSource source;
+  auto result = source.open("nonexistent_file_that_does_not_exist.csv");
+  EXPECT_FALSE(result.ok);
+  EXPECT_FALSE(source.is_open());
+}
+
+// =============================================================================
+// Content integrity tests
+// =============================================================================
+
+TEST_F(MmapSourceTest, ContentMatchesFile) {
+  std::string path = testDataPath("basic/simple.csv");
+  std::ifstream file(path, std::ios::binary);
+  if (!file.good()) {
+    GTEST_SKIP() << "Test data not found: " << path;
+  }
+  std::string expected((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+
+  MmapSource source;
+  ASSERT_TRUE(source.open(path).ok);
+  EXPECT_EQ(source.size(), expected.size());
+  EXPECT_EQ(std::memcmp(source.data(), expected.data(), expected.size()), 0);
+}
+
+TEST_F(MmapSourceTest, EmptyFile) {
+  std::string temp = "/tmp/libvroom_mmap_test_empty.csv";
+  { std::ofstream ofs(temp, std::ios::binary); }
+
+  MmapSource source;
+  auto result = source.open(temp);
+  ASSERT_TRUE(result.ok);
+  EXPECT_TRUE(source.is_open());
+  EXPECT_EQ(source.size(), 0);
+
+  std::remove(temp.c_str());
+}
+
+// =============================================================================
+// Close and lifecycle tests
+// =============================================================================
+
+TEST_F(MmapSourceTest, CloseReleasesResources) {
+  MmapSource source;
+  ASSERT_TRUE(source.open(testDataPath("basic/simple.csv")).ok);
+  EXPECT_TRUE(source.is_open());
+
+  source.close();
+  EXPECT_FALSE(source.is_open());
+  EXPECT_EQ(source.size(), 0);
+}
+
+TEST_F(MmapSourceTest, DoubleCloseIsSafe) {
+  MmapSource source;
+  ASSERT_TRUE(source.open(testDataPath("basic/simple.csv")).ok);
+  source.close();
+  source.close(); // Should not crash
+  EXPECT_FALSE(source.is_open());
+}
+
+TEST_F(MmapSourceTest, ReopenDifferentFile) {
+  std::string path1 = testDataPath("basic/simple.csv");
+  std::string path2 = testDataPath("quoted/quoted_fields.csv");
+
+  std::ifstream check1(path1), check2(path2);
+  if (!check1.good() || !check2.good()) {
+    GTEST_SKIP() << "Test data files not found";
+  }
+
+  MmapSource source;
+  ASSERT_TRUE(source.open(path1).ok);
+  size_t first_size = source.size();
+  EXPECT_GT(first_size, 0);
+
+  // Opening a new file should implicitly close the first
+  ASSERT_TRUE(source.open(path2).ok);
+  EXPECT_TRUE(source.is_open());
+  EXPECT_GT(source.size(), 0);
+}
+
+TEST_F(MmapSourceTest, DestructorCleansUp) {
+  // Construct and open in a scope, let destructor run
+  {
+    MmapSource source;
+    ASSERT_TRUE(source.open(testDataPath("basic/simple.csv")).ok);
+    EXPECT_TRUE(source.is_open());
+  }
+  // No crash or leak — destructor handled cleanup
+}


### PR DESCRIPTION
## Summary

- Replace `#ifdef _MSC_VER` with `#ifdef _WIN32` in `io_util.h` for aligned memory allocation/deallocation — MinGW defines neither `_MSC_VER` nor provides `posix_memalign`
- Add Windows `CreateFileMapping`/`MapViewOfFile` implementation in `mmap_source.cpp` alongside existing POSIX `mmap`/`munmap`, selected via `#ifdef _WIN32`
- Add portable `aligned_alloc_portable`/`aligned_free_portable` helpers to `io_util.h` and use them in benchmark files to eliminate raw `posix_memalign` calls
- Add 9 MmapSource unit tests covering open, close, content integrity, empty files, error handling, reopen, and destructor cleanup

## Context

libvroom fails to compile on Windows with MinGW/gcc (Rtools), which is the standard R toolchain on Windows. The `_MSC_VER` guards only handle MSVC but not MinGW. Discovered via R package CI: https://github.com/jimhester/vroom/actions/runs/21691610182/job/62552442646?pr=9

## Test plan

- [x] All 971 existing tests pass (0 failures)
- [x] 9 new MmapSource tests pass on Linux (POSIX path)
- [ ] Windows CI validates the `_WIN32` code paths (CreateFileMapping, _aligned_malloc)

Fixes #649