### PR TITLE
fix: skip leading blank/comment lines and handle unbalanced quotes in comments

### DIFF
--- a/include/libvroom/format_parser.h
+++ b/include/libvroom/format_parser.h
@@ -17,6 +17,8 @@ struct FormatLocale {
   std::array<std::string, 7> day_abbrev;    // Abbreviated: Sun..Sat
   std::string am = "AM";
   std::string pm = "PM";
+  std::string date_format = "%Y-%m-%d"; // Used by %x
+  std::string time_format = "%H:%M:%S"; // Used by %X
 
   static FormatLocale english();
 };
@@ -26,11 +28,12 @@ struct ParsedDateTime {
   int year = 1970;
   int month = 1;                   // 1-12
   int day = 1;                     // 1-31
-  int hour = 0;                    // 0-23
+  int hour = 0;                    // 0-23 (or unlimited for durations via %h)
   int minute = 0;                  // 0-59
   int second = 0;                  // 0-59
   double fractional_seconds = 0.0; // 0.0 - 0.999999
   int tz_offset_minutes = 0;       // Timezone offset in minutes from UTC
+  bool is_negative = false;        // For negative durations (e.g., "-1:23:45")
 
   // Convert to days since Unix epoch (1970-01-01)
   int32_t to_epoch_days() const;
@@ -38,7 +41,7 @@ struct ParsedDateTime {
   // Convert to microseconds since Unix epoch (UTC)
   int64_t to_epoch_micros() const;
 
-  // Convert to microseconds since midnight (for TIME)
+  // Convert to microseconds since midnight (for TIME / durations)
   int64_t to_seconds_since_midnight_micros() const;
 };
 
@@ -47,8 +50,8 @@ struct ParsedDateTime {
 class FormatParser {
 public:
   // Construct with a format string and locale.
-  // Format specifiers: %Y %y %m %d %e %b %B %a %A %H %I %M %S %OS %p %z %Z
-  // %% %D %F %T %R
+  // Format specifiers: %Y %y %m %d %e %b %B %a %A %H %h %I %M %S %OS %p %z %Z
+  // %% %D %F %T %R %x %X %. %AD %AT
   FormatParser(std::string_view format, const FormatLocale& locale);
 
   // Parse a value according to the format string.

--- a/python/tests/test_stub_api.py
+++ b/python/tests/test_stub_api.py
@@ -267,14 +267,14 @@ class TestErrorHandling:
         import vroom_csv
 
         with pytest.raises(RuntimeError, match="empty"):
-            vroom_csv.read_csv(empty_header_csv, separator=",", error_mode="permissive")
+            vroom_csv.read_csv(empty_header_csv, separator=",", error_mode="permissive", skip_empty_rows=False)
 
     def test_error_details_in_exception(self, empty_header_csv):
         """Test that error details are included in exception message."""
         import vroom_csv
 
         try:
-            vroom_csv.read_csv(empty_header_csv, separator=",", error_mode="permissive")
+            vroom_csv.read_csv(empty_header_csv, separator=",", error_mode="permissive", skip_empty_rows=False)
             assert False, "Should have raised RuntimeError"
         except RuntimeError as e:
             error_msg = str(e)

--- a/src/reader/streaming_parser.cpp
+++ b/src/reader/streaming_parser.cpp
@@ -463,7 +463,12 @@ struct StreamingParser::Impl {
             fast_contexts[col_idx].append(unescaped);
           }
         } else {
-          fast_contexts[col_idx].append(field_view);
+          if (options.csv.escape_backslash && field_view.find('\\') != std::string_view::npos) {
+            std::string unescaped = unescape_backslash(field_view, quote);
+            fast_contexts[col_idx].append(unescaped);
+          } else {
+            fast_contexts[col_idx].append(field_view);
+          }
         }
         col_idx++;
       }

--- a/test/error_handling_test.cpp
+++ b/test/error_handling_test.cpp
@@ -787,6 +787,7 @@ TEST(CsvReaderErrorTest, EmptyHeader) {
   libvroom::CsvOptions opts;
   opts.separator = ","; // Explicit separator for malformed data (bypass auto-detect)
   opts.error_mode = libvroom::ErrorMode::PERMISSIVE;
+  opts.skip_empty_rows = false; // Don't skip the empty leading line
 
   libvroom::CsvReader reader(opts);
   auto result = reader.open("test/data/malformed/empty_header.csv");


### PR DESCRIPTION
## Summary
- Add `skip_leading_empty_and_comment_lines()` to `comment_util.h` for skipping interleaved blank lines and comment lines (with optional leading whitespace) before the header
- Apply skip logic in both `CsvReader::open()` and `open_from_buffer()` before dialect detection
- Fix type inference to check for comment lines BEFORE calling `find_row_end()`, preventing unbalanced quotes in comment lines from corrupting quote parity tracking
- Relax timestamp inference to accept compact formats (HHMM, HHMMSS) and optional seconds
- Fix `scan_unquoted_field` and `scan_quoted_field` cross-block escape state handling
- Fix `expand_format` to preserve `%%` escape sequences for the main parser
- Add `h > 23` validation in `%AT` auto-detect time parser
- Fix `%h` duration parser to use `int64_t` with overflow protection
- Remove redundant `skip_leading_comment_lines` call in `open_from_buffer`
- Update EmptyHeader tests to use `skip_empty_rows=false` to preserve original behavior

These changes ensure compatibility with vroom R package conventions where leading blank lines and comment lines (even with leading whitespace) are skipped before header detection.

Closes #673

## Test plan
- [x] All 1198 upstream libvroom tests pass
- [x] All 977 vroom R package tests pass (0 failures) after re-vendoring
- [x] Quotes in comment lines no longer corrupt type inference
- [x] Leading blank/whitespace-only lines are skipped before header
- [x] Comment lines with leading whitespace are properly detected
- [x] Duration hours up to INT32_MAX (2.1 billion) parse correctly
- [x] `%%x` format string correctly produces literal `%x` match
- [x] Backslash escape at SIMD block boundary handled correctly in scalar fallback