### PR TITLE
fix: Python empty header tests with auto-detect default

### DIFF
--- a/python/tests/test_stub_api.py
+++ b/python/tests/test_stub_api.py
@@ -267,14 +267,14 @@ class TestErrorHandling:
         import vroom_csv
 
         with pytest.raises(RuntimeError, match="empty"):
-            vroom_csv.read_csv(empty_header_csv, error_mode="permissive")
+            vroom_csv.read_csv(empty_header_csv, separator=",", error_mode="permissive")
 
     def test_error_details_in_exception(self, empty_header_csv):
         """Test that error details are included in exception message."""
         import vroom_csv
 
         try:
-            vroom_csv.read_csv(empty_header_csv, error_mode="permissive")
+            vroom_csv.read_csv(empty_header_csv, separator=",", error_mode="permissive")
             assert False, "Should have raised RuntimeError"
         except RuntimeError as e:
             error_msg = str(e)


### PR DESCRIPTION
## Summary

Fixes Python CI failures from #654.

- `test_empty_header_fails` and `test_error_details_in_exception` were failing because auto-detection sets `has_header=false` for files starting with an empty line, bypassing the empty header error path
- Fix: pass `separator=","` explicitly so these tests exercise the intended error handling behavior

## Test plan

- [x] 26/26 Python tests pass locally
- [x] 969/969 C++ tests pass locally